### PR TITLE
feat(storage): add Deleted entity SaveChanges path

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -28,39 +28,44 @@ public class DynamoDatabaseWrapper(
             "DynamoDB does not support synchronous SaveChanges. Use SaveChangesAsync instead.");
 
     /// <summary>
-    /// Persists <see cref="EntityState.Added"/> entries as PartiQL <c>INSERT</c> statements and
+    /// Persists <see cref="EntityState.Added"/> entries as PartiQL <c>INSERT</c> statements,
     /// scalar/simple <see cref="EntityState.Modified"/> entries as PartiQL <c>UPDATE</c>
-    /// statements.
+    /// statements, and <see cref="EntityState.Deleted"/> entries as key-targeted PartiQL
+    /// <c>DELETE</c> statements.
     /// </summary>
     /// <param name="entries">The tracked entity changes to persist.</param>
     /// <param name="cancellationToken">Token to observe for cancellation.</param>
     /// <returns>The number of root entities written.</returns>
     /// <exception cref="NotSupportedException">
-    /// Thrown when an entry has an unsupported state (for example
-    /// <see cref="EntityState.Deleted"/>) or when a Modified entry contains unsupported mutations.
+    /// Thrown when an entry has an unsupported state or when a Modified entry contains
+    /// unsupported mutations.
     /// </exception>
     public override async Task<int> SaveChangesAsync(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
     {
-        // Guard: only Added/Modified are implemented; fail explicitly for Deleted and others.
+        // Guard: only Added/Modified/Deleted are implemented; fail explicitly for others.
         // Must run before PromoteModifiedOwnedRoots to avoid mutating DbContext state on a
         // batch that will ultimately throw.
         var unsupported = entries.FirstOrDefault(static e
-            => e.EntityState is not EntityState.Added and not EntityState.Modified
+            => e.EntityState is not EntityState.Added
+                and not EntityState.Modified
+                and not EntityState.Deleted
             && !e.EntityType.IsOwned());
 
         if (unsupported is not null)
             throw new NotSupportedException(
                 $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
-                + "Only Added and Modified entities can be persisted in this version.");
+                + "Only Added, Modified, and Deleted entities can be persisted in this version.");
 
         PromoteModifiedOwnedRoots(entries);
 
         var rootEntries = entries
             .Where(static e
                 => !e.EntityType.IsOwned()
-                && (e.EntityState == EntityState.Added || e.EntityState == EntityState.Modified))
+                && (e.EntityState == EntityState.Added
+                    || e.EntityState == EntityState.Modified
+                    || e.EntityState == EntityState.Deleted))
             .ToList();
 
         var rowsAffected = 0;
