### PR TITLE
feat(storage): add chunked transaction overflow handling with batch acceptance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,21 @@ During transactional execution, the provider enforces DynamoDB transaction const
 - Maximum 100 write statements.
 - No multiple operations targeting the same item in one transaction.
 
-If constraints are violated, `SaveChangesAsync` throws a clear error instead of silently downgrading to non-atomic execution.
+If constraints are violated, `SaveChangesAsync` throws a clear error unless overflow chunking is
+explicitly enabled.
+
+Overflow handling is provider-configurable:
+
+- `TransactionOverflowBehavior.Throw` (default): throw when a transactional write unit exceeds the
+    effective `MaxTransactionSize`.
+- `TransactionOverflowBehavior.UseChunking`: split the write unit into multiple
+    `ExecuteTransaction` calls of up to `MaxTransactionSize` operations each.
+
+`AutoTransactionBehavior.Always` still requires a single atomic transactional unit; if the write
+unit exceeds the effective max transaction size, SaveChanges throws.
+
+Chunking semantics are explicit: each chunk is atomic, but the full SaveChanges unit is not
+globally atomic across chunks.
 
 Per-root write compilation remains:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,10 @@ unit exceeds the effective max transaction size, SaveChanges throws.
 Chunking semantics are explicit: each chunk is atomic, but the full SaveChanges unit is not
 globally atomic across chunks.
 
+Tracker semantics during chunking are also explicit: after each successful chunk commit, entries
+represented by that chunk are accepted in the current context. If a later chunk fails, already
+committed chunk entries remain accepted while failed/unrun chunk entries remain pending.
+
 Per-root write compilation remains:
 
 1. **Added** — generates a PartiQL `INSERT INTO "Table" VALUE {...}` statement. The provider sets

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,10 @@ Configuration precedence:
 `UseChunking` keeps each chunk atomic, but the overall `SaveChanges` call is no longer globally
 atomic across all root writes.
 
