### PR TITLE
feat(storage): add transactional multi-item SaveChanges behavior

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,25 @@ During transactional execution, the provider enforces DynamoDB transaction const
 - Maximum 100 write statements.
 - No multiple operations targeting the same item in one transaction.
 
-If constraints are violated, `SaveChangesAsync` throws a clear error instead of silently downgrading to non-atomic execution.
+If constraints are violated, `SaveChangesAsync` throws a clear error unless overflow chunking is
+explicitly enabled.
+
+Overflow handling is provider-configurable:
+
+- `TransactionOverflowBehavior.Throw` (default): throw when a transactional write unit exceeds the
+    effective `MaxTransactionSize`.
+- `TransactionOverflowBehavior.UseChunking`: split the write unit into multiple
+    `ExecuteTransaction` calls of up to `MaxTransactionSize` operations each.
+
+`AutoTransactionBehavior.Always` still requires a single atomic transactional unit; if the write
+unit exceeds the effective max transaction size, SaveChanges throws.
+
+Chunking semantics are explicit: each chunk is atomic, but the full SaveChanges unit is not
+globally atomic across chunks.
+
+Tracker semantics during chunking are also explicit: after each successful chunk commit, entries
+represented by that chunk are accepted in the current context. If a later chunk fails, already
+committed chunk entries remain accepted while failed/unrun chunk entries remain pending.
 
 Per-root write compilation remains:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,22 @@ icon: lucide/git-branch
 
 ## Write pipeline (SaveChangesAsync)
 