@@ -74,12 +79,6 @@ public class DynamoDatabaseWrapper(
                     // Serialization is handled by the compiled, per-entity-type serializer — no
                     // per-call type dispatch or value-type boxing on the scalar-property hot path.
                     // Owned sub-entries are resolved on-demand via the EF state manager.
-                    //
-                    // Concurrency note: for Added entities there is no prior version to conflict
-                    // with. DynamoDB's PartiQL INSERT will fail with
-                    // ConditionalCheckFailedException if the key already exists, which is the
-                    // correct behavior for inserts. Optimistic concurrency token validation
-                    // (version checks) will be required when Deleted entity state is implemented.
                     var item = serializerSource.BuildItem(entry);
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
@@ -111,10 +110,26 @@ public class DynamoDatabaseWrapper(
                     break;
                 }
 
+                case EntityState.Deleted:
+                {
+                    // Deleting the root item removes the whole DynamoDB document including all
+                    // owned sub-entities — no separate statement is needed per owned entry.
+                    // DynamoDB DELETE on a missing key is a no-op; concurrency failure mapping
+                    // is deferred to the next story (6gu.5).
+                    var delete = BuildDeleteStatement(entry);
+
+                    commandLogger.ExecutingPartiQlWrite(delete.tableName, delete.sql);
+
+                    await clientWrapper
+                        .ExecuteWriteAsync(delete.sql, delete.parameters, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    break;
+                }
+
                 default:
-                    // TODO: handle remaining entity states (e.g. Deleted).
                     throw new NotSupportedException(
-                        $"SaveChanges for EntityState.{entry.EntityState} is not yet handled "
+                        $"SaveChanges for EntityState.{entry.EntityState} is not handled "
                         + $"in the write loop for '{entry.EntityType.DisplayName()}'.");
             }
 
@@ -385,6 +400,63 @@ public class DynamoDatabaseWrapper(
 
             return principal;
         }
+    }
+
+    /// <summary>
+    /// Generates a key-targeted PartiQL <c>DELETE FROM "table" WHERE "pk" = ? [AND "sk" = ?]</c>
+    /// statement for a root entity in the <see cref="EntityState.Deleted"/> state.
+    /// </summary>
+    /// <param name="entry">The root entity entry to delete.</param>
+    /// <returns>A tuple of (tableName, sql, parameters) for the DELETE statement.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the entity type does not define a partition key or when a key property
+    /// lacks a <see cref="DynamoTypeMapping"/>.
+    /// </exception>
+    private static (string tableName, string sql, List<AttributeValue> parameters)
+        BuildDeleteStatement(IUpdateEntry entry)
+    {
+        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+        var entityType = entry.EntityType;
+
+        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
+
+        var partitionKeyMapping = partitionKeyProperty.GetTypeMapping() as DynamoTypeMapping
+            ?? throw new InvalidOperationException(
+                $"Partition key property '{entityType.DisplayName()}.{partitionKeyProperty.Name}' "
+                + "requires a DynamoTypeMapping.");
+
+        // Use the original key value so that the correct DynamoDB item is targeted even if the
+        // in-memory value was touched before deletion was requested.
+        var parameters = new List<AttributeValue>
+        {
+            partitionKeyMapping.CreateAttributeValue(
+                GetOriginalOrCurrentValue(entry, partitionKeyProperty)),
+        };
+
+        var sqlBuilder = new StringBuilder();
+        sqlBuilder.AppendLine($"DELETE FROM \"{EscapeIdentifier(tableName)}\"");
+        sqlBuilder.Append(
+            $"WHERE \"{EscapeIdentifier(partitionKeyProperty.GetAttributeName())}\" = ?");
+
+        var sortKeyProperty = entityType.GetSortKeyProperty();
+        if (sortKeyProperty is not null)
+        {
+            var sortKeyMapping = sortKeyProperty.GetTypeMapping() as DynamoTypeMapping
+                ?? throw new InvalidOperationException(
+                    $"Sort key property '{entityType.DisplayName()}.{sortKeyProperty.Name}' "
+                    + "requires a DynamoTypeMapping.");
+
+            parameters.Add(
+                sortKeyMapping.CreateAttributeValue(
+                    GetOriginalOrCurrentValue(entry, sortKeyProperty)));
+
+            sqlBuilder.Append(
+                $" AND \"{EscapeIdentifier(sortKeyProperty.GetAttributeName())}\" = ?");
+        }
+
+        return (tableName, sqlBuilder.ToString(), parameters);
     }
 
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -79,6 +79,10 @@ public class DynamoDatabaseWrapper(
                     // Serialization is handled by the compiled, per-entity-type serializer — no
                     // per-call type dispatch or value-type boxing on the scalar-property hot path.
                     // Owned sub-entries are resolved on-demand via the EF state manager.
+                    //
+                    // Concurrency: no version check needed for inserts — DynamoDB's PartiQL INSERT
+                    // will fail with ConditionalCheckFailedException if the key already exists,
+                    // which is the correct insert-only semantic.
                     var item = serializerSource.BuildItem(entry);
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
@@ -416,6 +420,16 @@ public class DynamoDatabaseWrapper(
         BuildDeleteStatement(IUpdateEntry entry)
     {
         var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+
+        // Guard: same safety net as BuildInsertStatement — DynamoDB table names cannot contain
+        // double-quotes, but a bad annotation value would otherwise silently corrupt the
+        // identifier.
+        if (tableName.Contains('"'))
+            throw new ArgumentException(
+                $"Table name '{tableName}' contains an illegal character ('\"'). "
+                + "DynamoDB table names must not contain double-quote characters.",
+                nameof(tableName));
+
         var entityType = entry.EntityType;
 
         var partitionKeyProperty = entityType.GetPartitionKeyProperty()

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
@@ -68,6 +68,12 @@ public class DeletedEntitiesSaveChangesTests(SaveChangesTableDynamoFixture fixtu
         await Db.SaveChangesAsync(CancellationToken);
 
         Db.Entry(customer).State.Should().Be(EntityState.Detached);
+
+        AssertSql(
+            """
+            DELETE FROM "AppItems"
+            WHERE "Pk" = ? AND "Sk" = ?
+            """);
     }
 
     /// <summary>
@@ -167,5 +173,20 @@ public class DeletedEntitiesSaveChangesTests(SaveChangesTableDynamoFixture fixtu
 
         var deletedItem = await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
         deletedItem.Should().BeNull();
+
+        AssertSql(
+            """
+            INSERT INTO "AppItems"
+            VALUE {'Pk': ?, 'Sk': ?, '$type': ?, 'CreatedAt': ?, 'Email': ?, 'IsPreferred': ?, 'Notes': ?, 'NullableNote': ?, 'Preferences': ?, 'ReferenceIds': ?, 'Tags': ?, 'Version': ?, 'Contacts': ?}
+            """,
+            """
+            UPDATE "AppItems"
+            SET "Email" = ?
+            WHERE "Pk" = ? AND "Sk" = ?
+            """,
+            """
+            DELETE FROM "AppItems"
+            WHERE "Pk" = ? AND "Sk" = ?
+            """);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>Integration tests for <c>SaveChangesAsync</c> with <c>EntityState.Deleted</c> entities.</summary>
+public class DeletedEntitiesSaveChangesTests(SaveChangesTableDynamoFixture fixture)
+    : SaveChangesTableTestBase(fixture)
+{
+    /// <summary>
+    ///     A tracked entity removed via <c>DbSet.Remove</c> is deleted from DynamoDB and the item is
+    ///     absent on a subsequent raw SDK read.
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_TrackedEntity_RemovesItemFromDynamoDB()
+    {
+        // Insert a fresh customer — avoid seeded entities whose Preferences map cannot yet be
+        // materialized by the query pipeline (pre-existing limitation, unrelated to this story).
+        var customer = new CustomerItem
+        {
+            Pk = "TENANT#DEL",
+            Sk = "CUSTOMER#DEL-1",
+            Version = 1,
+            Email = "del@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Add(customer);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        Db.Customers.Remove(customer);
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+
+        affected.Should().Be(1);
+
+        var item = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
+        item.Should().BeNull();
+
+        AssertSql(
+            """
+            DELETE FROM "AppItems"
+            WHERE "Pk" = ? AND "Sk" = ?
+            """);
+    }
+
+    /// <summary>After a successful delete, EF transitions the entry state to Detached.</summary>
+    [Fact]
+    public async Task DeleteAsync_EntityStateTransitionsToDetached()
+    {
+        var customer = new CustomerItem
+        {
+            Pk = "TENANT#DEL",
+            Sk = "CUSTOMER#STATE-1",
+            Version = 1,
+            Email = "del-state@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Add(customer);
+        await Db.SaveChangesAsync(CancellationToken);
+
+        Db.Entry(customer).State.Should().Be(EntityState.Unchanged);
+
+        Db.Customers.Remove(customer);
+        Db.Entry(customer).State.Should().Be(EntityState.Deleted);
+
+        LoggerFactory.Clear();
+        await Db.SaveChangesAsync(CancellationToken);
+
+        Db.Entry(customer).State.Should().Be(EntityState.Detached);
+    }
+
+    /// <summary>
+    ///     Deleting a stub entity whose key doesn't exist in DynamoDB is a no-op — the DynamoDB
+    ///     PartiQL DELETE is idempotent. No exception is thrown and the entry transitions to Detached.
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_NonExistentKey_IsNoOp()
+    {
+        var stub = new CustomerItem
+        {
+            Pk = "TENANT#GHOST",
+            Sk = "CUSTOMER#GHOST-1",
+            Version = 1,
+            Email = "ghost@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+
+        // Attach and mark Deleted without inserting first — key does not exist in DynamoDB.
+        Db.Customers.Attach(stub);
+        Db.Entry(stub).State = EntityState.Deleted;
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+
+        affected.Should().Be(1);
+        Db.Entry(stub).State.Should().Be(EntityState.Detached);
+
+        // Confirm item is still absent (was never created).
+        var item = await GetItemAsync("TENANT#GHOST", "CUSTOMER#GHOST-1", CancellationToken);
+        item.Should().BeNull();
+    }
+
+    /// <summary>
+    ///     A single <c>SaveChangesAsync</c> call containing Added, Modified, and Deleted entries
+    ///     processes all three and returns the correct affected count with correct post-save tracking
+    ///     states.
+    /// </summary>
+    [Fact]
+    public async Task SaveChangesAsync_MixedAddedModifiedDeleted_BatchAllStates()
+    {
+        // Pre-insert two entities to serve as modify and delete targets.
+        var toModify = new CustomerItem
+        {
+            Pk = "TENANT#MIXED",
+            Sk = "CUSTOMER#MIXED-MOD",
+            Version = 1,
+            Email = "before-modify@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var toDelete = new CustomerItem
+        {
+            Pk = "TENANT#MIXED",
+            Sk = "CUSTOMER#MIXED-DEL",
+            Version = 1,
+            Email = "before-delete@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.AddRange(toModify, toDelete);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        // New entity to add in the mixed batch.
+        var toAdd = new CustomerItem
+        {
+            Pk = "TENANT#MIXED",
+            Sk = "CUSTOMER#MIXED-ADD",
+            Version = 1,
+            Email = "new@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+
+        Db.Customers.Add(toAdd);
+        toModify.Email = "after-modify@example.com";
+        Db.Customers.Remove(toDelete);
+
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+
+        affected.Should().Be(3);
+
+        // Post-save state checks.
+        Db.Entry(toAdd).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(toModify).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(toDelete).State.Should().Be(EntityState.Detached);
+
+        // Raw DynamoDB verification.
+        var addedItem = await GetItemAsync(toAdd.Pk, toAdd.Sk, CancellationToken);
+        addedItem.Should().NotBeNull();
+        addedItem!["Email"].S.Should().Be("new@example.com");
+
+        var modifiedItem = await GetItemAsync(toModify.Pk, toModify.Sk, CancellationToken);
+        modifiedItem.Should().NotBeNull();
+        modifiedItem!["Email"].S.Should().Be("after-modify@example.com");
+
+        var deletedItem = await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
+        deletedItem.Should().BeNull();
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesTableTestBase.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesTableTestBase.cs
@@ -83,7 +83,8 @@ public abstract class SaveChangesTableTestBase(SaveChangesTableDynamoFixture fix
             },
             cancellationToken);
 
-        return response.Item.Count == 0 ? null : response.Item;
+        // DynamoDB Local returns null (not an empty dict) for missing keys; handle both.
+        return response.Item is { Count: > 0 } item ? item : null;
     }
 
     /// <summary>Writes a batch and retries unprocessed items until completion.</summary>


### PR DESCRIPTION
## Summary

- Emits a key-targeted `DELETE FROM "table" WHERE "pk" = ? [AND "sk" = ?]` PartiQL statement for `EntityState.Deleted` root entries
- Owned sub-entries are skipped — deleting the root item removes the whole DynamoDB document
- Mixed Added/Modified/Deleted changesets process deterministically in a single `SaveChangesAsync` call
- DynamoDB DELETE on a missing key is a no-op; concurrency failure mapping deferred to 6gu.5
- Fixes `GetItemAsync` in test base to handle null `response.Item` returned by DynamoDB Local for missing keys

## Test plan

- [ ] `DeleteAsync_TrackedEntity_RemovesItemFromDynamoDB` — item absent after save, PartiQL baseline asserted
- [ ] `DeleteAsync_EntityStateTransitionsToDetached` — entry state Deleted → Detached after save
- [ ] `DeleteAsync_NonExistentKey_IsNoOp` — no exception, affected == 1, item stays absent
- [ ] `SaveChangesAsync_MixedAddedModifiedDeleted_BatchAllStates` — affected == 3, correct post-save states, raw DynamoDB verification
- [ ] No regressions in `AddedEntitiesSaveChangesTests` (7 tests) or `ModifiedScalarSaveChangesTests` (6 tests)