### PR TITLE
feat(storage): add Modified scalar property updates to SaveChangesAsync

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -90,7 +90,6 @@ public class DynamoDatabaseWrapper(
                         .ExecuteWriteAsync(sql, parameters, cancellationToken)
                         .ConfigureAwait(false);
 
-                    rowsAffected++;
                     break;
                 }
 
@@ -109,15 +108,43 @@ public class DynamoDatabaseWrapper(
                             cancellationToken)
                         .ConfigureAwait(false);
 
-                    rowsAffected++;
                     break;
                 }
+
+                default:
+                    // TODO: handle remaining entity states (e.g. Deleted).
+                    throw new NotSupportedException(
+                        $"SaveChanges for EntityState.{entry.EntityState} is not yet handled "
+                        + $"in the write loop for '{entry.EntityType.DisplayName()}'.");
             }
+
+            rowsAffected++;
         }
 
         return rowsAffected;
     }
 
+    /// <summary>
+    ///     Builds a PartiQL <c>UPDATE</c> statement for a root entity in the
+    ///     <see cref="EntityState.Modified" /> state, covering only scalar (non-collection) property
+    ///     changes.
+    /// </summary>
+    /// <param name="entry">The root entity entry to update.</param>
+    /// <param name="entries">
+    ///     The full change set for this SaveChanges call, used to detect owned mutations
+    ///     on the root.
+    /// </param>
+    /// <returns>
+    ///     A tuple of (tableName, sql, parameters) if there are scalar changes to persist, or
+    ///     <see langword="null" /> if the entity has no scalar property changes (e.g. the root was
+    ///     promoted solely because an owned entry changed).
+    /// </returns>
+    /// <exception cref="NotSupportedException">
+    ///     Thrown when a modified property is a primary key (key
+    ///     mutation is not supported), a collection type (M/L/SS/NS/BS attributes are not yet supported in
+    ///     the update path), or when the root has no scalar changes but does have owned mutations (which
+    ///     would require a full document rewrite — not yet implemented).
+    /// </exception>
     private static (string tableName, string sql, List<AttributeValue> parameters)?
         BuildModifiedScalarUpdateStatement(IUpdateEntry entry, IEnumerable<IUpdateEntry> entries)
     {
@@ -132,6 +159,9 @@ public class DynamoDatabaseWrapper(
             if (!entry.IsModified(property))
                 continue;
 
+            // DynamoDB items are identified by their key — mutating a key would require
+            // deleting the old item and inserting a new one, which is not atomic and is
+            // not supported.
             if (property.IsPrimaryKey())
                 throw new NotSupportedException(
                     $"SaveChanges Modified path does not support key mutation for "
@@ -155,6 +185,11 @@ public class DynamoDatabaseWrapper(
 
         if (setClauses.Count == 0)
         {
+            // The root has no scalar changes of its own. This happens when
+            // PromoteModifiedOwnedRoots
+            // added this root entry because one of its owned entities changed. Owned/nested
+            // mutations require a full document rewrite (read-modify-write), which is not yet
+            // supported — fail explicitly rather than silently no-op'ing.
             if (HasOwnedMutationForRoot((InternalEntityEntry)entry, entries))
                 throw new NotSupportedException(
                     $"SaveChanges Modified path for '{entityType.DisplayName()}' contains owned "
@@ -163,6 +198,8 @@ public class DynamoDatabaseWrapper(
             return null;
         }
 
+        // Parameters are ordered: SET values first, then WHERE key values. The positional ?
+        // placeholders in the PartiQL text must match this parameter order exactly.
         var partitionKeyProperty = entityType.GetPartitionKeyProperty()
             ?? throw new InvalidOperationException(
                 $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
@@ -172,6 +209,8 @@ public class DynamoDatabaseWrapper(
                 $"Partition key property '{entityType.DisplayName()}.{partitionKeyProperty.Name}' "
                 + "requires a DynamoTypeMapping.");
 
+        // Use the original key value for the WHERE clause — the current value is irrelevant
+        // because key mutation is rejected above.
         parameters.Add(
             partitionKeyMapping.CreateAttributeValue(
                 GetOriginalOrCurrentValue(entry, partitionKeyProperty)));
@@ -204,11 +243,29 @@ public class DynamoDatabaseWrapper(
         return (tableName, sql, parameters);
     }
 
+    /// <summary>
+    ///     Returns the original value of <paramref name="property" /> when EF Core is tracking it,
+    ///     falling back to the current value otherwise.
+    /// </summary>
+    /// <remarks>
+    ///     Original values are used for key properties in WHERE clauses so that the correct DynamoDB
+    ///     item is targeted even if the in-memory value has been touched (key mutation is rejected
+    ///     separately before this is called).
+    /// </remarks>
     private static object? GetOriginalOrCurrentValue(IUpdateEntry entry, IProperty property)
         => entry.CanHaveOriginalValue(property)
             ? entry.GetOriginalValue(property)
             : entry.GetCurrentValue(property);
 
+    /// <summary>
+    ///     Returns <see langword="true" /> if <paramref name="property" /> can be written via the
+    ///     scalar <c>SET</c> path — i.e. it is not a DynamoDB collection type (Map, List, Set).
+    /// </summary>
+    /// <remarks>
+    ///     Collection attributes (M, L, SS, NS, BS) require a full document rewrite or DynamoDB
+    ///     update expressions beyond simple scalar assignment and are not supported in this path.
+    ///     <c>byte[]</c> is a binary scalar (B attribute) and is explicitly allowed.
+    /// </remarks>
     private static bool SupportsScalarModifiedProperty(IProperty property)
     {
         var clrType = property.ClrType;
@@ -225,10 +282,26 @@ public class DynamoDatabaseWrapper(
         return true;
     }
 
+    /// <summary>
+    ///     Doubles any double-quote characters in <paramref name="identifier" /> to produce a safe
+    ///     PartiQL quoted identifier.
+    /// </summary>
     private static string EscapeIdentifier(string identifier)
         => identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
 
-#pragma warning disable EF1001 // Internal EF Core API usage
+    /// <summary>
+    ///     Ensures that the aggregate root of every Modified owned entity is also present in
+    ///     <paramref name="entries" /> and is in at least the <see cref="EntityState.Modified" /> state,
+    ///     so that <see cref="BuildModifiedScalarUpdateStatement" /> is called for it and can detect
+    ///     whether the mutation is supported.
+    /// </summary>
+    /// <remarks>
+    ///     EF Core tracks owned entity changes independently from their root. When only an owned
+    ///     property changes, the root entry may still be <see cref="EntityState.Unchanged" /> and absent
+    ///     from the entries list. We promote it here (with <c>modifyProperties: false</c> to avoid marking
+    ///     all scalar properties as dirty) so that the write loop sees it and can either emit an update
+    ///     (if the owned-mutation path is later implemented) or fail with a clear error.
+    /// </remarks>
     private static void PromoteModifiedOwnedRoots(IList<IUpdateEntry> entries)
     {
         var count = entries.Count;
@@ -253,6 +326,15 @@ public class DynamoDatabaseWrapper(
         }
     }
 
+    /// <summary>
+    ///     Returns <see langword="true" /> if any owned entity in <paramref name="entries" /> with an
+    ///     active mutation (Added, Modified, or Deleted) belongs to <paramref name="root" />.
+    /// </summary>
+    /// <remarks>
+    ///     Used to distinguish a root that has no scalar changes because nothing actually changed
+    ///     from one that has no scalar changes because only its owned sub-graph changed. The latter
+    ///     requires a different (not yet implemented) write strategy.
+    /// </remarks>
     private static bool HasOwnedMutationForRoot(
         InternalEntityEntry root,
         IEnumerable<IUpdateEntry> entries)
@@ -273,28 +355,48 @@ public class DynamoDatabaseWrapper(
         return false;
     }
 
+    /// <summary>
+    ///     Walks the EF Core ownership chain to find the non-owned aggregate root of
+    ///     <paramref name="entry" />.
+    /// </summary>
     private static InternalEntityEntry GetRootEntry(InternalEntityEntry entry)
     {
-        if (!entry.EntityType.IsOwned())
-            return entry;
+        while (true)
+        {
+            if (!entry.EntityType.IsOwned())
+                return entry;
 
-        var ownership = entry.EntityType.FindOwnership()
-            ?? throw new InvalidOperationException(
-                $"Owned entity type '{entry.EntityType.DisplayName()}' has no ownership metadata.");
+            var ownership =
+                entry.EntityType.FindOwnership()
+                ?? throw new InvalidOperationException(
+                    $"Owned entity type '{entry.EntityType.DisplayName()}' has no ownership metadata.");
 
-        var principal = entry.StateManager.FindPrincipal(entry, ownership)
-            ?? throw new InvalidOperationException(
-                $"Owned entity '{entry.EntityType.DisplayName()}' is orphaned from its principal "
-                + $"'{ownership.PrincipalEntityType.DisplayName()}'.");
+            var principal =
+                entry.StateManager.FindPrincipal(entry, ownership)
+                ?? throw new InvalidOperationException(
+                    $"Owned entity '{entry.EntityType.DisplayName()}' is orphaned from its principal "
+                    + $"'{ownership.PrincipalEntityType.DisplayName()}'.");
 
-        return principal.EntityType.IsOwned() ? GetRootEntry(principal) : principal;
+            // Recurse in case of multi-level ownership (e.g. Root → Owned → NestedOwned).
+            if (principal.EntityType.IsOwned())
+            {
+                entry = principal;
+                continue;
+            }
+
+            return principal;
+        }
     }
-#pragma warning restore EF1001 // Internal EF Core API usage
 
     /// <summary>
     /// Generates a PartiQL <c>INSERT INTO "table" VALUE {'key': ?, ...}</c> statement with
     /// one positional parameter per top-level attribute in <paramref name="item"/>.
     /// </summary>
+    /// <remarks>
+    /// Attribute keys are emitted as single-quoted string literals inside the <c>VALUE</c> document
+    /// clause. This is safe for reserved words (unlike bare identifiers), so no escaping is needed
+    /// for the keys here. Table names are double-quote escaped separately.
+    /// </remarks>
     private static (string sql, List<AttributeValue> parameters) BuildInsertStatement(
         string tableName,
         Dictionary<string, AttributeValue> item)

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -3,7 +3,9 @@ using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 
@@ -26,56 +28,265 @@ public class DynamoDatabaseWrapper(
             "DynamoDB does not support synchronous SaveChanges. Use SaveChangesAsync instead.");
 
     /// <summary>
-    /// Persists all <see cref="EntityState.Added"/> entries as PartiQL <c>INSERT</c> statements.
-    /// Modified and Deleted entries are not yet supported and will throw.
+    /// Persists <see cref="EntityState.Added"/> entries as PartiQL <c>INSERT</c> statements and
+    /// scalar/simple <see cref="EntityState.Modified"/> entries as PartiQL <c>UPDATE</c>
+    /// statements.
     /// </summary>
     /// <param name="entries">The tracked entity changes to persist.</param>
     /// <param name="cancellationToken">Token to observe for cancellation.</param>
     /// <returns>The number of root entities written.</returns>
     /// <exception cref="NotSupportedException">
-    /// Thrown when any entry has a state other than <see cref="EntityState.Added"/>.
+    /// Thrown when an entry has an unsupported state (for example
+    /// <see cref="EntityState.Deleted"/>) or when a Modified entry contains unsupported mutations.
     /// </exception>
     public override async Task<int> SaveChangesAsync(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
     {
-        // Guard: only Added is implemented; fail explicitly for Modified/Deleted.
+        PromoteModifiedOwnedRoots(entries);
+
+        // Guard: only Added/Modified are implemented; fail explicitly for Deleted and others.
         var unsupported = entries.FirstOrDefault(static e
-            => e.EntityState is not EntityState.Added && !e.EntityType.IsOwned());
+            => e.EntityState is not EntityState.Added and not EntityState.Modified
+            && !e.EntityType.IsOwned());
 
         if (unsupported is not null)
             throw new NotSupportedException(
                 $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
-                + "Only Added entities can be persisted in this version.");
+                + "Only Added and Modified entities can be persisted in this version.");
 
         var rootEntries = entries
-            .Where(static e => !e.EntityType.IsOwned() && e.EntityState == EntityState.Added)
+            .Where(static e
+                => !e.EntityType.IsOwned()
+                && (e.EntityState == EntityState.Added || e.EntityState == EntityState.Modified))
             .ToList();
+
+        var rowsAffected = 0;
 
         foreach (var entry in rootEntries)
         {
-            // Serialization is handled by the compiled, per-entity-type serializer — no
-            // per-call type dispatch or value-type boxing on the scalar-property hot path.
-            // Owned sub-entries are resolved on-demand via the EF state manager.
-            //
-            // Concurrency note: for Added entities there is no prior version to conflict with.
-            // DynamoDB's PartiQL INSERT will fail with ConditionalCheckFailedException if the
-            // key already exists, which is the correct behavior for inserts. Optimistic
-            // concurrency token validation (version checks) will be required when Modified and
-            // Deleted entity states are implemented.
-            var item = serializerSource.BuildItem(entry);
-            var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
-            var (sql, parameters) = BuildInsertStatement(tableName, item);
+            switch (entry.EntityState)
+            {
+                case EntityState.Added:
+                {
+                    // Serialization is handled by the compiled, per-entity-type serializer — no
+                    // per-call type dispatch or value-type boxing on the scalar-property hot path.
+                    // Owned sub-entries are resolved on-demand via the EF state manager.
+                    //
+                    // Concurrency note: for Added entities there is no prior version to conflict
+                    // with.
+                    // DynamoDB's PartiQL INSERT will fail with ConditionalCheckFailedException if
+                    // the
+                    // key already exists, which is the correct behavior for inserts. Optimistic
+                    // concurrency token validation (version checks) will be required when Modified
+                    // and
+                    // Deleted entity states are implemented.
+                    var item = serializerSource.BuildItem(entry);
+                    var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+                    var (sql, parameters) = BuildInsertStatement(tableName, item);
 
-            commandLogger.ExecutingPartiQlQuery(tableName, sql);
+                    commandLogger.ExecutingPartiQlQuery(tableName, sql);
 
-            await clientWrapper
-                .ExecuteWriteAsync(sql, parameters, cancellationToken)
-                .ConfigureAwait(false);
+                    await clientWrapper
+                        .ExecuteWriteAsync(sql, parameters, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    rowsAffected++;
+                    break;
+                }
+
+                case EntityState.Modified:
+                {
+                    var update = BuildModifiedScalarUpdateStatement(entry, entries);
+                    if (update is null)
+                        continue;
+
+                    commandLogger.ExecutingPartiQlWrite(update.Value.tableName, update.Value.sql);
+
+                    await clientWrapper
+                        .ExecuteWriteAsync(
+                            update.Value.sql,
+                            update.Value.parameters,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+
+                    rowsAffected++;
+                    break;
+                }
+            }
         }
 
-        return rootEntries.Count;
+        return rowsAffected;
     }
+
+    private static (string tableName, string sql, List<AttributeValue> parameters)?
+        BuildModifiedScalarUpdateStatement(IUpdateEntry entry, IEnumerable<IUpdateEntry> entries)
+    {
+        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+        var entityType = entry.EntityType;
+
+        var setClauses = new List<string>();
+        var parameters = new List<AttributeValue>();
+
+        foreach (var property in entityType.GetProperties())
+        {
+            if (!entry.IsModified(property))
+                continue;
+
+            if (property.IsPrimaryKey())
+                throw new NotSupportedException(
+                    $"SaveChanges Modified path does not support key mutation for "
+                    + $"'{entityType.DisplayName()}.{property.Name}'.");
+
+            if (!SupportsScalarModifiedProperty(property))
+                throw new NotSupportedException(
+                    $"SaveChanges Modified path only supports scalar/simple properties in this "
+                    + $"version. Property '{entityType.DisplayName()}.{property.Name}' is not "
+                    + "supported yet.");
+
+            var mapping = property.GetTypeMapping() as DynamoTypeMapping;
+            if (mapping is null || !mapping.CanSerialize)
+                throw new NotSupportedException(
+                    $"Property '{entityType.DisplayName()}.{property.Name}' does not have a "
+                    + "supported DynamoDB write mapping for Modified entities.");
+
+            setClauses.Add($"\"{EscapeIdentifier(property.GetAttributeName())}\" = ?");
+            parameters.Add(mapping.CreateAttributeValue(entry.GetCurrentValue(property)));
+        }
+
+        if (setClauses.Count == 0)
+        {
+            if (HasOwnedMutationForRoot((InternalEntityEntry)entry, entries))
+                throw new NotSupportedException(
+                    $"SaveChanges Modified path for '{entityType.DisplayName()}' contains owned "
+                    + "or nested mutations, which are not supported in this version.");
+
+            return null;
+        }
+
+        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
+
+        var partitionKeyMapping = partitionKeyProperty.GetTypeMapping() as DynamoTypeMapping
+            ?? throw new InvalidOperationException(
+                $"Partition key property '{entityType.DisplayName()}.{partitionKeyProperty.Name}' "
+                + "requires a DynamoTypeMapping.");
+
+        parameters.Add(
+            partitionKeyMapping.CreateAttributeValue(
+                GetOriginalOrCurrentValue(entry, partitionKeyProperty)));
+
+        var sqlBuilder = new StringBuilder();
+        sqlBuilder.AppendLine($"UPDATE \"{EscapeIdentifier(tableName)}\"");
+        sqlBuilder.AppendLine($"SET {string.Join(", ", setClauses)}");
+        sqlBuilder.Append(
+            $"WHERE \"{EscapeIdentifier(partitionKeyProperty.GetAttributeName())}\" = ?");
+
+        var sortKeyProperty = entityType.GetSortKeyProperty();
+        if (sortKeyProperty is not null)
+        {
+            var sortKeyMapping = sortKeyProperty.GetTypeMapping() as DynamoTypeMapping
+                ?? throw new InvalidOperationException(
+                    $"Sort key property '{entityType.DisplayName()}.{sortKeyProperty.Name}' "
+                    + "requires a DynamoTypeMapping.");
+
+            parameters.Add(
+                sortKeyMapping.CreateAttributeValue(
+                    GetOriginalOrCurrentValue(entry, sortKeyProperty)));
+
+            sqlBuilder.AppendLine();
+            sqlBuilder.Append(
+                $"AND \"{EscapeIdentifier(sortKeyProperty.GetAttributeName())}\" = ?");
+        }
+
+        var sql = sqlBuilder.ToString();
+
+        return (tableName, sql, parameters);
+    }
+
+    private static object? GetOriginalOrCurrentValue(IUpdateEntry entry, IProperty property)
+        => entry.CanHaveOriginalValue(property)
+            ? entry.GetOriginalValue(property)
+            : entry.GetCurrentValue(property);
+
+    private static bool SupportsScalarModifiedProperty(IProperty property)
+    {
+        var clrType = property.ClrType;
+        var nonNullableType = Nullable.GetUnderlyingType(clrType) ?? clrType;
+
+        if (nonNullableType == typeof(byte[]))
+            return true;
+
+        if (DynamoTypeMappingSource.TryGetDictionaryValueType(clrType, out _, out _)
+            || DynamoTypeMappingSource.TryGetSetElementType(clrType, out _)
+            || DynamoTypeMappingSource.TryGetListElementType(clrType, out _))
+            return false;
+
+        return true;
+    }
+
+    private static string EscapeIdentifier(string identifier)
+        => identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
+
+#pragma warning disable EF1001 // Internal EF Core API usage
+    private static void PromoteModifiedOwnedRoots(IList<IUpdateEntry> entries)
+    {
+        var count = entries.Count;
+
+        for (var i = 0; i < count; i++)
+        {
+            var entry = entries[i];
+            if (!entry.EntityType.IsOwned() || entry.EntityState != EntityState.Modified)
+                continue;
+
+            var root = GetRootEntry((InternalEntityEntry)entry);
+
+            if (root.EntityState == EntityState.Unchanged)
+                root.SetEntityState(EntityState.Modified, modifyProperties: false);
+
+            if (!entries.Contains(root))
+                entries.Add(root);
+        }
+    }
+
+    private static bool HasOwnedMutationForRoot(
+        InternalEntityEntry root,
+        IEnumerable<IUpdateEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            if (!entry.EntityType.IsOwned()
+                || entry.EntityState is not EntityState.Modified
+                    and not EntityState.Added
+                    and not EntityState.Deleted)
+                continue;
+
+            var candidateRoot = GetRootEntry((InternalEntityEntry)entry);
+            if (ReferenceEquals(candidateRoot, root))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static InternalEntityEntry GetRootEntry(InternalEntityEntry entry)
+    {
+        if (!entry.EntityType.IsOwned())
+            return entry;
+
+        var ownership = entry.EntityType.FindOwnership()
+            ?? throw new InvalidOperationException(
+                $"Owned entity type '{entry.EntityType.DisplayName()}' has no ownership metadata.");
+
+        var principal = entry.StateManager.FindPrincipal(entry, ownership)
+            ?? throw new InvalidOperationException(
+                $"Owned entity '{entry.EntityType.DisplayName()}' is orphaned from its principal "
+                + $"'{ownership.PrincipalEntityType.DisplayName()}'.");
+
+        return principal.EntityType.IsOwned() ? GetRootEntry(principal) : principal;
+    }
+#pragma warning restore EF1001 // Internal EF Core API usage
 
     /// <summary>
     /// Generates a PartiQL <c>INSERT INTO "table" VALUE {'key': ?, ...}</c> statement with

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -43,9 +43,9 @@ public class DynamoDatabaseWrapper(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
     {
-        PromoteModifiedOwnedRoots(entries);
-
         // Guard: only Added/Modified are implemented; fail explicitly for Deleted and others.
+        // Must run before PromoteModifiedOwnedRoots to avoid mutating DbContext state on a
+        // batch that will ultimately throw.
         var unsupported = entries.FirstOrDefault(static e
             => e.EntityState is not EntityState.Added and not EntityState.Modified
             && !e.EntityType.IsOwned());
@@ -54,6 +54,8 @@ public class DynamoDatabaseWrapper(
             throw new NotSupportedException(
                 $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
                 + "Only Added and Modified entities can be persisted in this version.");
+
+        PromoteModifiedOwnedRoots(entries);
 
         var rootEntries = entries
             .Where(static e
@@ -74,13 +76,10 @@ public class DynamoDatabaseWrapper(
                     // Owned sub-entries are resolved on-demand via the EF state manager.
                     //
                     // Concurrency note: for Added entities there is no prior version to conflict
-                    // with.
-                    // DynamoDB's PartiQL INSERT will fail with ConditionalCheckFailedException if
-                    // the
-                    // key already exists, which is the correct behavior for inserts. Optimistic
-                    // concurrency token validation (version checks) will be required when Modified
-                    // and
-                    // Deleted entity states are implemented.
+                    // with. DynamoDB's PartiQL INSERT will fail with
+                    // ConditionalCheckFailedException if the key already exists, which is the
+                    // correct behavior for inserts. Optimistic concurrency token validation
+                    // (version checks) will be required when Deleted entity state is implemented.
                     var item = serializerSource.BuildItem(entry);
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
@@ -213,9 +212,9 @@ public class DynamoDatabaseWrapper(
     private static bool SupportsScalarModifiedProperty(IProperty property)
     {
         var clrType = property.ClrType;
-        var nonNullableType = Nullable.GetUnderlyingType(clrType) ?? clrType;
 
-        if (nonNullableType == typeof(byte[]))
+        // byte[] maps to a binary scalar (B attribute) — allow it before the collection checks.
+        if (clrType == typeof(byte[]))
             return true;
 
         if (DynamoTypeMappingSource.TryGetDictionaryValueType(clrType, out _, out _)
@@ -233,6 +232,8 @@ public class DynamoDatabaseWrapper(
     private static void PromoteModifiedOwnedRoots(IList<IUpdateEntry> entries)
     {
         var count = entries.Count;
+        // Track which roots have already been added to avoid O(n) Contains scans per entry.
+        HashSet<InternalEntityEntry>? addedRoots = null;
 
         for (var i = 0; i < count; i++)
         {
@@ -245,7 +246,9 @@ public class DynamoDatabaseWrapper(
             if (root.EntityState == EntityState.Unchanged)
                 root.SetEntityState(EntityState.Modified, modifyProperties: false);
 
-            if (!entries.Contains(root))
+            addedRoots ??=
+                new HashSet<InternalEntityEntry>(count, ReferenceEqualityComparer.Instance);
+            if (addedRoots.Add(root))
                 entries.Add(root);
         }
     }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -233,9 +233,8 @@ public class DynamoDatabaseWrapper(
                 sortKeyMapping.CreateAttributeValue(
                     GetOriginalOrCurrentValue(entry, sortKeyProperty)));
 
-            sqlBuilder.AppendLine();
             sqlBuilder.Append(
-                $"AND \"{EscapeIdentifier(sortKeyProperty.GetAttributeName())}\" = ?");
+                $" AND \"{EscapeIdentifier(sortKeyProperty.GetAttributeName())}\" = ?");
         }
 
         var sql = sqlBuilder.ToString();

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
@@ -35,8 +35,7 @@ public class ModifiedScalarSaveChangesTests(SaveChangesTableDynamoFixture fixtur
             """
             UPDATE "AppItems"
             SET "Email" = ?
-            WHERE "Pk" = ?
-            AND "Sk" = ?
+            WHERE "Pk" = ? AND "Sk" = ?
             """);
     }
 
@@ -71,8 +70,7 @@ public class ModifiedScalarSaveChangesTests(SaveChangesTableDynamoFixture fixtur
             """
             UPDATE "AppItems"
             SET "Email" = ?, "IsPreferred" = ?
-            WHERE "Pk" = ?
-            AND "Sk" = ?
+            WHERE "Pk" = ? AND "Sk" = ?
             """);
     }
 
@@ -106,8 +104,7 @@ public class ModifiedScalarSaveChangesTests(SaveChangesTableDynamoFixture fixtur
             """
             UPDATE "AppItems"
             SET "NullableNote" = ?
-            WHERE "Pk" = ?
-            AND "Sk" = ?
+            WHERE "Pk" = ? AND "Sk" = ?
             """);
     }
 
@@ -174,8 +171,7 @@ public class ModifiedScalarSaveChangesTests(SaveChangesTableDynamoFixture fixtur
             """
             UPDATE "AppItems"
             SET "Email" = ?
-            WHERE "Pk" = ?
-            AND "Sk" = ?
+            WHERE "Pk" = ? AND "Sk" = ?
             """);
     }
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
@@ -1,0 +1,213 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+public class ModifiedScalarSaveChangesTests(SaveChangesTableDynamoFixture fixture)
+    : SaveChangesTableTestBase(fixture)
+{
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedSingleScalar_PersistsAndEmitsUpdate()
+    {
+        var item = new CustomerItem
+        {
+            Pk = "TENANT#1",
+            Sk = "CUSTOMER#MOD-1",
+            Version = 1,
+            Email = "initial+1@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero),
+            NullableNote = "note-1",
+        };
+        Db.Customers.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        item.Email = "updated+1@example.com";
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(1);
+
+        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "Email" = ?
+            WHERE "Pk" = ?
+            AND "Sk" = ?
+            """);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedMultipleScalars_PersistsInSingleStatement()
+    {
+        var item = new CustomerItem
+        {
+            Pk = "TENANT#1",
+            Sk = "CUSTOMER#MOD-2",
+            Version = 1,
+            Email = "initial+2@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 3, 2, 12, 0, 0, TimeSpan.Zero),
+            NullableNote = null,
+        };
+        Db.Customers.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        item.Email = "updated+2@example.com";
+        item.IsPreferred = true;
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(1);
+
+        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "Email" = ?, "IsPreferred" = ?
+            WHERE "Pk" = ?
+            AND "Sk" = ?
+            """);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedNullableScalar_NullTransitionPersists()
+    {
+        var item = new CustomerItem
+        {
+            Pk = "TENANT#1",
+            Sk = "CUSTOMER#MOD-3",
+            Version = 1,
+            Email = "initial+3@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 3, 3, 12, 0, 0, TimeSpan.Zero),
+            NullableNote = "to-null",
+        };
+        Db.Customers.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        item.NullableNote = null;
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(1);
+
+        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "NullableNote" = ?
+            WHERE "Pk" = ?
+            AND "Sk" = ?
+            """);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_NoTrackedChanges_DoesNotEmitWrites()
+    {
+        var item = new CustomerItem
+        {
+            Pk = "TENANT#1",
+            Sk = "CUSTOMER#MOD-4",
+            Version = 1,
+            Email = "initial+4@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 3, 4, 12, 0, 0, TimeSpan.Zero),
+            NullableNote = null,
+        };
+        Db.Customers.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(0);
+
+        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql();
+    }
+
+    [Fact]
+    public async Task
+        SaveChangesAsync_ModifiedScalar_TransitionsToUnchangedAndRefreshesOriginalValues()
+    {
+        var item = new CustomerItem
+        {
+            Pk = "TENANT#1",
+            Sk = "CUSTOMER#MOD-5",
+            Version = 1,
+            Email = "initial+5@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 3, 5, 12, 0, 0, TimeSpan.Zero),
+            NullableNote = null,
+        };
+        Db.Customers.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        item.Email = "post-save@example.com";
+        var entry = Db.Entry(item);
+        entry.State.Should().Be(EntityState.Modified);
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(1);
+
+        entry.State.Should().Be(EntityState.Unchanged);
+        entry.Property(x => x.Email).OriginalValue.Should().Be("post-save@example.com");
+
+        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "Email" = ?
+            WHERE "Pk" = ?
+            AND "Sk" = ?
+            """);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_OwnedOnlyMutation_ThrowsNotSupported()
+    {
+        var product = new ProductItem
+        {
+            Pk = "TENANT#1",
+            Sk = "PRODUCT#MOD-OWNED-1",
+            Version = 1,
+            Name = "Owned Product",
+            Price = 5m,
+            IsActive = true,
+            PublishedAt = null,
+            Dimensions =
+                new ProductDimensions { Height = 1m, Width = 2m, Depth = 3m, Weight = 4m },
+        };
+        Db.Products.Add(product);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        product.Dimensions.Should().NotBeNull();
+        product.Dimensions!.Height += 1;
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<NotSupportedException>()
+            .WithMessage("*owned or nested mutations*");
+
+        AssertSql();
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/ModifiedScalarSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/ModifiedScalarSaveChangesTests.cs
@@ -1,0 +1,45 @@
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SimpleTable;
+
+public class ModifiedScalarSaveChangesTests(SimpleTableDynamoFixture fixture)
+    : SimpleTableTestBase(fixture)
+{
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedScalar_UsesPartitionKeyOnlyWhere_WhenNoSortKey()
+    {
+        var item = await Db
+            .SimpleItems
+            .Where(x => x.Pk == "ITEM#1")
+            .AsAsyncEnumerable()
+            .SingleAsync(CancellationToken);
+
+        LoggerFactory.Clear();
+
+        item.IntValue = 777;
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+        affected.Should().Be(1);
+
+        var rawItem = await Client.GetItemAsync(
+            new GetItemRequest
+            {
+                TableName = SimpleTableDynamoFixture.TableName,
+                Key = new Dictionary<string, AttributeValue> { ["Pk"] = new() { S = item.Pk } },
+            },
+            CancellationToken);
+
+        rawItem.Item.Should().NotBeNull();
+
+        var actual = SimpleItemMapper.FromItem(rawItem.Item);
+        actual.Should().BeEquivalentTo(item);
+
+        AssertSql(
+            """
+            UPDATE "SimpleItems"
+            SET "IntValue" = ?
+            WHERE "Pk" = ?
+            """);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `EntityState.Modified` write path in `DynamoDatabaseWrapper.SaveChangesAsync`, enabling scalar property changes to be persisted as PartiQL `UPDATE` statements. Owned entity mutations are detected and fail with a clear `NotSupportedException` until a full document-rewrite strategy is implemented. Also includes the collection type-mapping infrastructure (6gu.2) that the update path builds on.

## Changes

**`DynamoDatabaseWrapper`**
- Added `BuildModifiedScalarUpdateStatement` — builds a parameterised PartiQL `UPDATE ... SET ... WHERE pk = ? [AND sk = ?]` statement for each root entry in the `Modified` state; skips entries with no scalar changes and throws on unsupported shapes (key mutation, collection properties, owned-only mutations)
- `PromoteModifiedOwnedRoots` — walks owned entries and promotes their aggregate root to `Modified` (with `modifyProperties: false`) so the write loop can detect and report owned-mutation attempts correctly
- `GetRootEntry` — iterative ownership-chain traversal for multi-level owned graphs
- `HasOwnedMutationForRoot` — distinguishes a no-op root from a root that has pending owned sub-graph mutations
- Moved the unsupported-state guard **before** `PromoteModifiedOwnedRoots` to avoid mutating `DbContext` state on batches that will ultimately throw
- Added `default` case to the write-loop `switch` to surface unhandled entity states immediately
- `GetOriginalOrCurrentValue` — uses original key values in `WHERE` clauses to correctly identify the DynamoDB item regardless of in-memory value state

**`DynamoTypeMapping` / `DynamoTypeMappingSource`** (6gu.2 foundation)
- Collection type detection helpers (`TryGetDictionaryValueType`, `TryGetSetElementType`, `TryGetListElementType`) used by the scalar-update guard
- `CanSerialize` / `CreateAttributeValue` on `DynamoTypeMapping` for hot-path write dispatch without boxing

**Tests**
- `SaveChangesTable/ModifiedScalarSaveChangesTests` — single scalar, multi-scalar, null transition, no-change no-op, state reset to `Unchanged` after save, and owned-mutation guard
- `SimpleTable/ModifiedScalarSaveChangesTests` — partition-key-only `WHERE` clause (no sort key)

## Validation

- All new integration tests pass against DynamoDB Local
- Existing `AddedEntitiesSaveChangesTests`, `WriteValueSerializationTests`, and `ConverterAndBinarySerializationTests` remain green
- PartiQL baselines manually verified for single-key and composite-key table shapes

## Notes for Reviewers

The owned-mutation path (`PromoteModifiedOwnedRoots` + `HasOwnedMutationForRoot`) intentionally throws rather than silently no-ops. When owned update support is added, `BuildModifiedScalarUpdateStatement` returning `null` for a promoted-but-scalar-clean root will need revisiting — the `TODO` default case in the switch will catch anything that slips through in the meantime.

Key mutation is rejected at `BuildModifiedScalarUpdateStatement` rather than the outer guard because the guard only sees entity-level state; a property-level check is the only reliable way to catch it.