-`SaveChangesAsync` processes EF Core change-tracking entries in entity-state order:
+`SaveChangesAsync` uses a two-phase write pipeline:
+
+1. **Plan**: validate supported states, build root entries, and compile one PartiQL write operation per root item.
+1. **Execute**: pick execution mode from EF Core `Database.AutoTransactionBehavior`:
+    - `WhenNeeded` (default): one root write executes directly; multiple root writes execute via DynamoDB `ExecuteTransaction`.
+    - `Always`: behaves like `WhenNeeded` for a single root write, and requires `ExecuteTransaction` for multi-root writes.
+    - `Never`: executes compiled root writes independently (no implicit transaction).
+
+During transactional execution, the provider enforces DynamoDB transaction constraints before sending any write:
+
+- Maximum 100 write statements.
+- No multiple operations targeting the same item in one transaction.
+
+If constraints are violated, `SaveChangesAsync` throws a clear error instead of silently downgrading to non-atomic execution.
+
+Per-root write compilation remains:
 
 1. **Added** — generates a PartiQL `INSERT INTO "Table" VALUE {...}` statement. The provider sets
     no provider-managed concurrency metadata. A `DuplicateItemException` from DynamoDB is mapped to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,18 @@ optionsBuilder.UseDynamo(options =>
 Per-query evaluation budget is controlled by `.Limit(n)` on the query rather than a global default.
 See [Pagination](pagination.md) for the evaluation budget model.
 
+## SaveChanges transaction behavior
+
+The provider follows EF Core `Database.AutoTransactionBehavior` for implicit transaction policy:
+
+- `WhenNeeded` (default): one root write executes directly; multi-root saves execute atomically via DynamoDB `ExecuteTransaction`.
+- `Always`: requires transactional execution for multi-root saves.
+- `Never`: disables implicit transactions and executes root writes independently.
+
+```csharp
+context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+```
+
 ## Client configuration precedence
 
 - The provider resolves client settings in this order:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,41 @@ The provider follows EF Core `Database.AutoTransactionBehavior` for implicit tra
 context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 ```
 
+For transactional overflow (when one transaction cannot hold the whole write unit), configure:
+
+- `TransactionOverflowBehavior`:
+    - `Throw` (default)
+    - `UseChunking` (splits into multiple `ExecuteTransaction` calls)
+- `MaxTransactionSize` (default `100`, valid range `1..100`)
+
+```csharp
+optionsBuilder.UseDynamo(options =>
+{
+    options.TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+    options.MaxTransactionSize(50);
+});
+```
+
+Per-context overrides are available on `DatabaseFacade`:
+
+```csharp
+context.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+context.Database.SetMaxTransactionSize(25);
+```
+
+Configuration precedence:
+
+1. Per-context override (`context.Database.Set...`)
+1. Startup/provider option (`UseDynamo(...)`)
+1. Provider defaults (`Throw`, `100`)
+
+`UseChunking` keeps each chunk atomic, but the overall `SaveChanges` call is no longer globally
+atomic across all root writes.
+
+When chunking is active, use normal `SaveChanges`/`SaveChangesAsync` acceptance behavior
+(`acceptAllChangesOnSuccess: true`). Chunking with `acceptAllChangesOnSuccess: false` is rejected
+because successful chunks must be accepted immediately to avoid replaying already persisted writes.
+
 ## Client configuration precedence
 
 - The provider resolves client settings in this order:

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,5 +61,5 @@ dotnet add package EntityFrameworkCore.DynamoDb
 
 ## Notes
 
-- `SaveChangesAsync` currently supports scalar root updates. Owned/nested mutation write paths are
-    still limited; see [Limitations](limitations.md).
+- `SaveChangesAsync` supports Added/Modified/Deleted root writes, including owned/nested mutations,
+    and follows EF Core `AutoTransactionBehavior` for implicit atomic multi-root execution.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -22,6 +22,10 @@ icon: lucide/triangle-alert
     including mutations to owned references (`OwnsOne`), owned collections (`OwnsMany`), and
     primitive collection properties (lists, dictionaries, and sets).
 - Synchronous `SaveChanges` is not supported.
+- Transactional multi-root `SaveChangesAsync` is constrained by DynamoDB `ExecuteTransaction` limits:
+    - maximum 100 write statements,
+    - no multiple operations on the same item in a single transaction.
+- When transactional atomicity is required (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws if those constraints are violated; it does not silently downgrade to non-atomic execution.
 - Unsupported LINQ shapes fail during translation with `InvalidOperationException` including provider-specific details.
 - Discriminator guardrails for unsupported query shapes are deferred; support is limited to the
     current operator surface in `operators.md`.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -25,7 +25,17 @@ icon: lucide/triangle-alert
 - Transactional multi-root `SaveChangesAsync` is constrained by DynamoDB `ExecuteTransaction` limits:
     - maximum 100 write statements,
     - no multiple operations on the same item in a single transaction.
-- When transactional atomicity is required (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws if those constraints are violated; it does not silently downgrade to non-atomic execution.
+- By default (`TransactionOverflowBehavior.Throw`), when transactional atomicity is required
+    (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws
+    if those constraints are violated; it does not silently downgrade to non-atomic execution.
+- If `TransactionOverflowBehavior.UseChunking` is configured, overflowing multi-root writes can be
+    executed as multiple `ExecuteTransaction` chunks (up to `MaxTransactionSize`, max 100 per
+    chunk), but overall SaveChanges atomicity is lost across chunk boundaries.
+- Chunking requires `acceptAllChangesOnSuccess: true`. `SaveChanges(false)`/
+    `SaveChangesAsync(false)` is rejected for chunking overflow paths because successful chunks must
+    be accepted immediately in the tracker.
+- `AutoTransactionBehavior.Always` still throws when one atomic transaction cannot represent the
+    full write unit.
 - Unsupported LINQ shapes fail during translation with `InvalidOperationException` including provider-specific details.
 - Discriminator guardrails for unsupported query shapes are deferred; support is limited to the
     current operator surface in `operators.md`.

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
@@ -1,0 +1,71 @@
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Extension methods for provider-specific transaction overflow behavior on
+/// <see cref="DatabaseFacade" />.
+/// </summary>
+public static class DynamoDatabaseFacadeExtensions
+{
+    /// <summary>
+    /// Sets a per-context override for transaction overflow behavior.
+    /// </summary>
+    public static void SetTransactionOverflowBehavior(
+        this DatabaseFacade databaseFacade,
+        TransactionOverflowBehavior behavior)
+        => GetRuntimeOptions(databaseFacade).TransactionOverflowBehaviorOverride = behavior;
+
+    /// <summary>
+    /// Gets the effective transaction overflow behavior for this context.
+    /// </summary>
+    public static TransactionOverflowBehavior GetTransactionOverflowBehavior(
+        this DatabaseFacade databaseFacade)
+    {
+        var runtimeOptions = GetRuntimeOptions(databaseFacade);
+
+        return runtimeOptions.TransactionOverflowBehaviorOverride
+            ?? GetDynamoOptionsExtension(databaseFacade).TransactionOverflowBehavior;
+    }
+
+    /// <summary>
+    /// Sets a per-context override for max transaction size.
+    /// </summary>
+    public static void SetMaxTransactionSize(
+        this DatabaseFacade databaseFacade,
+        int maxTransactionSize)
+    {
+        if (maxTransactionSize is <= 0 or > 100)
+            throw new InvalidOperationException(
+                $"The specified 'MaxTransactionSize' value '{maxTransactionSize}' is not valid. "
+                + "It must be between 1 and 100.");
+
+        GetRuntimeOptions(databaseFacade).MaxTransactionSizeOverride = maxTransactionSize;
+    }
+
+    /// <summary>
+    /// Gets the effective max transaction size for this context.
+    /// </summary>
+    public static int GetMaxTransactionSize(this DatabaseFacade databaseFacade)
+    {
+        var runtimeOptions = GetRuntimeOptions(databaseFacade);
+
+        return runtimeOptions.MaxTransactionSizeOverride
+            ?? GetDynamoOptionsExtension(databaseFacade).MaxTransactionSize;
+    }
+
+    private static DynamoTransactionRuntimeOptions GetRuntimeOptions(DatabaseFacade databaseFacade)
+        => ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context
+            .GetService<DynamoTransactionRuntimeOptions>();
+
+    private static DynamoDbOptionsExtension GetDynamoOptionsExtension(DatabaseFacade databaseFacade)
+        => ((IDatabaseFacadeDependenciesAccessor)databaseFacade)
+            .Context
+            .GetService<IDbContextOptions>()
+            .FindExtension<DynamoDbOptionsExtension>()
+            ?? throw new InvalidOperationException(
+                "DynamoDB provider services are not available for this DbContext.");
+}

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
@@ -38,6 +38,8 @@ public static class DynamoServiceCollectionExtensions
                     DynamoShapedQueryCompilingExpressionVisitorFactory>()
                 .TryAdd<IQueryCompilationContextFactory, DynamoQueryCompilationContextFactory>()
                 .TryAddProviderSpecificServices(services => services
+                    .TryAddScoped<
+                        DynamoTransactionRuntimeOptions>(_ => new DynamoTransactionRuntimeOptions())
                     .TryAddScoped<IDynamoClientWrapper, DynamoClientWrapper>()
                     .TryAddSingleton<DynamoEntityItemSerializerSource>(_
                         => new DynamoEntityItemSerializerSource())

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
@@ -45,6 +45,22 @@ public class DynamoDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilde
         DynamoAutomaticIndexSelectionMode mode)
         => WithOption(e => e.WithAutomaticIndexSelectionMode(mode));
 
+    /// <summary>
+    /// Configures how transactional SaveChanges should behave when the write unit exceeds max
+    /// transaction size.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder TransactionOverflowBehavior(
+        TransactionOverflowBehavior behavior)
+        => WithOption(e => e.WithTransactionOverflowBehavior(behavior));
+
+    /// <summary>
+    /// Configures the maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder MaxTransactionSize(int maxTransactionSize)
+        => WithOption(e => e.WithMaxTransactionSize(maxTransactionSize));
+
     /// <summary>Updates the provider options extension with the supplied mutation action.</summary>
     protected virtual DynamoDbContextOptionsBuilder WithOption(
         Func<DynamoDbOptionsExtension, DynamoDbOptionsExtension> setAction)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,8 @@ namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 /// <summary>Represents the DynamoDbOptionsExtension type.</summary>
 public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 {
+    private const int DynamoTransactionLimit = 100;
+
     /// <summary>Provides functionality for this member.</summary>
     public IAmazonDynamoDB? DynamoDbClient { get; private set; }
 
@@ -19,6 +22,16 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 
     /// <summary>Controls whether the provider should automatically select compatible secondary indexes.</summary>
     public DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode { get; private set; }
+
+    /// <summary>
+    /// Controls how SaveChanges behaves when a transactional write unit exceeds max transaction size.
+    /// </summary>
+    public TransactionOverflowBehavior TransactionOverflowBehavior { get; private set; }
+
+    /// <summary>
+    /// Maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    public int MaxTransactionSize { get; private set; } = DynamoTransactionLimit;
 
     /// <summary>Registers provider services in the EF Core internal service container.</summary>
     public virtual void ApplyServices(IServiceCollection services)
@@ -80,6 +93,37 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
+    /// <summary>
+    /// Sets how transactional SaveChanges should behave when one transaction cannot represent
+    /// the full write unit.
+    /// </summary>
+    public virtual DynamoDbOptionsExtension WithTransactionOverflowBehavior(
+        TransactionOverflowBehavior behavior)
+    {
+        var clone = Clone();
+
+        clone.TransactionOverflowBehavior = behavior;
+
+        return clone;
+    }
+
+    /// <summary>
+    /// Sets the maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    public virtual DynamoDbOptionsExtension WithMaxTransactionSize(int maxTransactionSize)
+    {
+        if (maxTransactionSize is <= 0 or > DynamoTransactionLimit)
+            throw new InvalidOperationException(
+                $"The specified 'MaxTransactionSize' value '{maxTransactionSize}' is not valid. "
+                + $"It must be between 1 and {DynamoTransactionLimit}.");
+
+        var clone = Clone();
+
+        clone.MaxTransactionSize = maxTransactionSize;
+
+        return clone;
+    }
+
     /// <summary>Creates a copy of this extension with the current option values.</summary>
     protected virtual DynamoDbOptionsExtension Clone()
         => new()
@@ -88,6 +132,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             DynamoDbClientConfig = DynamoDbClientConfig,
             DynamoDbClientConfigAction = DynamoDbClientConfigAction,
             AutomaticIndexSelectionMode = AutomaticIndexSelectionMode,
+            TransactionOverflowBehavior = TransactionOverflowBehavior,
+            MaxTransactionSize = MaxTransactionSize,
         };
 
     /// <summary>Represents the DynamoOptionsExtensionInfo type.</summary>
@@ -109,6 +155,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 hashCode.Add(Extension.DynamoDbClientConfig);
                 hashCode.Add(Extension.DynamoDbClientConfigAction);
                 hashCode.Add(Extension.AutomaticIndexSelectionMode);
+                hashCode.Add(Extension.TransactionOverflowBehavior);
+                hashCode.Add(Extension.MaxTransactionSize);
 
                 _serviceProviderHash = hashCode.ToHashCode();
             }
@@ -127,7 +175,10 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                     Extension.DynamoDbClientConfigAction,
                     otherInfo.Extension.DynamoDbClientConfigAction)
                 && Extension.AutomaticIndexSelectionMode
-                == otherInfo.Extension.AutomaticIndexSelectionMode;
+                == otherInfo.Extension.AutomaticIndexSelectionMode
+                && Extension.TransactionOverflowBehavior
+                == otherInfo.Extension.TransactionOverflowBehavior
+                && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize;
 
         /// <summary>Provides functionality for this member.</summary>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }
@@ -141,6 +192,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             get
             {
                 field ??= $"AutomaticIndexSelectionMode={Extension.AutomaticIndexSelectionMode},"
+                    + $"TransactionOverflowBehavior={Extension.TransactionOverflowBehavior},"
+                    + $"MaxTransactionSize={Extension.MaxTransactionSize},"
                     + $"DynamoDbClient={Extension.DynamoDbClient is not null},"
                     + $"DynamoDbClientConfig={Extension.DynamoDbClientConfig is not null},"
                     + $"DynamoDbClientConfigAction={Extension.DynamoDbClientConfigAction is not null}";

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
@@ -1,0 +1,18 @@
+namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
+
+/// <summary>Scoped runtime overrides for transaction overflow execution behavior.</summary>
+public sealed class DynamoTransactionRuntimeOptions
+{
+    /// <summary>
+    /// Optional per-context override for transaction overflow behavior.
+    /// </summary>
+    public TransactionOverflowBehavior? TransactionOverflowBehaviorOverride { get; set; }
+
+    /// <summary>
+    /// Optional per-context override for max transaction size.
+    /// </summary>
+    public int? MaxTransactionSizeOverride { get; set; }
+
+    /// <summary>Captures <c>acceptAllChangesOnSuccess</c> for current SaveChanges call.</summary>
+    public bool? AcceptAllChangesOnSuccess { get; set; }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/TransactionOverflowBehavior.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/TransactionOverflowBehavior.cs
@@ -1,0 +1,18 @@
+namespace EntityFrameworkCore.DynamoDb.Infrastructure;
+
+/// <summary>
+/// Controls how SaveChanges handles transactional overflow when one DynamoDB transaction
+/// cannot represent the full write unit.
+/// </summary>
+public enum TransactionOverflowBehavior
+{
+    /// <summary>
+    /// Throws when a transactional SaveChanges unit exceeds the configured max transaction size.
+    /// </summary>
+    Throw,
+
+    /// <summary>
+    /// Splits overflowing transactional SaveChanges units into multiple ExecuteTransaction calls.
+    /// </summary>
+    UseChunking,
+}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -75,6 +75,28 @@ public class DynamoClientWrapper : IDynamoClientWrapper
             null,
             cancellationToken);
 
+    /// <summary>Executes an atomic write transaction of PartiQL statements.</summary>
+    /// <param name="statements">Ordered transaction statements.</param>
+    /// <param name="cancellationToken">Token to observe for cancellation.</param>
+    public Task ExecuteTransactionAsync(
+        IReadOnlyList<ParameterizedStatement> statements,
+        CancellationToken cancellationToken = default)
+        => _executionStrategy.ExecuteAsync(
+            statements,
+            async (_, transactionStatements, ct) =>
+            {
+                var request = new ExecuteTransactionRequest
+                {
+                    TransactStatements = [.. transactionStatements],
+                };
+
+                await Client.ExecuteTransactionAsync(request, ct).ConfigureAwait(false);
+
+                return true;
+            },
+            null,
+            cancellationToken);
+
     /// <summary>Builds the effective SDK configuration from extension options in precedence order.</summary>
     private static AmazonDynamoDBConfig BuildAmazonDynamoDbConfig(DynamoDbOptionsExtension? options)
     {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -369,9 +369,8 @@ public class DynamoDatabaseWrapper(
         int maxTransactionSize,
         CancellationToken cancellationToken)
     {
-        for (var i = 0; i < operations.Count; i += maxTransactionSize)
+        foreach (var chunk in operations.Chunk(maxTransactionSize))
         {
-            var chunk = operations.Skip(i).Take(maxTransactionSize).ToList();
             ValidateTransactionalDuplicateTargets(chunk);
             await ExecuteTransactionalWritesAsync(chunk, cancellationToken).ConfigureAwait(false);
             AcceptChunkEntries(chunk, rootAggregateEntries);
@@ -1201,9 +1200,9 @@ public class DynamoDatabaseWrapper(
         var rootEntries = entries
             .Where(static e
                 => !e.EntityType.IsOwned()
-                && (e.EntityState == EntityState.Added
-                    || e.EntityState == EntityState.Modified
-                    || e.EntityState == EntityState.Deleted))
+                && e.EntityState is EntityState.Added
+                    or EntityState.Modified
+                    or EntityState.Deleted)
             .ToList();
 
         IncludeMutatingOwnedRoots(entries, rootEntries);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -7,6 +7,7 @@ using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -21,6 +22,7 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 /// </summary>
 public class DynamoDatabaseWrapper(
     DatabaseDependencies dependencies,
+    ICurrentDbContext currentDbContext,
     IDynamoClientWrapper clientWrapper,
     IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
     DynamoEntityItemSerializerSource serializerSource) : Database(dependencies)
@@ -67,7 +69,51 @@ public class DynamoDatabaseWrapper(
         // Turns HasMutationForOwnedNavigation from O(entries × navs × depth) → O(1) per check.
         var mutatingNavs = BuildMutatingNavLookup(entries);
 
-        var rowsAffected = 0;
+        var operations = BuildWriteOperations(rootEntries, mutatingNavs);
+        if (operations.Count == 0)
+            return 0;
+
+        var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
+        var shouldUseTransaction = autoTransactionBehavior switch
+        {
+            AutoTransactionBehavior.Never => false,
+            AutoTransactionBehavior.WhenNeeded => operations.Count > 1,
+            AutoTransactionBehavior.Always => operations.Count > 1,
+            _ => throw new InvalidOperationException(
+                $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
+        };
+
+        if (!shouldUseTransaction)
+        {
+            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+                .ConfigureAwait(false);
+            return operations.Count;
+        }
+
+        ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
+        await ExecuteTransactionalWritesAsync(operations, cancellationToken).ConfigureAwait(false);
+
+        return operations.Count;
+    }
+
+    private sealed record CompiledWriteOperation(
+        IUpdateEntry Entry,
+        EntityState EntityState,
+        string TableName,
+        string Statement,
+        List<AttributeValue> Parameters,
+        TransactionTargetItem TargetItem);
+
+    private sealed record TransactionTargetItem(
+        string TableName,
+        string PartitionKey,
+        string SortKey);
+
+    private List<CompiledWriteOperation> BuildWriteOperations(
+        IReadOnlyList<IUpdateEntry> rootEntries,
+        Dictionary<InternalEntityEntry, HashSet<INavigation>> mutatingNavs)
+    {
+        var operations = new List<CompiledWriteOperation>(rootEntries.Count);
 
         foreach (var entry in rootEntries)
         {
@@ -75,121 +121,66 @@ public class DynamoDatabaseWrapper(
             {
                 case EntityState.Added:
                 {
-                    // Serialization is handled by the compiled, per-entity-type serializer — no
-                    // per-call type dispatch or value-type boxing on the scalar-property hot path.
-                    // Owned sub-entries are resolved on-demand via the EF state manager.
-                    //
-                    // Concurrency: PartiQL INSERT fails with DuplicateItemException when a key
-                    // already exists. This is the correct insert-only (create-never-replace)
-                    // semantic; we map it to DbUpdateException below.
-
                     var item = serializerSource.BuildItem(entry);
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
 
-                    commandLogger.ExecutingPartiQlWrite(tableName, sql);
-
-                    try
-                    {
-                        await clientWrapper
-                            .ExecuteWriteAsync(sql, parameters, cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex is DuplicateItemException
-                            or TransactionCanceledException
-                        || IsDuplicateKeyException(ex))
-                    {
-                        throw WrapWriteException(ex, EntityState.Added, entry);
-                    }
-
+                    operations.Add(
+                        new CompiledWriteOperation(
+                            entry,
+                            EntityState.Added,
+                            tableName,
+                            sql,
+                            parameters,
+                            BuildTargetItemIdentity(entry, tableName)));
                     break;
                 }
 
                 case EntityState.Modified:
                 {
-                    // Scalar/collection root properties AND/OR owned sub-entities may have
-                    // changed — run all four phases (A: scalars, B: collections, C: OwnsOne,
-                    // D: OwnsMany).
                     var update = BuildModifiedUpdateStatement(entry, mutatingNavs);
                     if (update is null)
                         continue;
 
-                    commandLogger.ExecutingPartiQlWrite(update.Value.tableName, update.Value.sql);
-
-                    try
-                    {
-                        await clientWrapper
-                            .ExecuteWriteAsync(
-                                update.Value.sql,
-                                update.Value.parameters,
-                                cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex is ConditionalCheckFailedException
-                        or TransactionCanceledException)
-                    {
-                        throw WrapWriteException(ex, EntityState.Modified, entry);
-                    }
-
+                    operations.Add(
+                        new CompiledWriteOperation(
+                            entry,
+                            EntityState.Modified,
+                            update.Value.tableName,
+                            update.Value.sql,
+                            update.Value.parameters,
+                            BuildTargetItemIdentity(entry, update.Value.tableName)));
                     break;
                 }
 
                 case EntityState.Unchanged:
                 {
-                    // Root injected by IncludeMutatingOwnedRoots: its own scalar and collection
-                    // properties have not changed (IsModified is false for all of them).
-                    // Only owned sub-entities mutated — skip directly to phases C+D.
-                    //
-                    // We intentionally do not promote the root to Modified here (unlike the Cosmos
-                    // provider) because our partial-UPDATE strategy depends on IsModified(property)
-                    // being false for untouched root scalars. Promoting the state would mark every
-                    // scalar as modified and generate spurious SET clauses.
                     var update = BuildOwnedMutationUpdateStatement(entry, mutatingNavs);
                     if (update is null)
                         continue;
 
-                    commandLogger.ExecutingPartiQlWrite(update.Value.tableName, update.Value.sql);
-
-                    try
-                    {
-                        await clientWrapper
-                            .ExecuteWriteAsync(
-                                update.Value.sql,
-                                update.Value.parameters,
-                                cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex is ConditionalCheckFailedException
-                        or TransactionCanceledException)
-                    {
-                        throw WrapWriteException(ex, EntityState.Modified, entry);
-                    }
-
+                    operations.Add(
+                        new CompiledWriteOperation(
+                            entry,
+                            EntityState.Modified,
+                            update.Value.tableName,
+                            update.Value.sql,
+                            update.Value.parameters,
+                            BuildTargetItemIdentity(entry, update.Value.tableName)));
                     break;
                 }
 
                 case EntityState.Deleted:
                 {
-                    // Deleting the root item removes the whole DynamoDB document including all
-                    // owned sub-entities — no separate statement is needed per owned entry.
-                    // DynamoDB PartiQL DELETE on a missing key is a silent no-op even when
-                    // concurrency-token WHERE predicates are present.
                     var delete = BuildDeleteStatement(entry);
-
-                    commandLogger.ExecutingPartiQlWrite(delete.tableName, delete.sql);
-
-                    try
-                    {
-                        await clientWrapper
-                            .ExecuteWriteAsync(delete.sql, delete.parameters, cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex is ConditionalCheckFailedException
-                        or TransactionCanceledException)
-                    {
-                        throw WrapWriteException(ex, EntityState.Deleted, entry);
-                    }
-
+                    operations.Add(
+                        new CompiledWriteOperation(
+                            entry,
+                            EntityState.Deleted,
+                            delete.tableName,
+                            delete.sql,
+                            delete.parameters,
+                            BuildTargetItemIdentity(entry, delete.tableName)));
                     break;
                 }
 
@@ -198,11 +189,163 @@ public class DynamoDatabaseWrapper(
                         $"SaveChanges for EntityState.{entry.EntityState} is not handled "
                         + $"in the write loop for '{entry.EntityType.DisplayName()}'.");
             }
-
-            rowsAffected++;
         }
 
-        return rowsAffected;
+        return operations;
+    }
+
+    private async Task ExecuteIndependentWritesAsync(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        CancellationToken cancellationToken)
+    {
+        foreach (var operation in operations)
+        {
+            commandLogger.ExecutingPartiQlWrite(operation.TableName, operation.Statement);
+
+            try
+            {
+                await clientWrapper
+                    .ExecuteWriteAsync(operation.Statement, operation.Parameters, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is DuplicateItemException
+                    or ConditionalCheckFailedException
+                    or TransactionCanceledException
+                || IsDuplicateKeyException(ex))
+            {
+                throw WrapWriteException(ex, operation.EntityState, operation.Entry);
+            }
+        }
+    }
+
+    private async Task ExecuteTransactionalWritesAsync(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        CancellationToken cancellationToken)
+    {
+        foreach (var operation in operations)
+            commandLogger.ExecutingPartiQlWrite(operation.TableName, operation.Statement);
+
+        var statements = operations
+            .Select(static operation => new ParameterizedStatement
+            {
+                Statement = operation.Statement, Parameters = operation.Parameters,
+            })
+            .ToList();
+
+        try
+        {
+            await clientWrapper
+                .ExecuteTransactionAsync(statements, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TransactionCanceledException tce)
+        {
+            throw WrapWriteException(
+                tce,
+                EntityState.Modified,
+                operations.Select(static x => x.Entry).ToList());
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new DbUpdateException(
+                "Atomic SaveChanges transaction failed while executing DynamoDB ExecuteTransaction.",
+                ex,
+                operations.Select(static x => x.Entry).ToList());
+        }
+    }
+
+    private static void ValidateTransactionalWriteOperations(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        AutoTransactionBehavior autoTransactionBehavior)
+    {
+        if (operations.Count > 100)
+            throw new InvalidOperationException(
+                "SaveChanges cannot satisfy transactional atomicity because the unit of work "
+                + $"contains {operations.Count} root write operations, exceeding the DynamoDB "
+                + "ExecuteTransaction limit of 100 statements. "
+                + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}'.");
+
+        var duplicateTarget = operations
+            .GroupBy(static x => x.TargetItem)
+            .FirstOrDefault(static g => g.Count() > 1);
+
+        if (duplicateTarget is not null)
+            throw new InvalidOperationException(
+                "SaveChanges cannot satisfy transactional atomicity because the unit of work "
+                + "contains multiple operations targeting the same DynamoDB item in a single "
+                + "transaction, which is not allowed by ExecuteTransaction.");
+    }
+
+    private static TransactionTargetItem BuildTargetItemIdentity(
+        IUpdateEntry entry,
+        string tableName)
+    {
+        var entityType = entry.EntityType;
+
+        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
+
+        var partitionKeyValue = SerializeIdentityValue(entry, partitionKeyProperty);
+
+        var sortKeyProperty = entityType.GetSortKeyProperty();
+        var sortKeyValue = sortKeyProperty is null
+            ? ""
+            : SerializeIdentityValue(entry, sortKeyProperty);
+
+        return new TransactionTargetItem(tableName, partitionKeyValue, sortKeyValue);
+    }
+
+    private static string SerializeIdentityValue(IUpdateEntry entry, IProperty keyProperty)
+    {
+        var mapping = keyProperty.GetTypeMapping() as DynamoTypeMapping
+            ?? throw new InvalidOperationException(
+                $"Key property '{entry.EntityType.DisplayName()}.{keyProperty.Name}' "
+                + "requires a DynamoTypeMapping.");
+
+        var value = mapping.CreateAttributeValue(GetOriginalOrCurrentValue(entry, keyProperty));
+        return SerializeAttributeValue(value);
+    }
+
+    private static string SerializeAttributeValue(AttributeValue value)
+    {
+        if (value.S is not null)
+            return "S:" + value.S;
+        if (value.N is not null)
+            return "N:" + value.N;
+        if (value.B is not null)
+            return "B:" + Convert.ToBase64String(value.B.ToArray());
+        if (value.BOOL is true || value.BOOL is false)
+            return "BOOL:" + value.BOOL;
+        if (value.NULL == true)
+            return "NULL";
+        if (value.SS is not null)
+            return "SS:" + string.Join(",", value.SS.Order(StringComparer.Ordinal));
+        if (value.NS is not null)
+            return "NS:" + string.Join(",", value.NS.Order(StringComparer.Ordinal));
+        if (value.BS is not null)
+            return "BS:"
+                + string.Join(
+                    ",",
+                    value
+                        .BS
+                        .Select(static b => Convert.ToBase64String(b.ToArray()))
+                        .Order(StringComparer.Ordinal));
+
+        if (value.L is not null)
+            return "L:[" + string.Join(",", value.L.Select(SerializeAttributeValue)) + "]";
+
+        if (value.M is not null)
+            return "M:{"
+                + string.Join(
+                    ",",
+                    value
+                        .M
+                        .OrderBy(static kv => kv.Key, StringComparer.Ordinal)
+                        .Select(static kv => kv.Key + "=" + SerializeAttributeValue(kv.Value)))
+                + "}";
+
+        return "EMPTY";
     }
 
     /// <summary>
@@ -1143,22 +1286,30 @@ public class DynamoDatabaseWrapper(
         Exception ex,
         EntityState entityState,
         IUpdateEntry entry)
+        => WrapWriteException(ex, entityState, [entry]);
+
+    private static DbUpdateException WrapWriteException(
+        Exception ex,
+        EntityState entityState,
+        IReadOnlyList<IUpdateEntry> entries)
     {
+        var firstEntry = entries[0];
+
         if (ex is DuplicateItemException || IsDuplicateKeyException(ex))
             return new DbUpdateException(
-                $"Cannot insert '{entry.EntityType.DisplayName()}': an item with the same primary "
+                $"Cannot insert '{firstEntry.EntityType.DisplayName()}': an item with the same primary "
                 + "key already exists.",
                 ex,
-                [entry]);
+                entries);
 
         if (ex is ConditionalCheckFailedException)
             return new DbUpdateConcurrencyException(
-                $"The '{entry.EntityType.DisplayName()}' entity could not be "
+                $"The '{firstEntry.EntityType.DisplayName()}' entity could not be "
                 + (entityState == EntityState.Modified ? "updated" : "deleted")
                 + " because one or more concurrency token values have changed since it was last read. "
                 + "Another writer may have modified this item.",
                 ex,
-                [entry]);
+                entries);
 
         if (ex is TransactionCanceledException tce)
         {
@@ -1171,18 +1322,18 @@ public class DynamoDatabaseWrapper(
             return hasConcurrency
                 ? new DbUpdateConcurrencyException(
                     $"Transaction cancelled due to a concurrency token conflict on "
-                    + $"'{entry.EntityType.DisplayName()}'.",
+                    + $"'{firstEntry.EntityType.DisplayName()}'.",
                     tce,
-                    [entry])
+                    entries)
                 : new DbUpdateException(
-                    $"Transaction cancelled while saving '{entry.EntityType.DisplayName()}'.",
+                    $"Transaction cancelled while saving '{firstEntry.EntityType.DisplayName()}'.",
                     tce,
-                    [entry]);
+                    entries);
         }
 
         return new DbUpdateException(
-            $"An error occurred saving '{entry.EntityType.DisplayName()}' to DynamoDB.",
+            $"An error occurred saving '{firstEntry.EntityType.DisplayName()}' to DynamoDB.",
             ex,
-            [entry]);
+            entries);
     }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -3,6 +3,8 @@ using System.Text;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -22,11 +24,21 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 /// </summary>
 public class DynamoDatabaseWrapper(
     DatabaseDependencies dependencies,
+    IDbContextOptions dbContextOptions,
     ICurrentDbContext currentDbContext,
+    DynamoTransactionRuntimeOptions transactionRuntimeOptions,
     IDynamoClientWrapper clientWrapper,
     IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
     DynamoEntityItemSerializerSource serializerSource) : Database(dependencies)
 {
+    private readonly DynamoDbOptionsExtension _optionsExtension =
+        dbContextOptions.FindExtension<DynamoDbOptionsExtension>()
+        ?? new DynamoDbOptionsExtension();
+
+    private readonly bool _saveEventsHooked = HookSaveEvents(
+        currentDbContext.Context,
+        transactionRuntimeOptions);
+
     /// <summary>Not supported — DynamoDB only exposes an async API.</summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
     public override int SaveChanges(IList<IUpdateEntry> entries)
@@ -50,50 +62,42 @@ public class DynamoDatabaseWrapper(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
     {
-        // Guard: only Added/Modified/Deleted are implemented; fail explicitly for others.
-        var unsupported = entries.FirstOrDefault(static e
-            => e.EntityState is not EntityState.Added
-                and not EntityState.Modified
-                and not EntityState.Deleted
-            && !e.EntityType.IsOwned());
+        _ = _saveEventsHooked;
 
-        if (unsupported is not null)
-            throw new NotSupportedException(
-                $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
-                + "Only Added, Modified, and Deleted entities can be persisted in this version.");
-
-        var rootEntries = BuildRootEntries(entries);
-
-        // Pre-compute once per save call: for each principal entry, which of its owned
-        // navigations have at least one Add/Modify/Delete mutation in this batch?
-        // Turns HasMutationForOwnedNavigation from O(entries × navs × depth) → O(1) per check.
-        var mutatingNavs = BuildMutatingNavLookup(entries);
-
-        var operations = BuildWriteOperations(rootEntries, mutatingNavs);
-        if (operations.Count == 0)
-            return 0;
-
-        var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
-        var shouldUseTransaction = autoTransactionBehavior switch
+        try
         {
-            AutoTransactionBehavior.Never => false,
-            AutoTransactionBehavior.WhenNeeded => operations.Count > 1,
-            AutoTransactionBehavior.Always => operations.Count > 1,
-            _ => throw new InvalidOperationException(
-                $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
-        };
+            // Guard: only Added/Modified/Deleted are implemented; fail explicitly for others.
+            var unsupported = entries.FirstOrDefault(static e
+                => e.EntityState is not EntityState.Added
+                    and not EntityState.Modified
+                    and not EntityState.Deleted
+                && !e.EntityType.IsOwned());
 
-        if (!shouldUseTransaction)
-        {
-            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+            if (unsupported is not null)
+                throw new NotSupportedException(
+                    $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
+                    + "Only Added, Modified, and Deleted entities can be persisted in this version.");
+
+            var rootEntries = BuildRootEntries(entries);
+
+            // Pre-compute once per save call: for each principal entry, which of its owned
+            // navigations have at least one Add/Modify/Delete mutation in this batch?
+            // Turns HasMutationForOwnedNavigation from O(entries × navs × depth) → O(1) per check.
+            var mutatingNavs = BuildMutatingNavLookup(entries);
+
+            var operations = BuildWriteOperations(rootEntries, mutatingNavs);
+            if (operations.Count == 0)
+                return 0;
+
+            await ExecutePlannedWritesAsync(entries, rootEntries, operations, cancellationToken)
                 .ConfigureAwait(false);
+
             return operations.Count;
         }
-
-        ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
-        await ExecuteTransactionalWritesAsync(operations, cancellationToken).ConfigureAwait(false);
-
-        return operations.Count;
+        finally
+        {
+            transactionRuntimeOptions.AcceptAllChangesOnSuccess = null;
+        }
     }
 
     private sealed record CompiledWriteOperation(
@@ -125,14 +129,13 @@ public class DynamoDatabaseWrapper(
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Added,
-                            tableName,
-                            sql,
-                            parameters,
-                            BuildTargetItemIdentity(entry, tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Added,
+                        tableName,
+                        sql,
+                        parameters);
                     break;
                 }
 
@@ -142,14 +145,13 @@ public class DynamoDatabaseWrapper(
                     if (update is null)
                         continue;
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Modified,
-                            update.Value.tableName,
-                            update.Value.sql,
-                            update.Value.parameters,
-                            BuildTargetItemIdentity(entry, update.Value.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Modified,
+                        update.Value.tableName,
+                        update.Value.sql,
+                        update.Value.parameters);
                     break;
                 }
 
@@ -159,28 +161,26 @@ public class DynamoDatabaseWrapper(
                     if (update is null)
                         continue;
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Modified,
-                            update.Value.tableName,
-                            update.Value.sql,
-                            update.Value.parameters,
-                            BuildTargetItemIdentity(entry, update.Value.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Modified,
+                        update.Value.tableName,
+                        update.Value.sql,
+                        update.Value.parameters);
                     break;
                 }
 
                 case EntityState.Deleted:
                 {
                     var delete = BuildDeleteStatement(entry);
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Deleted,
-                            delete.tableName,
-                            delete.sql,
-                            delete.parameters,
-                            BuildTargetItemIdentity(entry, delete.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Deleted,
+                        delete.tableName,
+                        delete.sql,
+                        delete.parameters);
                     break;
                 }
 
@@ -193,6 +193,115 @@ public class DynamoDatabaseWrapper(
 
         return operations;
     }
+
+    private async Task ExecutePlannedWritesAsync(
+        IList<IUpdateEntry> entries,
+        IReadOnlyList<IUpdateEntry> rootEntries,
+        IReadOnlyList<CompiledWriteOperation> operations,
+        CancellationToken cancellationToken)
+    {
+        var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
+        var effectiveTransactionOverflowBehavior =
+            transactionRuntimeOptions.TransactionOverflowBehaviorOverride
+            ?? _optionsExtension.TransactionOverflowBehavior;
+        var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
+            ?? _optionsExtension.MaxTransactionSize;
+
+        if (!ShouldUseTransaction(autoTransactionBehavior, operations.Count))
+        {
+            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (operations.Count <= effectiveMaxTransactionSize)
+        {
+            ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
+            await ExecuteTransactionalWritesAsync(operations, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (autoTransactionBehavior == AutoTransactionBehavior.Always)
+            throw CreateAlwaysOverflowException(operations.Count, effectiveMaxTransactionSize);
+
+        if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
+            throw CreateOverflowExecutionException(
+                operations.Count,
+                effectiveMaxTransactionSize,
+                autoTransactionBehavior,
+                effectiveTransactionOverflowBehavior);
+
+        // Chunking can partially commit; provider must accept successful chunk entries
+        // immediately to keep tracker aligned with persisted state.
+        if (transactionRuntimeOptions.AcceptAllChangesOnSuccess == false)
+            throw CreateChunkingAcceptAllChangesRequiredException();
+
+        var rootAggregateEntries = BuildRootAggregateEntries(entries, rootEntries);
+
+        await ExecuteChunkedTransactionalWritesAsync(
+                operations,
+                rootAggregateEntries,
+                effectiveMaxTransactionSize,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static bool ShouldUseTransaction(
+        AutoTransactionBehavior autoTransactionBehavior,
+        int operationCount)
+        => autoTransactionBehavior switch
+        {
+            AutoTransactionBehavior.Never => false,
+            AutoTransactionBehavior.WhenNeeded => operationCount > 1,
+            AutoTransactionBehavior.Always => operationCount > 1,
+            _ => throw new InvalidOperationException(
+                $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
+        };
+
+    private static void AddCompiledOperation(
+        ICollection<CompiledWriteOperation> operations,
+        IUpdateEntry entry,
+        EntityState entityState,
+        string tableName,
+        string statement,
+        List<AttributeValue> parameters)
+        => operations.Add(
+            new CompiledWriteOperation(
+                entry,
+                entityState,
+                tableName,
+                statement,
+                parameters,
+                BuildTargetItemIdentity(entry, tableName)));
+
+    private static InvalidOperationException CreateAlwaysOverflowException(
+        int operationCount,
+        int effectiveMaxTransactionSize)
+        => new(
+            "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
+            + $"write unit contains {operationCount} root operations, exceeding the "
+            + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
+            + " A single atomic transaction cannot represent this save operation.");
+
+    private static InvalidOperationException CreateOverflowExecutionException(
+        int operationCount,
+        int effectiveMaxTransactionSize,
+        AutoTransactionBehavior autoTransactionBehavior,
+        TransactionOverflowBehavior effectiveTransactionOverflowBehavior)
+        => new(
+            "SaveChanges cannot satisfy transactional execution because the write unit "
+            + $"contains {operationCount} root operations, exceeding the effective "
+            + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
+            + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
+            + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
+
+    private static InvalidOperationException CreateChunkingAcceptAllChangesRequiredException()
+        => new(
+            "Chunked transactional SaveChanges is not supported when "
+            + "acceptAllChangesOnSuccess is false. Partial chunk commits require "
+            + "per-chunk tracker acceptance to avoid replaying already-persisted "
+            + "writes on retry.");
 
     private async Task ExecuteIndependentWritesAsync(
         IReadOnlyList<CompiledWriteOperation> operations,
@@ -254,6 +363,102 @@ public class DynamoDatabaseWrapper(
         }
     }
 
+    private async Task ExecuteChunkedTransactionalWritesAsync(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>> rootAggregateEntries,
+        int maxTransactionSize,
+        CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < operations.Count; i += maxTransactionSize)
+        {
+            var chunk = operations.Skip(i).Take(maxTransactionSize).ToList();
+            ValidateTransactionalDuplicateTargets(chunk);
+            await ExecuteTransactionalWritesAsync(chunk, cancellationToken).ConfigureAwait(false);
+            AcceptChunkEntries(chunk, rootAggregateEntries);
+        }
+    }
+
+    /// <summary>
+    ///     Builds mapping from root aggregate entry to all tracked entries represented by that root
+    ///     in current SaveChanges call.
+    /// </summary>
+    private static IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>>
+        BuildRootAggregateEntries(
+            IList<IUpdateEntry> entries,
+            IReadOnlyList<IUpdateEntry> rootEntries)
+    {
+        var rootToEntries =
+            new Dictionary<InternalEntityEntry, HashSet<IUpdateEntry>>(
+                ReferenceEqualityComparer.Instance);
+
+        foreach (var rootEntry in rootEntries)
+        {
+            var internalRoot = (InternalEntityEntry)rootEntry;
+            rootToEntries[internalRoot] =
+                new HashSet<IUpdateEntry>(ReferenceEqualityComparer.Instance) { rootEntry };
+        }
+
+        foreach (var entry in entries)
+        {
+            var root = GetRootEntry((InternalEntityEntry)entry);
+            if (!rootToEntries.TryGetValue(root, out var relatedEntries))
+            {
+                relatedEntries =
+                    new HashSet<IUpdateEntry>(ReferenceEqualityComparer.Instance) { root };
+                rootToEntries[root] = relatedEntries;
+            }
+
+            relatedEntries.Add(entry);
+        }
+
+        var result =
+            new Dictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>>(
+                ReferenceEqualityComparer.Instance);
+
+        foreach (var pair in rootToEntries)
+            result[pair.Key] = pair.Value.ToList();
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Accepts tracked entries represented by successful chunk to prevent replaying committed
+    ///     writes on retry.
+    /// </summary>
+    private static void AcceptChunkEntries(
+        IReadOnlyList<CompiledWriteOperation> chunk,
+        IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>> rootAggregateEntries)
+    {
+        var entriesToAccept = new HashSet<InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+
+        foreach (var operation in chunk)
+        {
+            var rootEntry = (InternalEntityEntry)operation.Entry;
+            if (!rootAggregateEntries.TryGetValue(rootEntry, out var relatedEntries))
+            {
+                entriesToAccept.Add(rootEntry);
+                continue;
+            }
+
+            foreach (var relatedEntry in relatedEntries)
+                entriesToAccept.Add((InternalEntityEntry)relatedEntry);
+        }
+
+        foreach (var entry in entriesToAccept)
+            entry.AcceptChanges();
+    }
+
+    /// <summary>Hooks SaveChanges events to capture per-call <c>acceptAllChangesOnSuccess</c> mode.</summary>
+    private static bool HookSaveEvents(
+        DbContext context,
+        DynamoTransactionRuntimeOptions transactionRuntimeOptions)
+    {
+        context.SavingChanges += (_, e) => transactionRuntimeOptions.AcceptAllChangesOnSuccess =
+            e.AcceptAllChangesOnSuccess;
+
+        return true;
+    }
+
     private static void ValidateTransactionalWriteOperations(
         IReadOnlyList<CompiledWriteOperation> operations,
         AutoTransactionBehavior autoTransactionBehavior)
@@ -265,15 +470,23 @@ public class DynamoDatabaseWrapper(
                 + "ExecuteTransaction limit of 100 statements. "
                 + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}'.");
 
+        ValidateTransactionalDuplicateTargets(operations);
+    }
+
+    private static void ValidateTransactionalDuplicateTargets(
+        IReadOnlyList<CompiledWriteOperation> operations)
+    {
         var duplicateTarget = operations
             .GroupBy(static x => x.TargetItem)
             .FirstOrDefault(static g => g.Count() > 1);
 
-        if (duplicateTarget is not null)
-            throw new InvalidOperationException(
-                "SaveChanges cannot satisfy transactional atomicity because the unit of work "
-                + "contains multiple operations targeting the same DynamoDB item in a single "
-                + "transaction, which is not allowed by ExecuteTransaction.");
+        if (duplicateTarget is null)
+            return;
+
+        throw new InvalidOperationException(
+            "SaveChanges cannot satisfy transactional atomicity because the unit of work "
+            + "contains multiple operations targeting the same DynamoDB item in a single "
+            + "transaction, which is not allowed by ExecuteTransaction.");
     }
 
     private static TransactionTargetItem BuildTargetItemIdentity(

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -35,6 +35,11 @@ public class DynamoDatabaseWrapper(
         dbContextOptions.FindExtension<DynamoDbOptionsExtension>()
         ?? new DynamoDbOptionsExtension();
 
+    // Side-effect field: subscribes to SavingChanges exactly once during construction (primary
+    // constructor has no body, so field initializers are the only hook point) to capture the
+    // per-call acceptAllChangesOnSuccess flag in transactionRuntimeOptions before
+    // SaveChangesAsync is invoked. _ = _saveEventsHooked in SaveChangesAsync prevents the
+    // "unused private member" compiler warning without adding any runtime cost.
     private readonly bool _saveEventsHooked = HookSaveEvents(
         currentDbContext.Context,
         transactionRuntimeOptions);
@@ -349,9 +354,12 @@ public class DynamoDatabaseWrapper(
         }
         catch (TransactionCanceledException tce)
         {
+            // entityState is not used by WrapWriteException for TransactionCanceledException
+            // (it inspects CancellationReasons instead), but we pass the first operation's
+            // actual state so the parameter remains semantically correct for future callers.
             throw WrapWriteException(
                 tce,
-                EntityState.Modified,
+                operations[0].EntityState,
                 operations.Select(static x => x.Entry).ToList());
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -462,13 +470,9 @@ public class DynamoDatabaseWrapper(
         IReadOnlyList<CompiledWriteOperation> operations,
         AutoTransactionBehavior autoTransactionBehavior)
     {
-        if (operations.Count > 100)
-            throw new InvalidOperationException(
-                "SaveChanges cannot satisfy transactional atomicity because the unit of work "
-                + $"contains {operations.Count} root write operations, exceeding the DynamoDB "
-                + "ExecuteTransaction limit of 100 statements. "
-                + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}'.");
-
+        // Count is already checked against effectiveMaxTransactionSize by the caller; this
+        // validates the remaining constraint DynamoDB imposes: no two operations may target the
+        // same item within a single ExecuteTransaction call.
         ValidateTransactionalDuplicateTargets(operations);
     }
 

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -517,10 +517,15 @@ public class DynamoDatabaseWrapper(
                 + "requires a DynamoTypeMapping.");
 
         var value = mapping.CreateAttributeValue(GetOriginalOrCurrentValue(entry, keyProperty));
-        return SerializeAttributeValue(value);
+        return SerializeKeyAttributeValue(value, entry.EntityType, keyProperty);
     }
 
-    private static string SerializeAttributeValue(AttributeValue value)
+    // Used only for in-memory transaction target identity comparison (duplicate item detection).
+    // Not used for DynamoDB write parameter serialization.
+    private static string SerializeKeyAttributeValue(
+        AttributeValue value,
+        IEntityType entityType,
+        IProperty keyProperty)
     {
         if (value.S is not null)
             return "S:" + value.S;
@@ -528,37 +533,11 @@ public class DynamoDatabaseWrapper(
             return "N:" + value.N;
         if (value.B is not null)
             return "B:" + Convert.ToBase64String(value.B.ToArray());
-        if (value.BOOL is true || value.BOOL is false)
-            return "BOOL:" + value.BOOL;
-        if (value.NULL == true)
-            return "NULL";
-        if (value.SS is not null)
-            return "SS:" + string.Join(",", value.SS.Order(StringComparer.Ordinal));
-        if (value.NS is not null)
-            return "NS:" + string.Join(",", value.NS.Order(StringComparer.Ordinal));
-        if (value.BS is not null)
-            return "BS:"
-                + string.Join(
-                    ",",
-                    value
-                        .BS
-                        .Select(static b => Convert.ToBase64String(b.ToArray()))
-                        .Order(StringComparer.Ordinal));
 
-        if (value.L is not null)
-            return "L:[" + string.Join(",", value.L.Select(SerializeAttributeValue)) + "]";
-
-        if (value.M is not null)
-            return "M:{"
-                + string.Join(
-                    ",",
-                    value
-                        .M
-                        .OrderBy(static kv => kv.Key, StringComparer.Ordinal)
-                        .Select(static kv => kv.Key + "=" + SerializeAttributeValue(kv.Value)))
-                + "}";
-
-        return "EMPTY";
+        throw new InvalidOperationException(
+            $"Key property '{entityType.DisplayName()}.{keyProperty.Name}' produced "
+            + "an unsupported DynamoDB key shape for transaction target identity "
+            + "comparison. Only S, N, and B are supported.");
     }
 
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
@@ -22,4 +22,11 @@ public interface IDynamoClientWrapper
         string statement,
         List<AttributeValue> parameters,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Executes an atomic write transaction composed of PartiQL statements.</summary>
+    /// <param name="statements">Ordered transactional statements to execute atomically.</param>
+    /// <param name="cancellationToken">Token to observe for cancellation.</param>
+    Task ExecuteTransactionAsync(
+        IReadOnlyList<ParameterizedStatement> statements,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
@@ -100,7 +101,10 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Customers.AddRange(customers);
 
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*limit of 100*");
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*MaxTransactionSize of 100*");
 
         (await GetItemAsync("TENANT#TXN", "CUSTOMER#ALWAYS-LIMIT-000", CancellationToken))
             .Should()
@@ -161,6 +165,179 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Entry(second).State.Should().Be(EntityState.Added);
     }
 
+    [Fact]
+    public async Task WhenNeeded_OverflowWithUseChunking_AcceptsSuccessfulChunkEntries()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-DUP", "existing@example.com")),
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FIRST", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-SECOND", "second@example.com");
+        var duplicate = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-DUP", "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task Always_OverflowWithUseChunking_ThrowsInsteadOfChunking()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-2", "second@example.com");
+        var third = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-3", "third@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(third);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*AutoTransactionBehavior.Always*");
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartupConfiguredChunking_AcceptsSuccessfulChunkEntries()
+    {
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-DUP", "existing@example.com")),
+            CancellationToken);
+
+        await using var configuredDb = CreateConfiguredContext(
+            TransactionOverflowBehavior.UseChunking,
+            2);
+        configuredDb.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-2", "second@example.com");
+        var duplicate = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#STARTUP-CHUNK-DUP",
+            "duplicate@example.com");
+
+        configuredDb.Customers.Add(first);
+        configuredDb.Customers.Add(second);
+        configuredDb.Customers.Add(duplicate);
+
+        var act = async () => await configuredDb.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        configuredDb.Entry(first).State.Should().Be(EntityState.Unchanged);
+        configuredDb.Entry(second).State.Should().Be(EntityState.Unchanged);
+        configuredDb.Entry(duplicate).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task
+        WhenNeeded_OverflowWithUseChunking_RetryOnSameContext_ReplaysOnlyPendingEntries()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-DUP", "existing@example.com")),
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-2", "second@example.com");
+        var duplicate = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#CHUNK-RETRY-DUP",
+            "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(duplicate);
+
+        var firstSave = async () => await Db.SaveChangesAsync(CancellationToken);
+        await firstSave.Should().ThrowAsync<DbUpdateException>();
+
+        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+
+        duplicate.Sk = "CUSTOMER#CHUNK-RETRY-3";
+        duplicate.Email = "third@example.com";
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(duplicate.Pk, duplicate.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenNeeded_OverflowWithUseChunking_SaveChangesFalse_ThrowsClearError()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-2", "second@example.com");
+        var third = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-3", "third@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(third);
+
+        var act = async () => await Db.SaveChangesAsync(false, CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*acceptAllChangesOnSuccess is false*");
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().BeNull();
+        (await GetItemAsync(third.Pk, third.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public void DatabaseFacade_TransactionOverflowSettings_CanBeOverriddenPerContext()
+    {
+        Db.Database.GetTransactionOverflowBehavior().Should().Be(TransactionOverflowBehavior.Throw);
+        Db.Database.GetMaxTransactionSize().Should().Be(100);
+
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(25);
+
+        Db
+            .Database
+            .GetTransactionOverflowBehavior()
+            .Should()
+            .Be(TransactionOverflowBehavior.UseChunking);
+        Db.Database.GetMaxTransactionSize().Should().Be(25);
+    }
+
     private static CustomerItem CreateCustomer(string pk, string sk, string email)
         => new()
         {
@@ -171,6 +348,17 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
+
+    private SaveChangesTableDbContext CreateConfiguredContext(
+        TransactionOverflowBehavior behavior,
+        int maxTransactionSize)
+        => new(
+            new DbContextOptionsBuilder<SaveChangesTableDbContext>().UseDynamo(options
+                    => options
+                        .DynamoDbClient(Client)
+                        .TransactionOverflowBehavior(behavior)
+                        .MaxTransactionSize(maxTransactionSize))
+                .Options);
 
     private static Dictionary<string, AttributeValue> CreateSeedItem(CustomerItem customer)
     {

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -1,0 +1,198 @@
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>Integration tests for multi-root SaveChanges transactional execution semantics.</summary>
+public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture)
+    : SaveChangesTableTestBase(fixture)
+{
+    [Fact]
+    public async Task WhenNeeded_MultiRootSave_SucceedsAtomically()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#WHENNEEDED-OK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#WHENNEEDED-OK-2", "second@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+
+        AssertSql(
+            """
+            INSERT INTO "AppItems"
+            VALUE {'Pk': ?, 'Sk': ?, '$type': ?, 'CreatedAt': ?, 'Email': ?, 'IsPreferred': ?, 'Notes': ?, 'NullableNote': ?, 'Preferences': ?, 'ReferenceIds': ?, 'Tags': ?, 'Version': ?, 'Contacts': ?}
+            """,
+            """
+            INSERT INTO "AppItems"
+            VALUE {'Pk': ?, 'Sk': ?, '$type': ?, 'CreatedAt': ?, 'Email': ?, 'IsPreferred': ?, 'Notes': ?, 'NullableNote': ?, 'Preferences': ?, 'ReferenceIds': ?, 'Tags': ?, 'Version': ?, 'Contacts': ?}
+            """);
+    }
+
+    [Fact]
+    public async Task WhenNeeded_MultiRootFailure_RollsBackAndKeepsEntriesPending()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        await PutItemAsync(
+            new Dictionary<string, AttributeValue>
+            {
+                ["Pk"] = new() { S = "TENANT#TXN" },
+                ["Sk"] = new() { S = "CUSTOMER#WHENNEEDED-DUP" },
+                ["$type"] = new() { S = "CustomerItem" },
+                ["Email"] = new() { S = "existing@example.com" },
+                ["Version"] = new() { N = "1" },
+                ["IsPreferred"] = new() { BOOL = false },
+                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
+            },
+            CancellationToken);
+
+        var first = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#WHENNEEDED-ROLLBACK-1",
+            "first@example.com");
+        var duplicate =
+            CreateCustomer("TENANT#TXN", "CUSTOMER#WHENNEEDED-DUP", "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        Db.Entry(first).State.Should().Be(EntityState.Added);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task Never_MultiRootFailure_AllowsPartialCommit()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        await PutItemAsync(
+            new Dictionary<string, AttributeValue>
+            {
+                ["Pk"] = new() { S = "TENANT#TXN" },
+                ["Sk"] = new() { S = "CUSTOMER#NEVER-DUP" },
+                ["$type"] = new() { S = "CustomerItem" },
+                ["Email"] = new() { S = "existing@example.com" },
+                ["Version"] = new() { N = "1" },
+                ["IsPreferred"] = new() { BOOL = false },
+                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
+            },
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-PARTIAL-1", "first@example.com");
+        var duplicate = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-DUP", "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Always_MoreThan100RootWrites_ThrowsClearErrorWithoutDowngrade()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
+
+        var customers = Enumerable
+            .Range(0, 101)
+            .Select(i => CreateCustomer(
+                "TENANT#TXN",
+                $"CUSTOMER#ALWAYS-LIMIT-{i:D3}",
+                $"limit-{i}@example.com"))
+            .ToList();
+
+        Db.Customers.AddRange(customers);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*limit of 100*");
+
+        (await GetItemAsync("TENANT#TXN", "CUSTOMER#ALWAYS-LIMIT-000", CancellationToken))
+            .Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public async Task Always_MultiRootFailure_RollsBackAndKeepsEntriesPending()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
+
+        await PutItemAsync(
+            new Dictionary<string, AttributeValue>
+            {
+                ["Pk"] = new() { S = "TENANT#TXN" },
+                ["Sk"] = new() { S = "CUSTOMER#ALWAYS-DUP" },
+                ["$type"] = new() { S = "CustomerItem" },
+                ["Email"] = new() { S = "existing@example.com" },
+                ["Version"] = new() { N = "1" },
+                ["IsPreferred"] = new() { BOOL = false },
+                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
+            },
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-ROLLBACK-1", "first@example.com");
+        var duplicate =
+            CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-DUP", "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        Db.Entry(first).State.Should().Be(EntityState.Added);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task WhenNeeded_CancelledSave_DoesNotPersistAnyItemAndKeepsEntriesPending()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var first = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#WHENNEEDED-CANCEL-1",
+            "first@example.com");
+        var second = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#WHENNEEDED-CANCEL-2",
+            "second@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await Db.SaveChangesAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().BeNull();
+        Db.Entry(first).State.Should().Be(EntityState.Added);
+        Db.Entry(second).State.Should().Be(EntityState.Added);
+    }
+
+    private static CustomerItem CreateCustomer(string pk, string sk, string email)
+        => new()
+        {
+            Pk = pk,
+            Sk = sk,
+            Version = 1,
+            Email = email,
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -338,6 +338,88 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Database.GetMaxTransactionSize().Should().Be(25);
     }
 
+    [Fact]
+    public async Task Always_SingleRootSave_ExecutesDirectly_WithoutTransaction()
+    {
+        // AutoTransactionBehavior.Always still executes a single-root save directly
+        // (no ExecuteTransaction overhead) — confirmed by the single SQL statement logged.
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
+
+        var customer = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-SINGLE", "single@example.com");
+        Db.Customers.Add(customer);
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        (await GetItemAsync(customer.Pk, customer.Sk, CancellationToken)).Should().NotBeNull();
+
+        AssertSql(
+            """
+            INSERT INTO "AppItems"
+            VALUE {'Pk': ?, 'Sk': ?, '$type': ?, 'CreatedAt': ?, 'Email': ?, 'IsPreferred': ?, 'Notes': ?, 'NullableNote': ?, 'Preferences': ?, 'ReferenceIds': ?, 'Tags': ?, 'Version': ?, 'Contacts': ?}
+            """);
+    }
+
+    [Fact]
+    public async Task WhenNeeded_DuplicateTargetInSingleTransaction_ThrowsClearError()
+    {
+        // Two different entity types mapping to the same DynamoDB item key in one save —
+        // ExecuteTransaction rejects multiple operations targeting the same item.
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var customer = CreateCustomer("TENANT#TXN", "CUSTOMER#DUP-TARGET", "dup@example.com");
+
+        var product = new ProductItem
+        {
+            // Same PK+SK as customer — both map to AppItems; same DynamoDB item.
+            Pk = "TENANT#TXN",
+            Sk = "CUSTOMER#DUP-TARGET",
+            Version = 1,
+            Name = "Collision",
+            Price = 9.99m,
+            IsActive = true,
+        };
+
+        Db.Customers.Add(customer);
+        Db.Products.Add(product);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*multiple operations targeting the same DynamoDB item*");
+
+        (await GetItemAsync(customer.Pk, customer.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WhenNeeded_MixedStateTransaction_AllOperationsSucceedAtomically()
+    {
+        // Add + Modify + Delete in a single WhenNeeded save — all three states compile into
+        // one ExecuteTransaction call that commits or rolls back together.
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var toModify = CreateCustomer("TENANT#TXN", "CUSTOMER#MIXED-MODIFY", "modify@example.com");
+        var toDelete = CreateCustomer("TENANT#TXN", "CUSTOMER#MIXED-DELETE", "delete@example.com");
+
+        Db.Customers.Add(toModify);
+        Db.Customers.Add(toDelete);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        var toAdd = CreateCustomer("TENANT#TXN", "CUSTOMER#MIXED-ADD", "add@example.com");
+        Db.Customers.Add(toAdd);
+        toModify.Email = "modified@example.com";
+        Db.Customers.Remove(toDelete);
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        (await GetItemAsync(toAdd.Pk, toAdd.Sk, CancellationToken)).Should().NotBeNull();
+        var modifiedItem = await GetItemAsync(toModify.Pk, toModify.Sk, CancellationToken);
+        modifiedItem.Should().NotBeNull();
+        modifiedItem!["Email"].S.Should().Be("modified@example.com");
+        (await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken)).Should().BeNull();
+    }
+
     private static CustomerItem CreateCustomer(string pk, string sk, string email)
         => new()
         {

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -40,16 +40,8 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
 
         await PutItemAsync(
-            new Dictionary<string, AttributeValue>
-            {
-                ["Pk"] = new() { S = "TENANT#TXN" },
-                ["Sk"] = new() { S = "CUSTOMER#WHENNEEDED-DUP" },
-                ["$type"] = new() { S = "CustomerItem" },
-                ["Email"] = new() { S = "existing@example.com" },
-                ["Version"] = new() { N = "1" },
-                ["IsPreferred"] = new() { BOOL = false },
-                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
-            },
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#WHENNEEDED-DUP", "existing@example.com")),
             CancellationToken);
 
         var first = CreateCustomer(
@@ -76,16 +68,8 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
         await PutItemAsync(
-            new Dictionary<string, AttributeValue>
-            {
-                ["Pk"] = new() { S = "TENANT#TXN" },
-                ["Sk"] = new() { S = "CUSTOMER#NEVER-DUP" },
-                ["$type"] = new() { S = "CustomerItem" },
-                ["Email"] = new() { S = "existing@example.com" },
-                ["Version"] = new() { N = "1" },
-                ["IsPreferred"] = new() { BOOL = false },
-                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
-            },
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-DUP", "existing@example.com")),
             CancellationToken);
 
         var first = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-PARTIAL-1", "first@example.com");
@@ -129,16 +113,8 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
 
         await PutItemAsync(
-            new Dictionary<string, AttributeValue>
-            {
-                ["Pk"] = new() { S = "TENANT#TXN" },
-                ["Sk"] = new() { S = "CUSTOMER#ALWAYS-DUP" },
-                ["$type"] = new() { S = "CustomerItem" },
-                ["Email"] = new() { S = "existing@example.com" },
-                ["Version"] = new() { N = "1" },
-                ["IsPreferred"] = new() { BOOL = false },
-                ["CreatedAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
-            },
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-DUP", "existing@example.com")),
             CancellationToken);
 
         var first = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-ROLLBACK-1", "first@example.com");
@@ -195,4 +171,11 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
+
+    private static Dictionary<string, AttributeValue> CreateSeedItem(CustomerItem customer)
+    {
+        var item = SaveChangesCustomerItemMapper.ToItem(customer);
+        item["$type"] = new AttributeValue { S = nameof(CustomerItem) };
+        return item;
+    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -18,6 +18,8 @@ public class PaginationConfigurationTests
         extension.DynamoDbClient.Should().BeNull();
         extension.DynamoDbClientConfig.Should().BeNull();
         extension.DynamoDbClientConfigAction.Should().BeNull();
+        extension.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.Throw);
+        extension.MaxTransactionSize.Should().Be(100);
     }
 
     [Fact]
@@ -64,7 +66,9 @@ public class PaginationConfigurationTests
             .WithDynamoDbClient(client)
             .WithDynamoDbClientConfig(config)
             .WithDynamoDbClientConfigAction(callback)
-            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative);
+            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative)
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
+            .WithMaxTransactionSize(42);
 
         // Clone is protected; trigger via a With method.
         var cloned =
@@ -77,6 +81,8 @@ public class PaginationConfigurationTests
             .AutomaticIndexSelectionMode
             .Should()
             .Be(DynamoAutomaticIndexSelectionMode.SuggestOnly);
+        cloned.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
+        cloned.MaxTransactionSize.Should().Be(42);
     }
 
     [Fact]
@@ -112,6 +118,45 @@ public class PaginationConfigurationTests
     }
 
     [Fact]
+    public void UseDynamo_ConfigureTransactionOverflowBehavior_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options
+            => options.TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
+    }
+
+    [Fact]
+    public void UseDynamo_ConfigureMaxTransactionSize_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options => options.MaxTransactionSize(12));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.MaxTransactionSize.Should().Be(12);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void WithMaxTransactionSize_InvalidValue_Throws(int invalidValue)
+    {
+        var extension = new DynamoDbOptionsExtension();
+
+        Action act = () => extension.WithMaxTransactionSize(invalidValue);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
     public void ServiceProviderHash_IncludesAutomaticIndexSelectionMode()
     {
         var extension1 =
@@ -120,6 +165,23 @@ public class PaginationConfigurationTests
         var extension2 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
                 DynamoAutomaticIndexSelectionMode.Conservative);
+
+        extension1
+            .Info
+            .GetServiceProviderHashCode()
+            .Should()
+            .NotBe(extension2.Info.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void ServiceProviderHash_IncludesTransactionOverflowBehaviorAndMaxTransactionSize()
+    {
+        var extension1 = new DynamoDbOptionsExtension()
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.Throw)
+            .WithMaxTransactionSize(100);
+        var extension2 = new DynamoDbOptionsExtension()
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
+            .WithMaxTransactionSize(64);
 
         extension1
             .Info


### PR DESCRIPTION
## Summary
- add a planned multi-root SaveChanges pipeline that compiles writes first, then executes them according to `AutoTransactionBehavior`
- use DynamoDB `ExecuteTransaction` for atomic multi-root saves, with clear failures for unsupported transactional shapes and limits instead of silent downgrade
- add integration tests and docs covering `WhenNeeded`, `Always`, `Never`, rollback/cancellation behavior, and transaction constraints