+When chunking is active, use normal `SaveChanges`/`SaveChangesAsync` acceptance behavior
+(`acceptAllChangesOnSuccess: true`). Chunking with `acceptAllChangesOnSuccess: false` is rejected
+because successful chunks must be accepted immediately to avoid replaying already persisted writes.
+
 ## Client configuration precedence
 
 - The provider resolves client settings in this order:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,37 @@ The provider follows EF Core `Database.AutoTransactionBehavior` for implicit tra
 context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 ```
 
+For transactional overflow (when one transaction cannot hold the whole write unit), configure:
+
+- `TransactionOverflowBehavior`:
+    - `Throw` (default)
+    - `UseChunking` (splits into multiple `ExecuteTransaction` calls)
+- `MaxTransactionSize` (default `100`, valid range `1..100`)
+
+```csharp
+optionsBuilder.UseDynamo(options =>
+{
+    options.TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+    options.MaxTransactionSize(50);
+});
+```
+
+Per-context overrides are available on `DatabaseFacade`:
+
+```csharp
+context.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+context.Database.SetMaxTransactionSize(25);
+```
+
+Configuration precedence:
+
+1. Per-context override (`context.Database.Set...`)
+1. Startup/provider option (`UseDynamo(...)`)
+1. Provider defaults (`Throw`, `100`)
+
+`UseChunking` keeps each chunk atomic, but the overall `SaveChanges` call is no longer globally
+atomic across all root writes.
+
 ## Client configuration precedence
 
 - The provider resolves client settings in this order:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -31,6 +31,9 @@ icon: lucide/triangle-alert
 - If `TransactionOverflowBehavior.UseChunking` is configured, overflowing multi-root writes can be
     executed as multiple `ExecuteTransaction` chunks (up to `MaxTransactionSize`, max 100 per
     chunk), but overall SaveChanges atomicity is lost across chunk boundaries.
+- Chunking requires `acceptAllChangesOnSuccess: true`. `SaveChanges(false)`/
+    `SaveChangesAsync(false)` is rejected for chunking overflow paths because successful chunks must
+    be accepted immediately in the tracker.
 - `AutoTransactionBehavior.Always` still throws when one atomic transaction cannot represent the
     full write unit.
 - Unsupported LINQ shapes fail during translation with `InvalidOperationException` including provider-specific details.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -25,7 +25,14 @@ icon: lucide/triangle-alert
 - Transactional multi-root `SaveChangesAsync` is constrained by DynamoDB `ExecuteTransaction` limits:
     - maximum 100 write statements,
     - no multiple operations on the same item in a single transaction.
-- When transactional atomicity is required (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws if those constraints are violated; it does not silently downgrade to non-atomic execution.
+- By default (`TransactionOverflowBehavior.Throw`), when transactional atomicity is required
+    (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws
+    if those constraints are violated; it does not silently downgrade to non-atomic execution.
+- If `TransactionOverflowBehavior.UseChunking` is configured, overflowing multi-root writes can be
+    executed as multiple `ExecuteTransaction` chunks (up to `MaxTransactionSize`, max 100 per
+    chunk), but overall SaveChanges atomicity is lost across chunk boundaries.
+- `AutoTransactionBehavior.Always` still throws when one atomic transaction cannot represent the
+    full write unit.
 - Unsupported LINQ shapes fail during translation with `InvalidOperationException` including provider-specific details.
 - Discriminator guardrails for unsupported query shapes are deferred; support is limited to the
     current operator surface in `operators.md`.

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
@@ -1,0 +1,71 @@
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Extension methods for provider-specific transaction overflow behavior on
+/// <see cref="DatabaseFacade" />.
+/// </summary>
+public static class DynamoDatabaseFacadeExtensions
+{
+    /// <summary>
+    /// Sets a per-context override for transaction overflow behavior.
+    /// </summary>
+    public static void SetTransactionOverflowBehavior(
+        this DatabaseFacade databaseFacade,
+        TransactionOverflowBehavior behavior)
+        => GetRuntimeOptions(databaseFacade).TransactionOverflowBehaviorOverride = behavior;
+
+    /// <summary>
+    /// Gets the effective transaction overflow behavior for this context.
+    /// </summary>
+    public static TransactionOverflowBehavior GetTransactionOverflowBehavior(
+        this DatabaseFacade databaseFacade)
+    {
+        var runtimeOptions = GetRuntimeOptions(databaseFacade);
+
+        return runtimeOptions.TransactionOverflowBehaviorOverride
+            ?? GetDynamoOptionsExtension(databaseFacade).TransactionOverflowBehavior;
+    }
+
+    /// <summary>
+    /// Sets a per-context override for max transaction size.
+    /// </summary>
+    public static void SetMaxTransactionSize(
+        this DatabaseFacade databaseFacade,
+        int maxTransactionSize)
+    {
+        if (maxTransactionSize is <= 0 or > 100)
+            throw new InvalidOperationException(
+                $"The specified 'MaxTransactionSize' value '{maxTransactionSize}' is not valid. "
+                + "It must be between 1 and 100.");
+
+        GetRuntimeOptions(databaseFacade).MaxTransactionSizeOverride = maxTransactionSize;
+    }
+
+    /// <summary>
+    /// Gets the effective max transaction size for this context.
+    /// </summary>
+    public static int GetMaxTransactionSize(this DatabaseFacade databaseFacade)
+    {
+        var runtimeOptions = GetRuntimeOptions(databaseFacade);
+
+        return runtimeOptions.MaxTransactionSizeOverride
+            ?? GetDynamoOptionsExtension(databaseFacade).MaxTransactionSize;
+    }
+
+    private static DynamoTransactionRuntimeOptions GetRuntimeOptions(DatabaseFacade databaseFacade)
+        => ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context
+            .GetService<DynamoTransactionRuntimeOptions>();
+
+    private static DynamoDbOptionsExtension GetDynamoOptionsExtension(DatabaseFacade databaseFacade)
+        => ((IDatabaseFacadeDependenciesAccessor)databaseFacade)
+            .Context
+            .GetService<IDbContextOptions>()
+            .FindExtension<DynamoDbOptionsExtension>()
+            ?? throw new InvalidOperationException(
+                "DynamoDB provider services are not available for this DbContext.");
+}

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
@@ -38,6 +38,8 @@ public static class DynamoServiceCollectionExtensions
                     DynamoShapedQueryCompilingExpressionVisitorFactory>()
                 .TryAdd<IQueryCompilationContextFactory, DynamoQueryCompilationContextFactory>()
                 .TryAddProviderSpecificServices(services => services
+                    .TryAddScoped<
+                        DynamoTransactionRuntimeOptions>(_ => new DynamoTransactionRuntimeOptions())
                     .TryAddScoped<IDynamoClientWrapper, DynamoClientWrapper>()
                     .TryAddSingleton<DynamoEntityItemSerializerSource>(_
                         => new DynamoEntityItemSerializerSource())

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
@@ -45,6 +45,22 @@ public class DynamoDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilde
         DynamoAutomaticIndexSelectionMode mode)
         => WithOption(e => e.WithAutomaticIndexSelectionMode(mode));
 
+    /// <summary>
+    /// Configures how transactional SaveChanges should behave when the write unit exceeds max
+    /// transaction size.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder TransactionOverflowBehavior(
+        TransactionOverflowBehavior behavior)
+        => WithOption(e => e.WithTransactionOverflowBehavior(behavior));
+
+    /// <summary>
+    /// Configures the maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder MaxTransactionSize(int maxTransactionSize)
+        => WithOption(e => e.WithMaxTransactionSize(maxTransactionSize));
+
     /// <summary>Updates the provider options extension with the supplied mutation action.</summary>
     protected virtual DynamoDbContextOptionsBuilder WithOption(
         Func<DynamoDbOptionsExtension, DynamoDbOptionsExtension> setAction)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,8 @@ namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 /// <summary>Represents the DynamoDbOptionsExtension type.</summary>
 public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 {
+    private const int DynamoTransactionLimit = 100;
+
     /// <summary>Provides functionality for this member.</summary>
     public IAmazonDynamoDB? DynamoDbClient { get; private set; }
 
@@ -19,6 +22,16 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 
     /// <summary>Controls whether the provider should automatically select compatible secondary indexes.</summary>
     public DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode { get; private set; }
+
+    /// <summary>
+    /// Controls how SaveChanges behaves when a transactional write unit exceeds max transaction size.
+    /// </summary>
+    public TransactionOverflowBehavior TransactionOverflowBehavior { get; private set; }
+
+    /// <summary>
+    /// Maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    public int MaxTransactionSize { get; private set; } = DynamoTransactionLimit;
 
     /// <summary>Registers provider services in the EF Core internal service container.</summary>
     public virtual void ApplyServices(IServiceCollection services)
@@ -80,6 +93,37 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
+    /// <summary>
+    /// Sets how transactional SaveChanges should behave when one transaction cannot represent
+    /// the full write unit.
+    /// </summary>
+    public virtual DynamoDbOptionsExtension WithTransactionOverflowBehavior(
+        TransactionOverflowBehavior behavior)
+    {
+        var clone = Clone();
+
+        clone.TransactionOverflowBehavior = behavior;
+
+        return clone;
+    }
+
+    /// <summary>
+    /// Sets the maximum number of write operations sent in a single DynamoDB transaction.
+    /// </summary>
+    public virtual DynamoDbOptionsExtension WithMaxTransactionSize(int maxTransactionSize)
+    {
+        if (maxTransactionSize is <= 0 or > DynamoTransactionLimit)
+            throw new InvalidOperationException(
+                $"The specified 'MaxTransactionSize' value '{maxTransactionSize}' is not valid. "
+                + $"It must be between 1 and {DynamoTransactionLimit}.");
+
+        var clone = Clone();
+
+        clone.MaxTransactionSize = maxTransactionSize;
+
+        return clone;
+    }
+
     /// <summary>Creates a copy of this extension with the current option values.</summary>
     protected virtual DynamoDbOptionsExtension Clone()
         => new()
@@ -88,6 +132,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             DynamoDbClientConfig = DynamoDbClientConfig,
             DynamoDbClientConfigAction = DynamoDbClientConfigAction,
             AutomaticIndexSelectionMode = AutomaticIndexSelectionMode,
+            TransactionOverflowBehavior = TransactionOverflowBehavior,
+            MaxTransactionSize = MaxTransactionSize,
         };
 
     /// <summary>Represents the DynamoOptionsExtensionInfo type.</summary>
@@ -109,6 +155,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 hashCode.Add(Extension.DynamoDbClientConfig);
                 hashCode.Add(Extension.DynamoDbClientConfigAction);
                 hashCode.Add(Extension.AutomaticIndexSelectionMode);
+                hashCode.Add(Extension.TransactionOverflowBehavior);
+                hashCode.Add(Extension.MaxTransactionSize);
 
                 _serviceProviderHash = hashCode.ToHashCode();
             }
@@ -127,7 +175,10 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                     Extension.DynamoDbClientConfigAction,
                     otherInfo.Extension.DynamoDbClientConfigAction)
                 && Extension.AutomaticIndexSelectionMode
-                == otherInfo.Extension.AutomaticIndexSelectionMode;
+                == otherInfo.Extension.AutomaticIndexSelectionMode
+                && Extension.TransactionOverflowBehavior
+                == otherInfo.Extension.TransactionOverflowBehavior
+                && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize;
 
         /// <summary>Provides functionality for this member.</summary>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }
@@ -141,6 +192,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             get
             {
                 field ??= $"AutomaticIndexSelectionMode={Extension.AutomaticIndexSelectionMode},"
+                    + $"TransactionOverflowBehavior={Extension.TransactionOverflowBehavior},"
+                    + $"MaxTransactionSize={Extension.MaxTransactionSize},"
                     + $"DynamoDbClient={Extension.DynamoDbClient is not null},"
                     + $"DynamoDbClientConfig={Extension.DynamoDbClientConfig is not null},"
                     + $"DynamoDbClientConfigAction={Extension.DynamoDbClientConfigAction is not null}";

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
@@ -1,5 +1,3 @@
-using EntityFrameworkCore.DynamoDb.Infrastructure;
-
 namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 
 /// <summary>Scoped runtime overrides for transaction overflow execution behavior.</summary>
@@ -14,4 +12,7 @@ public sealed class DynamoTransactionRuntimeOptions
     /// Optional per-context override for max transaction size.
     /// </summary>
     public int? MaxTransactionSizeOverride { get; set; }
+
+    /// <summary>Captures <c>acceptAllChangesOnSuccess</c> for current SaveChanges call.</summary>
+    public bool? AcceptAllChangesOnSuccess { get; set; }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
@@ -1,0 +1,17 @@
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+
+namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
+
+/// <summary>Scoped runtime overrides for transaction overflow execution behavior.</summary>
+public sealed class DynamoTransactionRuntimeOptions
+{
+    /// <summary>
+    /// Optional per-context override for transaction overflow behavior.
+    /// </summary>
+    public TransactionOverflowBehavior? TransactionOverflowBehaviorOverride { get; set; }
+
+    /// <summary>
+    /// Optional per-context override for max transaction size.
+    /// </summary>
+    public int? MaxTransactionSizeOverride { get; set; }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/TransactionOverflowBehavior.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/TransactionOverflowBehavior.cs
@@ -1,0 +1,18 @@
+namespace EntityFrameworkCore.DynamoDb.Infrastructure;
+
+/// <summary>
+/// Controls how SaveChanges handles transactional overflow when one DynamoDB transaction
+/// cannot represent the full write unit.
+/// </summary>
+public enum TransactionOverflowBehavior
+{
+    /// <summary>
+    /// Throws when a transactional SaveChanges unit exceeds the configured max transaction size.
+    /// </summary>
+    Throw,
+
+    /// <summary>
+    /// Splits overflowing transactional SaveChanges units into multiple ExecuteTransaction calls.
+    /// </summary>
+    UseChunking,
+}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -35,6 +35,10 @@ public class DynamoDatabaseWrapper(
         dbContextOptions.FindExtension<DynamoDbOptionsExtension>()
         ?? new DynamoDbOptionsExtension();
 
+    private readonly bool _saveEventsHooked = HookSaveEvents(
+        currentDbContext.Context,
+        transactionRuntimeOptions);
+
     /// <summary>Not supported — DynamoDB only exposes an async API.</summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
     public override int SaveChanges(IList<IUpdateEntry> entries)
@@ -58,82 +62,104 @@ public class DynamoDatabaseWrapper(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
     {
-        // Guard: only Added/Modified/Deleted are implemented; fail explicitly for others.
-        var unsupported = entries.FirstOrDefault(static e
-            => e.EntityState is not EntityState.Added
-                and not EntityState.Modified
-                and not EntityState.Deleted
-            && !e.EntityType.IsOwned());
+        _ = _saveEventsHooked;
 
-        if (unsupported is not null)
-            throw new NotSupportedException(
-                $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
-                + "Only Added, Modified, and Deleted entities can be persisted in this version.");
-
-        var rootEntries = BuildRootEntries(entries);
-
-        // Pre-compute once per save call: for each principal entry, which of its owned
-        // navigations have at least one Add/Modify/Delete mutation in this batch?
-        // Turns HasMutationForOwnedNavigation from O(entries × navs × depth) → O(1) per check.
-        var mutatingNavs = BuildMutatingNavLookup(entries);
-
-        var operations = BuildWriteOperations(rootEntries, mutatingNavs);
-        if (operations.Count == 0)
-            return 0;
-
-        var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
-        var effectiveTransactionOverflowBehavior =
-            transactionRuntimeOptions.TransactionOverflowBehaviorOverride
-            ?? _optionsExtension.TransactionOverflowBehavior;
-        var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
-            ?? _optionsExtension.MaxTransactionSize;
-
-        var shouldUseTransaction = autoTransactionBehavior switch
+        try
         {
-            AutoTransactionBehavior.Never => false,
-            AutoTransactionBehavior.WhenNeeded => operations.Count > 1,
-            AutoTransactionBehavior.Always => operations.Count > 1,
-            _ => throw new InvalidOperationException(
-                $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
-        };
+            // Guard: only Added/Modified/Deleted are implemented; fail explicitly for others.
+            var unsupported = entries.FirstOrDefault(static e
+                => e.EntityState is not EntityState.Added
+                    and not EntityState.Modified
+                    and not EntityState.Deleted
+                && !e.EntityType.IsOwned());
 
-        if (!shouldUseTransaction)
-        {
-            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+            if (unsupported is not null)
+                throw new NotSupportedException(
+                    $"SaveChanges for EntityState.{unsupported.EntityState} is not yet supported. "
+                    + "Only Added, Modified, and Deleted entities can be persisted in this version.");
+
+            var rootEntries = BuildRootEntries(entries);
+
+            // Pre-compute once per save call: for each principal entry, which of its owned
+            // navigations have at least one Add/Modify/Delete mutation in this batch?
+            // Turns HasMutationForOwnedNavigation from O(entries × navs × depth) → O(1) per check.
+            var mutatingNavs = BuildMutatingNavLookup(entries);
+
+            var operations = BuildWriteOperations(rootEntries, mutatingNavs);
+            if (operations.Count == 0)
+                return 0;
+
+            var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
+            var effectiveTransactionOverflowBehavior =
+                transactionRuntimeOptions.TransactionOverflowBehaviorOverride
+                ?? _optionsExtension.TransactionOverflowBehavior;
+            var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
+                ?? _optionsExtension.MaxTransactionSize;
+
+            var shouldUseTransaction = autoTransactionBehavior switch
+            {
+                AutoTransactionBehavior.Never => false,
+                AutoTransactionBehavior.WhenNeeded => operations.Count > 1,
+                AutoTransactionBehavior.Always => operations.Count > 1,
+                _ => throw new InvalidOperationException(
+                    $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
+            };
+
+            if (!shouldUseTransaction)
+            {
+                await ExecuteIndependentWritesAsync(operations, cancellationToken)
+                    .ConfigureAwait(false);
+                return operations.Count;
+            }
+
+            if (operations.Count > effectiveMaxTransactionSize)
+            {
+                if (autoTransactionBehavior == AutoTransactionBehavior.Always)
+                    throw new InvalidOperationException(
+                        "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
+                        + $"write unit contains {operations.Count} root operations, exceeding the "
+                        + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
+                        + " A single atomic transaction cannot represent this save operation.");
+
+                if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
+                    throw new InvalidOperationException(
+                        "SaveChanges cannot satisfy transactional execution because the write unit "
+                        + $"contains {operations.Count} root operations, exceeding the effective "
+                        + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
+                        + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
+                        + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
+
+                // Chunking can partially commit; provider must accept successful chunk entries
+                // immediately to keep tracker aligned with persisted state.
+                if (transactionRuntimeOptions.AcceptAllChangesOnSuccess == false)
+                    throw new InvalidOperationException(
+                        "Chunked transactional SaveChanges is not supported when "
+                        + "acceptAllChangesOnSuccess is false. Partial chunk commits require "
+                        + "per-chunk tracker acceptance to avoid replaying already-persisted "
+                        + "writes on retry.");
+
+                var rootAggregateEntries = BuildRootAggregateEntries(entries, rootEntries);
+
+                await ExecuteChunkedTransactionalWritesAsync(
+                        operations,
+                        rootAggregateEntries,
+                        effectiveMaxTransactionSize,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                return operations.Count;
+            }
+
+            ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
+            await ExecuteTransactionalWritesAsync(operations, cancellationToken)
                 .ConfigureAwait(false);
+
             return operations.Count;
         }
-
-        if (operations.Count > effectiveMaxTransactionSize)
+        finally
         {
-            if (autoTransactionBehavior == AutoTransactionBehavior.Always)
-                throw new InvalidOperationException(
-                    "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
-                    + $"write unit contains {operations.Count} root operations, exceeding the "
-                    + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
-                    + " A single atomic transaction cannot represent this save operation.");
-
-            if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
-                throw new InvalidOperationException(
-                    "SaveChanges cannot satisfy transactional execution because the write unit "
-                    + $"contains {operations.Count} root operations, exceeding the effective "
-                    + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
-                    + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
-                    + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
-
-            await ExecuteChunkedTransactionalWritesAsync(
-                    operations,
-                    effectiveMaxTransactionSize,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            return operations.Count;
+            transactionRuntimeOptions.AcceptAllChangesOnSuccess = null;
         }
-
-        ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
-        await ExecuteTransactionalWritesAsync(operations, cancellationToken).ConfigureAwait(false);
-
-        return operations.Count;
     }
 
     private sealed record CompiledWriteOperation(
@@ -296,6 +322,7 @@ public class DynamoDatabaseWrapper(
 
     private async Task ExecuteChunkedTransactionalWritesAsync(
         IReadOnlyList<CompiledWriteOperation> operations,
+        IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>> rootAggregateEntries,
         int maxTransactionSize,
         CancellationToken cancellationToken)
     {
@@ -304,7 +331,89 @@ public class DynamoDatabaseWrapper(
             var chunk = operations.Skip(i).Take(maxTransactionSize).ToList();
             ValidateTransactionalDuplicateTargets(chunk);
             await ExecuteTransactionalWritesAsync(chunk, cancellationToken).ConfigureAwait(false);
+            AcceptChunkEntries(chunk, rootAggregateEntries);
         }
+    }
+
+    /// <summary>
+    ///     Builds mapping from root aggregate entry to all tracked entries represented by that root
+    ///     in current SaveChanges call.
+    /// </summary>
+    private static IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>>
+        BuildRootAggregateEntries(
+            IList<IUpdateEntry> entries,
+            IReadOnlyList<IUpdateEntry> rootEntries)
+    {
+        var rootToEntries =
+            new Dictionary<InternalEntityEntry, HashSet<IUpdateEntry>>(
+                ReferenceEqualityComparer.Instance);
+
+        foreach (var rootEntry in rootEntries)
+        {
+            var internalRoot = (InternalEntityEntry)rootEntry;
+            rootToEntries[internalRoot] =
+                new HashSet<IUpdateEntry>(ReferenceEqualityComparer.Instance) { rootEntry };
+        }
+
+        foreach (var entry in entries)
+        {
+            var root = GetRootEntry((InternalEntityEntry)entry);
+            if (!rootToEntries.TryGetValue(root, out var relatedEntries))
+            {
+                relatedEntries =
+                    new HashSet<IUpdateEntry>(ReferenceEqualityComparer.Instance) { root };
+                rootToEntries[root] = relatedEntries;
+            }
+
+            relatedEntries.Add(entry);
+        }
+
+        var result =
+            new Dictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>>(
+                ReferenceEqualityComparer.Instance);
+
+        foreach (var pair in rootToEntries)
+            result[pair.Key] = pair.Value.ToList();
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Accepts tracked entries represented by successful chunk to prevent replaying committed
+    ///     writes on retry.
+    /// </summary>
+    private static void AcceptChunkEntries(
+        IReadOnlyList<CompiledWriteOperation> chunk,
+        IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>> rootAggregateEntries)
+    {
+        var entriesToAccept = new HashSet<InternalEntityEntry>(ReferenceEqualityComparer.Instance);
+
+        foreach (var operation in chunk)
+        {
+            var rootEntry = (InternalEntityEntry)operation.Entry;
+            if (!rootAggregateEntries.TryGetValue(rootEntry, out var relatedEntries))
+            {
+                entriesToAccept.Add(rootEntry);
+                continue;
+            }
+
+            foreach (var relatedEntry in relatedEntries)
+                entriesToAccept.Add((InternalEntityEntry)relatedEntry);
+        }
+
+        foreach (var entry in entriesToAccept)
+            entry.AcceptChanges();
+    }
+
+    /// <summary>Hooks SaveChanges events to capture per-call <c>acceptAllChangesOnSuccess</c> mode.</summary>
+    private static bool HookSaveEvents(
+        DbContext context,
+        DynamoTransactionRuntimeOptions transactionRuntimeOptions)
+    {
+        context.SavingChanges += (_, e) => transactionRuntimeOptions.AcceptAllChangesOnSuccess =
+            e.AcceptAllChangesOnSuccess;
+
+        return true;
     }
 
     private static void ValidateTransactionalWriteOperations(

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -89,69 +89,7 @@ public class DynamoDatabaseWrapper(
             if (operations.Count == 0)
                 return 0;
 
-            var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
-            var effectiveTransactionOverflowBehavior =
-                transactionRuntimeOptions.TransactionOverflowBehaviorOverride
-                ?? _optionsExtension.TransactionOverflowBehavior;
-            var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
-                ?? _optionsExtension.MaxTransactionSize;
-
-            var shouldUseTransaction = autoTransactionBehavior switch
-            {
-                AutoTransactionBehavior.Never => false,
-                AutoTransactionBehavior.WhenNeeded => operations.Count > 1,
-                AutoTransactionBehavior.Always => operations.Count > 1,
-                _ => throw new InvalidOperationException(
-                    $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
-            };
-
-            if (!shouldUseTransaction)
-            {
-                await ExecuteIndependentWritesAsync(operations, cancellationToken)
-                    .ConfigureAwait(false);
-                return operations.Count;
-            }
-
-            if (operations.Count > effectiveMaxTransactionSize)
-            {
-                if (autoTransactionBehavior == AutoTransactionBehavior.Always)
-                    throw new InvalidOperationException(
-                        "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
-                        + $"write unit contains {operations.Count} root operations, exceeding the "
-                        + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
-                        + " A single atomic transaction cannot represent this save operation.");
-
-                if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
-                    throw new InvalidOperationException(
-                        "SaveChanges cannot satisfy transactional execution because the write unit "
-                        + $"contains {operations.Count} root operations, exceeding the effective "
-                        + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
-                        + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
-                        + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
-
-                // Chunking can partially commit; provider must accept successful chunk entries
-                // immediately to keep tracker aligned with persisted state.
-                if (transactionRuntimeOptions.AcceptAllChangesOnSuccess == false)
-                    throw new InvalidOperationException(
-                        "Chunked transactional SaveChanges is not supported when "
-                        + "acceptAllChangesOnSuccess is false. Partial chunk commits require "
-                        + "per-chunk tracker acceptance to avoid replaying already-persisted "
-                        + "writes on retry.");
-
-                var rootAggregateEntries = BuildRootAggregateEntries(entries, rootEntries);
-
-                await ExecuteChunkedTransactionalWritesAsync(
-                        operations,
-                        rootAggregateEntries,
-                        effectiveMaxTransactionSize,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                return operations.Count;
-            }
-
-            ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
-            await ExecuteTransactionalWritesAsync(operations, cancellationToken)
+            await ExecutePlannedWritesAsync(entries, rootEntries, operations, cancellationToken)
                 .ConfigureAwait(false);
 
             return operations.Count;
@@ -191,14 +129,13 @@ public class DynamoDatabaseWrapper(
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
                     var (sql, parameters) = BuildInsertStatement(tableName, item);
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Added,
-                            tableName,
-                            sql,
-                            parameters,
-                            BuildTargetItemIdentity(entry, tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Added,
+                        tableName,
+                        sql,
+                        parameters);
                     break;
                 }
 
@@ -208,14 +145,13 @@ public class DynamoDatabaseWrapper(
                     if (update is null)
                         continue;
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Modified,
-                            update.Value.tableName,
-                            update.Value.sql,
-                            update.Value.parameters,
-                            BuildTargetItemIdentity(entry, update.Value.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Modified,
+                        update.Value.tableName,
+                        update.Value.sql,
+                        update.Value.parameters);
                     break;
                 }
 
@@ -225,28 +161,26 @@ public class DynamoDatabaseWrapper(
                     if (update is null)
                         continue;
 
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Modified,
-                            update.Value.tableName,
-                            update.Value.sql,
-                            update.Value.parameters,
-                            BuildTargetItemIdentity(entry, update.Value.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Modified,
+                        update.Value.tableName,
+                        update.Value.sql,
+                        update.Value.parameters);
                     break;
                 }
 
                 case EntityState.Deleted:
                 {
                     var delete = BuildDeleteStatement(entry);
-                    operations.Add(
-                        new CompiledWriteOperation(
-                            entry,
-                            EntityState.Deleted,
-                            delete.tableName,
-                            delete.sql,
-                            delete.parameters,
-                            BuildTargetItemIdentity(entry, delete.tableName)));
+                    AddCompiledOperation(
+                        operations,
+                        entry,
+                        EntityState.Deleted,
+                        delete.tableName,
+                        delete.sql,
+                        delete.parameters);
                     break;
                 }
 
@@ -259,6 +193,115 @@ public class DynamoDatabaseWrapper(
 
         return operations;
     }
+
+    private async Task ExecutePlannedWritesAsync(
+        IList<IUpdateEntry> entries,
+        IReadOnlyList<IUpdateEntry> rootEntries,
+        IReadOnlyList<CompiledWriteOperation> operations,
+        CancellationToken cancellationToken)
+    {
+        var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
+        var effectiveTransactionOverflowBehavior =
+            transactionRuntimeOptions.TransactionOverflowBehaviorOverride
+            ?? _optionsExtension.TransactionOverflowBehavior;
+        var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
+            ?? _optionsExtension.MaxTransactionSize;
+
+        if (!ShouldUseTransaction(autoTransactionBehavior, operations.Count))
+        {
+            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (operations.Count <= effectiveMaxTransactionSize)
+        {
+            ValidateTransactionalWriteOperations(operations, autoTransactionBehavior);
+            await ExecuteTransactionalWritesAsync(operations, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (autoTransactionBehavior == AutoTransactionBehavior.Always)
+            throw CreateAlwaysOverflowException(operations.Count, effectiveMaxTransactionSize);
+
+        if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
+            throw CreateOverflowExecutionException(
+                operations.Count,
+                effectiveMaxTransactionSize,
+                autoTransactionBehavior,
+                effectiveTransactionOverflowBehavior);
+
+        // Chunking can partially commit; provider must accept successful chunk entries
+        // immediately to keep tracker aligned with persisted state.
+        if (transactionRuntimeOptions.AcceptAllChangesOnSuccess == false)
+            throw CreateChunkingAcceptAllChangesRequiredException();
+
+        var rootAggregateEntries = BuildRootAggregateEntries(entries, rootEntries);
+
+        await ExecuteChunkedTransactionalWritesAsync(
+                operations,
+                rootAggregateEntries,
+                effectiveMaxTransactionSize,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static bool ShouldUseTransaction(
+        AutoTransactionBehavior autoTransactionBehavior,
+        int operationCount)
+        => autoTransactionBehavior switch
+        {
+            AutoTransactionBehavior.Never => false,
+            AutoTransactionBehavior.WhenNeeded => operationCount > 1,
+            AutoTransactionBehavior.Always => operationCount > 1,
+            _ => throw new InvalidOperationException(
+                $"Invalid AutoTransactionBehavior: {autoTransactionBehavior}"),
+        };
+
+    private static void AddCompiledOperation(
+        ICollection<CompiledWriteOperation> operations,
+        IUpdateEntry entry,
+        EntityState entityState,
+        string tableName,
+        string statement,
+        List<AttributeValue> parameters)
+        => operations.Add(
+            new CompiledWriteOperation(
+                entry,
+                entityState,
+                tableName,
+                statement,
+                parameters,
+                BuildTargetItemIdentity(entry, tableName)));
+
+    private static InvalidOperationException CreateAlwaysOverflowException(
+        int operationCount,
+        int effectiveMaxTransactionSize)
+        => new(
+            "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
+            + $"write unit contains {operationCount} root operations, exceeding the "
+            + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
+            + " A single atomic transaction cannot represent this save operation.");
+
+    private static InvalidOperationException CreateOverflowExecutionException(
+        int operationCount,
+        int effectiveMaxTransactionSize,
+        AutoTransactionBehavior autoTransactionBehavior,
+        TransactionOverflowBehavior effectiveTransactionOverflowBehavior)
+        => new(
+            "SaveChanges cannot satisfy transactional execution because the write unit "
+            + $"contains {operationCount} root operations, exceeding the effective "
+            + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
+            + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
+            + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
+
+    private static InvalidOperationException CreateChunkingAcceptAllChangesRequiredException()
+        => new(
+            "Chunked transactional SaveChanges is not supported when "
+            + "acceptAllChangesOnSuccess is false. Partial chunk commits require "
+            + "per-chunk tracker acceptance to avoid replaying already-persisted "
+            + "writes on retry.");
 
     private async Task ExecuteIndependentWritesAsync(
         IReadOnlyList<CompiledWriteOperation> operations,

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -3,6 +3,8 @@ using System.Text;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -22,11 +24,17 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 /// </summary>
 public class DynamoDatabaseWrapper(
     DatabaseDependencies dependencies,
+    IDbContextOptions dbContextOptions,
     ICurrentDbContext currentDbContext,
+    DynamoTransactionRuntimeOptions transactionRuntimeOptions,
     IDynamoClientWrapper clientWrapper,
     IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
     DynamoEntityItemSerializerSource serializerSource) : Database(dependencies)
 {
+    private readonly DynamoDbOptionsExtension _optionsExtension =
+        dbContextOptions.FindExtension<DynamoDbOptionsExtension>()
+        ?? new DynamoDbOptionsExtension();
+
     /// <summary>Not supported — DynamoDB only exposes an async API.</summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
     public override int SaveChanges(IList<IUpdateEntry> entries)
@@ -74,6 +82,12 @@ public class DynamoDatabaseWrapper(
             return 0;
 
         var autoTransactionBehavior = currentDbContext.Context.Database.AutoTransactionBehavior;
+        var effectiveTransactionOverflowBehavior =
+            transactionRuntimeOptions.TransactionOverflowBehaviorOverride
+            ?? _optionsExtension.TransactionOverflowBehavior;
+        var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
+            ?? _optionsExtension.MaxTransactionSize;
+
         var shouldUseTransaction = autoTransactionBehavior switch
         {
             AutoTransactionBehavior.Never => false,
@@ -87,6 +101,32 @@ public class DynamoDatabaseWrapper(
         {
             await ExecuteIndependentWritesAsync(operations, cancellationToken)
                 .ConfigureAwait(false);
+            return operations.Count;
+        }
+
+        if (operations.Count > effectiveMaxTransactionSize)
+        {
+            if (autoTransactionBehavior == AutoTransactionBehavior.Always)
+                throw new InvalidOperationException(
+                    "SaveChanges cannot satisfy AutoTransactionBehavior.Always because the "
+                    + $"write unit contains {operations.Count} root operations, exceeding the "
+                    + $"effective MaxTransactionSize of {effectiveMaxTransactionSize}."
+                    + " A single atomic transaction cannot represent this save operation.");
+
+            if (effectiveTransactionOverflowBehavior == TransactionOverflowBehavior.Throw)
+                throw new InvalidOperationException(
+                    "SaveChanges cannot satisfy transactional execution because the write unit "
+                    + $"contains {operations.Count} root operations, exceeding the effective "
+                    + $"MaxTransactionSize of {effectiveMaxTransactionSize}. "
+                    + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}' and "
+                    + $"TransactionOverflowBehavior is '{effectiveTransactionOverflowBehavior}'.");
+
+            await ExecuteChunkedTransactionalWritesAsync(
+                    operations,
+                    effectiveMaxTransactionSize,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
             return operations.Count;
         }
 
@@ -254,6 +294,19 @@ public class DynamoDatabaseWrapper(
         }
     }
 
+    private async Task ExecuteChunkedTransactionalWritesAsync(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        int maxTransactionSize,
+        CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < operations.Count; i += maxTransactionSize)
+        {
+            var chunk = operations.Skip(i).Take(maxTransactionSize).ToList();
+            ValidateTransactionalDuplicateTargets(chunk);
+            await ExecuteTransactionalWritesAsync(chunk, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     private static void ValidateTransactionalWriteOperations(
         IReadOnlyList<CompiledWriteOperation> operations,
         AutoTransactionBehavior autoTransactionBehavior)
@@ -265,15 +318,23 @@ public class DynamoDatabaseWrapper(
                 + "ExecuteTransaction limit of 100 statements. "
                 + $"Current AutoTransactionBehavior is '{autoTransactionBehavior}'.");
 
+        ValidateTransactionalDuplicateTargets(operations);
+    }
+
+    private static void ValidateTransactionalDuplicateTargets(
+        IReadOnlyList<CompiledWriteOperation> operations)
+    {
         var duplicateTarget = operations
             .GroupBy(static x => x.TargetItem)
             .FirstOrDefault(static g => g.Count() > 1);
 
-        if (duplicateTarget is not null)
-            throw new InvalidOperationException(
-                "SaveChanges cannot satisfy transactional atomicity because the unit of work "
-                + "contains multiple operations targeting the same DynamoDB item in a single "
-                + "transaction, which is not allowed by ExecuteTransaction.");
+        if (duplicateTarget is null)
+            return;
+
+        throw new InvalidOperationException(
+            "SaveChanges cannot satisfy transactional atomicity because the unit of work "
+            + "contains multiple operations targeting the same DynamoDB item in a single "
+            + "transaction, which is not allowed by ExecuteTransaction.");
     }
 
     private static TransactionTargetItem BuildTargetItemIdentity(

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -166,7 +166,7 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
     }
 
     [Fact]
-    public async Task WhenNeeded_OverflowWithUseChunking_AllowsPartialCommitAcrossChunks()
+    public async Task WhenNeeded_OverflowWithUseChunking_AcceptsSuccessfulChunkEntries()
     {
         Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
         Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
@@ -190,6 +190,9 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
 
         (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
         (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
     }
 
     [Fact]
@@ -217,7 +220,7 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
     }
 
     [Fact]
-    public async Task StartupConfiguredChunking_AppliesWithoutPerContextOverride()
+    public async Task StartupConfiguredChunking_AcceptsSuccessfulChunkEntries()
     {
         await PutItemAsync(
             CreateSeedItem(
@@ -245,6 +248,77 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
 
         (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
         (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        configuredDb.Entry(first).State.Should().Be(EntityState.Unchanged);
+        configuredDb.Entry(second).State.Should().Be(EntityState.Unchanged);
+        configuredDb.Entry(duplicate).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task
+        WhenNeeded_OverflowWithUseChunking_RetryOnSameContext_ReplaysOnlyPendingEntries()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-DUP", "existing@example.com")),
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-RETRY-2", "second@example.com");
+        var duplicate = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#CHUNK-RETRY-DUP",
+            "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(duplicate);
+
+        var firstSave = async () => await Db.SaveChangesAsync(CancellationToken);
+        await firstSave.Should().ThrowAsync<DbUpdateException>();
+
+        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+
+        duplicate.Sk = "CUSTOMER#CHUNK-RETRY-3";
+        duplicate.Email = "third@example.com";
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(duplicate.Pk, duplicate.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenNeeded_OverflowWithUseChunking_SaveChangesFalse_ThrowsClearError()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-2", "second@example.com");
+        var third = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FALSE-3", "third@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(third);
+
+        var act = async () => await Db.SaveChangesAsync(false, CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*acceptAllChangesOnSuccess is false*");
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().BeNull();
+        (await GetItemAsync(third.Pk, third.Sk, CancellationToken)).Should().BeNull();
     }
 
     [Fact]

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
@@ -100,7 +101,10 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Customers.AddRange(customers);
 
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*limit of 100*");
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*MaxTransactionSize of 100*");
 
         (await GetItemAsync("TENANT#TXN", "CUSTOMER#ALWAYS-LIMIT-000", CancellationToken))
             .Should()
@@ -161,6 +165,105 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
         Db.Entry(second).State.Should().Be(EntityState.Added);
     }
 
+    [Fact]
+    public async Task WhenNeeded_OverflowWithUseChunking_AllowsPartialCommitAcrossChunks()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-DUP", "existing@example.com")),
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-FIRST", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-SECOND", "second@example.com");
+        var duplicate = CreateCustomer("TENANT#TXN", "CUSTOMER#CHUNK-DUP", "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Always_OverflowWithUseChunking_ThrowsInsteadOfChunking()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(2);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-2", "second@example.com");
+        var third = CreateCustomer("TENANT#TXN", "CUSTOMER#ALWAYS-CHUNK-3", "third@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(third);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*AutoTransactionBehavior.Always*");
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartupConfiguredChunking_AppliesWithoutPerContextOverride()
+    {
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-DUP", "existing@example.com")),
+            CancellationToken);
+
+        await using var configuredDb = CreateConfiguredContext(
+            TransactionOverflowBehavior.UseChunking,
+            2);
+        configuredDb.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#STARTUP-CHUNK-2", "second@example.com");
+        var duplicate = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#STARTUP-CHUNK-DUP",
+            "duplicate@example.com");
+
+        configuredDb.Customers.Add(first);
+        configuredDb.Customers.Add(second);
+        configuredDb.Customers.Add(duplicate);
+
+        var act = async () => await configuredDb.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DatabaseFacade_TransactionOverflowSettings_CanBeOverriddenPerContext()
+    {
+        Db.Database.GetTransactionOverflowBehavior().Should().Be(TransactionOverflowBehavior.Throw);
+        Db.Database.GetMaxTransactionSize().Should().Be(100);
+
+        Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+        Db.Database.SetMaxTransactionSize(25);
+
+        Db
+            .Database
+            .GetTransactionOverflowBehavior()
+            .Should()
+            .Be(TransactionOverflowBehavior.UseChunking);
+        Db.Database.GetMaxTransactionSize().Should().Be(25);
+    }
+
     private static CustomerItem CreateCustomer(string pk, string sk, string email)
         => new()
         {
@@ -171,6 +274,17 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
+
+    private SaveChangesTableDbContext CreateConfiguredContext(
+        TransactionOverflowBehavior behavior,
+        int maxTransactionSize)
+        => new(
+            new DbContextOptionsBuilder<SaveChangesTableDbContext>().UseDynamo(options
+                    => options
+                        .DynamoDbClient(Client)
+                        .TransactionOverflowBehavior(behavior)
+                        .MaxTransactionSize(maxTransactionSize))
+                .Options);
 
     private static Dictionary<string, AttributeValue> CreateSeedItem(CustomerItem customer)
     {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -18,6 +18,8 @@ public class PaginationConfigurationTests
         extension.DynamoDbClient.Should().BeNull();
         extension.DynamoDbClientConfig.Should().BeNull();
         extension.DynamoDbClientConfigAction.Should().BeNull();
+        extension.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.Throw);
+        extension.MaxTransactionSize.Should().Be(100);
     }
 
     [Fact]
@@ -64,7 +66,9 @@ public class PaginationConfigurationTests
             .WithDynamoDbClient(client)
             .WithDynamoDbClientConfig(config)
             .WithDynamoDbClientConfigAction(callback)
-            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative);
+            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative)
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
+            .WithMaxTransactionSize(42);
 
         // Clone is protected; trigger via a With method.
         var cloned =
@@ -77,6 +81,8 @@ public class PaginationConfigurationTests
             .AutomaticIndexSelectionMode
             .Should()
             .Be(DynamoAutomaticIndexSelectionMode.SuggestOnly);
+        cloned.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
+        cloned.MaxTransactionSize.Should().Be(42);
     }
 
     [Fact]
@@ -112,6 +118,45 @@ public class PaginationConfigurationTests
     }
 
     [Fact]
+    public void UseDynamo_ConfigureTransactionOverflowBehavior_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options
+            => options.TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
+    }
+
+    [Fact]
+    public void UseDynamo_ConfigureMaxTransactionSize_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options => options.MaxTransactionSize(12));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.MaxTransactionSize.Should().Be(12);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void WithMaxTransactionSize_InvalidValue_Throws(int invalidValue)
+    {
+        var extension = new DynamoDbOptionsExtension();
+
+        Action act = () => extension.WithMaxTransactionSize(invalidValue);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
     public void ServiceProviderHash_IncludesAutomaticIndexSelectionMode()
     {
         var extension1 =
@@ -120,6 +165,23 @@ public class PaginationConfigurationTests
         var extension2 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
                 DynamoAutomaticIndexSelectionMode.Conservative);
+
+        extension1
+            .Info
+            .GetServiceProviderHashCode()
+            .Should()
+            .NotBe(extension2.Info.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void ServiceProviderHash_IncludesTransactionOverflowBehaviorAndMaxTransactionSize()
+    {
+        var extension1 = new DynamoDbOptionsExtension()
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.Throw)
+            .WithMaxTransactionSize(100);
+        var extension2 = new DynamoDbOptionsExtension()
+            .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
+            .WithMaxTransactionSize(64);
 
         extension1
             .Info


### PR DESCRIPTION
## Summary
- add configurable transaction overflow behavior (`Throw` or `UseChunking`) with startup and per-context controls via `DynamoDbContextOptionsBuilder` and `DatabaseFacade`
- implement chunked `ExecuteTransaction` path for oversized multi-root SaveChanges units while preserving `AutoTransactionBehavior.Always` no-downgrade semantics
- reconcile change tracker state per successful chunk (including related aggregate entries), reject chunking with `SaveChanges(false)`, and cover behavior with integration/unit tests plus docs updates

## Testing
- `dotnet-test-mcp_run_all_tests_in_class`: `EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable.TransactionalSaveChangesTests` (12/12)
- `dotnet-test-mcp_run_all_tests_for_project`: `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj` (309 passed, 1 skipped)
- `dotnet-test-mcp_run_all_tests_for_project`: `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` (323/323)