### PR TITLE
feat(storage): batch non-atomic multi-root SaveChanges for AutoTransactionBehavior.Never

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ icon: lucide/git-branch
 1. **Execute**: pick execution mode from EF Core `Database.AutoTransactionBehavior`:
     - `WhenNeeded` (default): one root write executes directly; multiple root writes execute via DynamoDB `ExecuteTransaction`.
     - `Always`: behaves like `WhenNeeded` for a single root write, and requires `ExecuteTransaction` for multi-root writes.
-    - `Never`: executes compiled root writes independently (no implicit transaction).
+    - `Never`: executes one root write directly, and executes multi-root writes through non-atomic DynamoDB `BatchExecuteStatement` in chunks.
 
 During transactional execution, the provider enforces DynamoDB transaction constraints before sending any write:
 
@@ -65,6 +65,9 @@ globally atomic across chunks.
 Tracker semantics during chunking are also explicit: after each successful chunk commit, entries
 represented by that chunk are accepted in the current context. If a later chunk fails, already
 committed chunk entries remain accepted while failed/unrun chunk entries remain pending.
+
+Non-atomic batch chunking for `AutoTransactionBehavior.Never` follows the same tracker-acceptance
+model: successful statements are accepted immediately so retries do not replay committed writes.
 
 Per-root write compilation remains:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,7 @@ The provider follows EF Core `Database.AutoTransactionBehavior` for implicit tra
 
 - `WhenNeeded` (default): one root write executes directly; multi-root saves execute atomically via DynamoDB `ExecuteTransaction`.
 - `Always`: requires transactional execution for multi-root saves.
-- `Never`: disables implicit transactions and executes root writes independently.
+- `Never`: disables implicit transactions and executes multi-root writes using non-atomic DynamoDB `BatchExecuteStatement` chunks.
 
 ```csharp
 context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
@@ -64,11 +64,28 @@ context.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseC
 context.Database.SetMaxTransactionSize(25);
 ```
 
+For non-atomic multi-root batching when `AutoTransactionBehavior.Never` is set, configure:
+
+- `MaxBatchWriteSize` (default `25`, valid range `1..25`)
+
+```csharp
+optionsBuilder.UseDynamo(options =>
+{
+    options.MaxBatchWriteSize(20);
+});
+```
+
+Per-context override:
+
+```csharp
+context.Database.SetMaxBatchWriteSize(10);
+```
+
 Configuration precedence:
 
 1. Per-context override (`context.Database.Set...`)
 1. Startup/provider option (`UseDynamo(...)`)
-1. Provider defaults (`Throw`, `100`)
+1. Provider defaults (`Throw`, `100`, `25`)
 
 `UseChunking` keeps each chunk atomic, but the overall `SaveChanges` call is no longer globally
 atomic across all root writes.
@@ -76,6 +93,9 @@ atomic across all root writes.
 When chunking is active, use normal `SaveChanges`/`SaveChangesAsync` acceptance behavior
 (`acceptAllChangesOnSuccess: true`). Chunking with `acceptAllChangesOnSuccess: false` is rejected
 because successful chunks must be accepted immediately to avoid replaying already persisted writes.
+
+The same acceptance rule applies to non-atomic `BatchExecuteStatement` chunk iteration under
+`AutoTransactionBehavior.Never` for multi-root saves.
 
 ## Client configuration precedence
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,4 +62,5 @@ dotnet add package EntityFrameworkCore.DynamoDb
 ## Notes
 
 - `SaveChangesAsync` supports Added/Modified/Deleted root writes, including owned/nested mutations,
-    and follows EF Core `AutoTransactionBehavior` for implicit atomic multi-root execution.
+    and follows EF Core `AutoTransactionBehavior` for execution policy (`WhenNeeded`/`Always`
+    transactional for multi-root, `Never` non-atomic batched for multi-root).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -28,12 +28,18 @@ icon: lucide/triangle-alert
 - By default (`TransactionOverflowBehavior.Throw`), when transactional atomicity is required
     (`AutoTransactionBehavior.WhenNeeded` for multi-root saves, or `Always`), the provider throws
     if those constraints are violated; it does not silently downgrade to non-atomic execution.
+- When `AutoTransactionBehavior.Never` is set for multi-root saves, writes run through non-atomic
+    `BatchExecuteStatement` chunk iteration (default max batch size 25, configurable down to 1).
+- `BatchExecuteStatement` can partially succeed within a chunk; successful statements may commit
+    even when other statements fail.
 - If `TransactionOverflowBehavior.UseChunking` is configured, overflowing multi-root writes can be
     executed as multiple `ExecuteTransaction` chunks (up to `MaxTransactionSize`, max 100 per
     chunk), but overall SaveChanges atomicity is lost across chunk boundaries.
 - Chunking requires `acceptAllChangesOnSuccess: true`. `SaveChanges(false)`/
     `SaveChangesAsync(false)` is rejected for chunking overflow paths because successful chunks must
     be accepted immediately in the tracker.
+- Non-atomic batch chunk iteration under `AutoTransactionBehavior.Never` also requires
+    `acceptAllChangesOnSuccess: true` for the same reason.
 - `AutoTransactionBehavior.Always` still throws when one atomic transaction cannot represent the
     full write unit.
 - Unsupported LINQ shapes fail during translation with `InvalidOperationException` including provider-specific details.

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
@@ -57,6 +57,28 @@ public static class DynamoDatabaseFacadeExtensions
             ?? GetDynamoOptionsExtension(databaseFacade).MaxTransactionSize;
     }
 
+    /// <summary>Sets a per-context override for max non-atomic batch write size.</summary>
+    public static void SetMaxBatchWriteSize(
+        this DatabaseFacade databaseFacade,
+        int maxBatchWriteSize)
+    {
+        if (maxBatchWriteSize is <= 0 or > 25)
+            throw new InvalidOperationException(
+                $"The specified 'MaxBatchWriteSize' value '{maxBatchWriteSize}' is not valid. "
+                + "It must be between 1 and 25.");
+
+        GetRuntimeOptions(databaseFacade).MaxBatchWriteSizeOverride = maxBatchWriteSize;
+    }
+
+    /// <summary>Gets the effective max non-atomic batch write size for this context.</summary>
+    public static int GetMaxBatchWriteSize(this DatabaseFacade databaseFacade)
+    {
+        var runtimeOptions = GetRuntimeOptions(databaseFacade);
+
+        return runtimeOptions.MaxBatchWriteSizeOverride
+            ?? GetDynamoOptionsExtension(databaseFacade).MaxBatchWriteSize;
+    }
+
     private static DynamoTransactionRuntimeOptions GetRuntimeOptions(DatabaseFacade databaseFacade)
         => ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context
             .GetService<DynamoTransactionRuntimeOptions>();

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
@@ -61,6 +61,14 @@ public class DynamoDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilde
     public virtual DynamoDbContextOptionsBuilder MaxTransactionSize(int maxTransactionSize)
         => WithOption(e => e.WithMaxTransactionSize(maxTransactionSize));
 
+    /// <summary>
+    ///     Configures default maximum number of write operations sent in a single non-atomic PartiQL
+    ///     batch.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder MaxBatchWriteSize(int maxBatchWriteSize)
+        => WithOption(e => e.WithMaxBatchWriteSize(maxBatchWriteSize));
+
     /// <summary>Updates the provider options extension with the supplied mutation action.</summary>
     protected virtual DynamoDbContextOptionsBuilder WithOption(
         Func<DynamoDbOptionsExtension, DynamoDbOptionsExtension> setAction)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.Extensions;
-using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +9,7 @@ namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 {
     private const int DynamoTransactionLimit = 100;
+    private const int DynamoPartiQlBatchLimit = 25;
 
     /// <summary>Provides functionality for this member.</summary>
     public IAmazonDynamoDB? DynamoDbClient { get; private set; }
@@ -32,6 +32,9 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     /// Maximum number of write operations sent in a single DynamoDB transaction.
     /// </summary>
     public int MaxTransactionSize { get; private set; } = DynamoTransactionLimit;
+
+    /// <summary>Maximum number of write operations sent in a single non-atomic PartiQL batch.</summary>
+    public int MaxBatchWriteSize { get; private set; } = DynamoPartiQlBatchLimit;
 
     /// <summary>Registers provider services in the EF Core internal service container.</summary>
     public virtual void ApplyServices(IServiceCollection services)
@@ -124,6 +127,21 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
+    /// <summary>Sets the maximum number of write operations sent in a single non-atomic PartiQL batch.</summary>
+    public virtual DynamoDbOptionsExtension WithMaxBatchWriteSize(int maxBatchWriteSize)
+    {
+        if (maxBatchWriteSize is <= 0 or > DynamoPartiQlBatchLimit)
+            throw new InvalidOperationException(
+                $"The specified 'MaxBatchWriteSize' value '{maxBatchWriteSize}' is not valid. "
+                + $"It must be between 1 and {DynamoPartiQlBatchLimit}.");
+
+        var clone = Clone();
+
+        clone.MaxBatchWriteSize = maxBatchWriteSize;
+
+        return clone;
+    }
+
     /// <summary>Creates a copy of this extension with the current option values.</summary>
     protected virtual DynamoDbOptionsExtension Clone()
         => new()
@@ -134,6 +152,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             AutomaticIndexSelectionMode = AutomaticIndexSelectionMode,
             TransactionOverflowBehavior = TransactionOverflowBehavior,
             MaxTransactionSize = MaxTransactionSize,
+            MaxBatchWriteSize = MaxBatchWriteSize,
         };
 
     /// <summary>Represents the DynamoOptionsExtensionInfo type.</summary>
@@ -157,6 +176,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 hashCode.Add(Extension.AutomaticIndexSelectionMode);
                 hashCode.Add(Extension.TransactionOverflowBehavior);
                 hashCode.Add(Extension.MaxTransactionSize);
+                hashCode.Add(Extension.MaxBatchWriteSize);
 
                 _serviceProviderHash = hashCode.ToHashCode();
             }
@@ -178,7 +198,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 == otherInfo.Extension.AutomaticIndexSelectionMode
                 && Extension.TransactionOverflowBehavior
                 == otherInfo.Extension.TransactionOverflowBehavior
-                && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize;
+                && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize
+                && Extension.MaxBatchWriteSize == otherInfo.Extension.MaxBatchWriteSize;
 
         /// <summary>Provides functionality for this member.</summary>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }
@@ -194,6 +215,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 field ??= $"AutomaticIndexSelectionMode={Extension.AutomaticIndexSelectionMode},"
                     + $"TransactionOverflowBehavior={Extension.TransactionOverflowBehavior},"
                     + $"MaxTransactionSize={Extension.MaxTransactionSize},"
+                    + $"MaxBatchWriteSize={Extension.MaxBatchWriteSize},"
                     + $"DynamoDbClient={Extension.DynamoDbClient is not null},"
                     + $"DynamoDbClientConfig={Extension.DynamoDbClientConfig is not null},"
                     + $"DynamoDbClientConfigAction={Extension.DynamoDbClientConfigAction is not null}";

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoTransactionRuntimeOptions.cs
@@ -13,6 +13,9 @@ public sealed class DynamoTransactionRuntimeOptions
     /// </summary>
     public int? MaxTransactionSizeOverride { get; set; }
 
+    /// <summary>Optional per-context override for max non-atomic batch write size.</summary>
+    public int? MaxBatchWriteSizeOverride { get; set; }
+
     /// <summary>Captures <c>acceptAllChangesOnSuccess</c> for current SaveChanges call.</summary>
     public bool? AcceptAllChangesOnSuccess { get; set; }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -97,6 +97,30 @@ public class DynamoClientWrapper : IDynamoClientWrapper
             null,
             cancellationToken);
 
+    /// <summary>Executes non-atomic PartiQL batch write statements.</summary>
+    /// <param name="statements">Ordered batch statements.</param>
+    /// <param name="cancellationToken">Token to observe for cancellation.</param>
+    /// <returns>Per-statement responses returned by DynamoDB.</returns>
+    public Task<IReadOnlyList<BatchStatementResponse>> ExecuteBatchWriteAsync(
+        IReadOnlyList<BatchStatementRequest> statements,
+        CancellationToken cancellationToken = default)
+        => _executionStrategy.ExecuteAsync(
+            statements,
+            async (_, batchStatements, ct) =>
+            {
+                var request = new BatchExecuteStatementRequest
+                {
+                    Statements = [.. batchStatements],
+                };
+
+                var response =
+                    await Client.BatchExecuteStatementAsync(request, ct).ConfigureAwait(false);
+
+                return (IReadOnlyList<BatchStatementResponse>)(response.Responses ?? []);
+            },
+            null,
+            cancellationToken);
+
     /// <summary>Builds the effective SDK configuration from extension options in precedence order.</summary>
     private static AmazonDynamoDBConfig BuildAmazonDynamoDbConfig(DynamoDbOptionsExtension? options)
     {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -437,19 +437,12 @@ public class DynamoDatabaseWrapper(
                     .ExecuteBatchWriteAsync(statements, cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is DuplicateItemException
-                    or ConditionalCheckFailedException
-                    or TransactionCanceledException
-                || IsDuplicateKeyException(ex)
-                || IsConditionalCheckFailedException(ex))
-            {
-                throw WrapWriteException(
-                    ex,
-                    chunk[0].EntityState,
-                    chunk.Select(static x => x.Entry).ToList());
-            }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                // BatchExecuteStatement returns per-statement errors in the response body
+                // (Responses[i].Error), not as thrown exceptions. Exceptions here are
+                // transport-level failures (network, auth, throttling) where no statements
+                // can have partially succeeded.
                 throw new DbUpdateException(
                     "Non-atomic SaveChanges batch failed while executing DynamoDB "
                     + "BatchExecuteStatement.",
@@ -480,8 +473,14 @@ public class DynamoDatabaseWrapper(
 
                 failedEntries ??= [];
                 failedEntries.Add(chunk[i].Entry);
-                firstFailure ??= CreateBatchStatementException(response.Error);
-                firstFailedState = chunk[i].EntityState;
+
+                // Capture only the first failure — subsequent per-statement errors in the same
+                // chunk are collected into failedEntries but a single exception is thrown.
+                if (firstFailure is null)
+                {
+                    firstFailure = CreateBatchStatementException(response.Error);
+                    firstFailedState = chunk[i].EntityState;
+                }
             }
 
             if (successfulOperations.Count > 0)

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -211,10 +211,29 @@ public class DynamoDatabaseWrapper(
             ?? _optionsExtension.TransactionOverflowBehavior;
         var effectiveMaxTransactionSize = transactionRuntimeOptions.MaxTransactionSizeOverride
             ?? _optionsExtension.MaxTransactionSize;
+        var effectiveMaxBatchWriteSize = transactionRuntimeOptions.MaxBatchWriteSizeOverride
+            ?? _optionsExtension.MaxBatchWriteSize;
 
         if (!ShouldUseTransaction(autoTransactionBehavior, operations.Count))
         {
-            await ExecuteIndependentWritesAsync(operations, cancellationToken)
+            if (operations.Count == 1)
+            {
+                await ExecuteIndependentWritesAsync(operations, cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            // Non-atomic batch chunks can partially commit; provider must accept successful
+            // statements immediately to keep tracker aligned with persisted state.
+            if (transactionRuntimeOptions.AcceptAllChangesOnSuccess == false)
+                throw CreateNonAtomicBatchAcceptAllChangesRequiredException();
+
+            var nonAtomicRootAggregateEntries = BuildRootAggregateEntries(entries, rootEntries);
+            await ExecuteChunkedBatchWritesAsync(
+                    operations,
+                    nonAtomicRootAggregateEntries,
+                    effectiveMaxBatchWriteSize,
+                    cancellationToken)
                 .ConfigureAwait(false);
             return;
         }
@@ -308,6 +327,13 @@ public class DynamoDatabaseWrapper(
             + "per-chunk tracker acceptance to avoid replaying already-persisted "
             + "writes on retry.");
 
+    private static InvalidOperationException CreateNonAtomicBatchAcceptAllChangesRequiredException()
+        => new(
+            "Non-atomic batched SaveChanges is not supported when "
+            + "acceptAllChangesOnSuccess is false. Partial batch commits require "
+            + "per-batch tracker acceptance to avoid replaying already-persisted "
+            + "writes on retry.");
+
     private async Task ExecuteIndependentWritesAsync(
         IReadOnlyList<CompiledWriteOperation> operations,
         CancellationToken cancellationToken)
@@ -384,6 +410,93 @@ public class DynamoDatabaseWrapper(
             AcceptChunkEntries(chunk, rootAggregateEntries);
         }
     }
+
+    private async Task ExecuteChunkedBatchWritesAsync(
+        IReadOnlyList<CompiledWriteOperation> operations,
+        IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<IUpdateEntry>> rootAggregateEntries,
+        int maxBatchWriteSize,
+        CancellationToken cancellationToken)
+    {
+        foreach (var chunk in operations.Chunk(maxBatchWriteSize))
+        {
+            foreach (var operation in chunk)
+                commandLogger.ExecutingPartiQlWrite(operation.TableName, operation.Statement);
+
+            var statements = chunk
+                .Select(static operation => new BatchStatementRequest
+                {
+                    Statement = operation.Statement, Parameters = operation.Parameters,
+                })
+                .ToList();
+
+            IReadOnlyList<BatchStatementResponse> responses;
+
+            try
+            {
+                responses = await clientWrapper
+                    .ExecuteBatchWriteAsync(statements, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is DuplicateItemException
+                    or ConditionalCheckFailedException
+                    or TransactionCanceledException
+                || IsDuplicateKeyException(ex)
+                || IsConditionalCheckFailedException(ex))
+            {
+                throw WrapWriteException(
+                    ex,
+                    chunk[0].EntityState,
+                    chunk.Select(static x => x.Entry).ToList());
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw new DbUpdateException(
+                    "Non-atomic SaveChanges batch failed while executing DynamoDB "
+                    + "BatchExecuteStatement.",
+                    ex,
+                    chunk.Select(static x => x.Entry).ToList());
+            }
+
+            if (responses.Count != chunk.Length)
+                throw new DbUpdateException(
+                    "DynamoDB BatchExecuteStatement returned an unexpected number of "
+                    + "responses. SaveChanges cannot reconcile partial commit state safely.",
+                    null,
+                    chunk.Select(static x => x.Entry).ToList());
+
+            var successfulOperations = new List<CompiledWriteOperation>(chunk.Length);
+            List<IUpdateEntry>? failedEntries = null;
+            EntityState firstFailedState = default;
+            Exception? firstFailure = null;
+
+            for (var i = 0; i < chunk.Length; i++)
+            {
+                var response = responses[i];
+                if (response.Error is null)
+                {
+                    successfulOperations.Add(chunk[i]);
+                    continue;
+                }
+
+                failedEntries ??= [];
+                failedEntries.Add(chunk[i].Entry);
+                firstFailure ??= CreateBatchStatementException(response.Error);
+                firstFailedState = chunk[i].EntityState;
+            }
+
+            if (successfulOperations.Count > 0)
+                AcceptChunkEntries(successfulOperations, rootAggregateEntries);
+
+            if (failedEntries is not null)
+                throw WrapWriteException(firstFailure!, firstFailedState, failedEntries);
+        }
+    }
+
+    private static AmazonDynamoDBException CreateBatchStatementException(BatchStatementError error)
+        => new(error.Message ?? "DynamoDB BatchExecuteStatement reported a statement failure.")
+        {
+            ErrorCode = error.Code,
+        };
 
     /// <summary>
     ///     Builds mapping from root aggregate entry to all tracked entries represented by that root
@@ -1412,6 +1525,14 @@ public class DynamoDatabaseWrapper(
         => ex is AmazonDynamoDBException ade
             && string.Equals(ade.ErrorCode, "DuplicateItem", StringComparison.Ordinal);
 
+    private static bool IsConditionalCheckFailedException(Exception ex)
+        => ex is AmazonDynamoDBException ade
+            && (string.Equals(ade.ErrorCode, "ConditionalCheckFailed", StringComparison.Ordinal)
+                || string.Equals(
+                    ade.ErrorCode,
+                    "ConditionalCheckFailedException",
+                    StringComparison.Ordinal));
+
     /// <summary>
     ///     Appends WHERE predicates and parameter values for all configured non-key concurrency token
     ///     properties on <paramref name="entityType" />, using tracked original values.
@@ -1497,7 +1618,7 @@ public class DynamoDatabaseWrapper(
                 ex,
                 entries);
 
-        if (ex is ConditionalCheckFailedException)
+        if (ex is ConditionalCheckFailedException || IsConditionalCheckFailedException(ex))
             return new DbUpdateConcurrencyException(
                 $"The '{firstEntry.EntityType.DisplayName()}' entity could not be "
                 + (entityState == EntityState.Modified ? "updated" : "deleted")

--- a/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
@@ -29,4 +29,12 @@ public interface IDynamoClientWrapper
     Task ExecuteTransactionAsync(
         IReadOnlyList<ParameterizedStatement> statements,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Executes non-atomic PartiQL batch write statements.</summary>
+    /// <param name="statements">Ordered batch statements to execute.</param>
+    /// <param name="cancellationToken">Token to observe for cancellation.</param>
+    /// <returns>Per-statement responses for the submitted batch.</returns>
+    Task<IReadOnlyList<BatchStatementResponse>> ExecuteBatchWriteAsync(
+        IReadOnlyList<BatchStatementRequest> statements,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -86,6 +86,60 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
     }
 
     [Fact]
+    public async Task Never_MultiRootBatch_SaveChangesFalse_ThrowsClearError()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-FALSE-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-FALSE-2", "second@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+
+        var act = async () => await Db.SaveChangesAsync(false, CancellationToken);
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*acceptAllChangesOnSuccess is false*");
+
+        Db.Entry(first).State.Should().Be(EntityState.Added);
+        Db.Entry(second).State.Should().Be(EntityState.Added);
+    }
+
+    [Fact]
+    public async Task Never_BatchedChunkFailure_AcceptsSuccessfulPriorChunkEntries()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+        Db.Database.SetMaxBatchWriteSize(2);
+
+        await PutItemAsync(
+            CreateSeedItem(
+                CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-CHUNK-DUP", "existing@example.com")),
+            CancellationToken);
+
+        var first = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-CHUNK-1", "first@example.com");
+        var second = CreateCustomer("TENANT#TXN", "CUSTOMER#NEVER-CHUNK-2", "second@example.com");
+        var duplicate = CreateCustomer(
+            "TENANT#TXN",
+            "CUSTOMER#NEVER-CHUNK-DUP",
+            "duplicate@example.com");
+
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        Db.Customers.Add(duplicate);
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
+        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+
+        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Always_MoreThan100RootWrites_ThrowsClearErrorWithoutDowngrade()
     {
         Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
@@ -326,9 +380,11 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
     {
         Db.Database.GetTransactionOverflowBehavior().Should().Be(TransactionOverflowBehavior.Throw);
         Db.Database.GetMaxTransactionSize().Should().Be(100);
+        Db.Database.GetMaxBatchWriteSize().Should().Be(25);
 
         Db.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
         Db.Database.SetMaxTransactionSize(25);
+        Db.Database.SetMaxBatchWriteSize(10);
 
         Db
             .Database
@@ -336,6 +392,7 @@ public class TransactionalSaveChangesTests(SaveChangesTableDynamoFixture fixture
             .Should()
             .Be(TransactionOverflowBehavior.UseChunking);
         Db.Database.GetMaxTransactionSize().Should().Be(25);
+        Db.Database.GetMaxBatchWriteSize().Should().Be(10);
     }
 
     [Fact]

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -20,6 +20,7 @@ public class PaginationConfigurationTests
         extension.DynamoDbClientConfigAction.Should().BeNull();
         extension.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.Throw);
         extension.MaxTransactionSize.Should().Be(100);
+        extension.MaxBatchWriteSize.Should().Be(25);
     }
 
     [Fact]
@@ -68,7 +69,8 @@ public class PaginationConfigurationTests
             .WithDynamoDbClientConfigAction(callback)
             .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative)
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
-            .WithMaxTransactionSize(42);
+            .WithMaxTransactionSize(42)
+            .WithMaxBatchWriteSize(11);
 
         // Clone is protected; trigger via a With method.
         var cloned =
@@ -83,6 +85,7 @@ public class PaginationConfigurationTests
             .Be(DynamoAutomaticIndexSelectionMode.SuggestOnly);
         cloned.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
         cloned.MaxTransactionSize.Should().Be(42);
+        cloned.MaxBatchWriteSize.Should().Be(11);
     }
 
     [Fact]
@@ -144,6 +147,19 @@ public class PaginationConfigurationTests
         extension!.MaxTransactionSize.Should().Be(12);
     }
 
+    [Fact]
+    public void UseDynamo_ConfigureMaxBatchWriteSize_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options => options.MaxBatchWriteSize(9));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.MaxBatchWriteSize.Should().Be(9);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(101)]
@@ -152,6 +168,18 @@ public class PaginationConfigurationTests
         var extension = new DynamoDbOptionsExtension();
 
         Action act = () => extension.WithMaxTransactionSize(invalidValue);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(26)]
+    public void WithMaxBatchWriteSize_InvalidValue_Throws(int invalidValue)
+    {
+        var extension = new DynamoDbOptionsExtension();
+
+        Action act = () => extension.WithMaxBatchWriteSize(invalidValue);
 
         act.Should().Throw<InvalidOperationException>();
     }
@@ -174,14 +202,16 @@ public class PaginationConfigurationTests
     }
 
     [Fact]
-    public void ServiceProviderHash_IncludesTransactionOverflowBehaviorAndMaxTransactionSize()
+    public void ServiceProviderHash_IncludesTransactionAndBatchSizingOptions()
     {
         var extension1 = new DynamoDbOptionsExtension()
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.Throw)
-            .WithMaxTransactionSize(100);
+            .WithMaxTransactionSize(100)
+            .WithMaxBatchWriteSize(25);
         var extension2 = new DynamoDbOptionsExtension()
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
-            .WithMaxTransactionSize(64);
+            .WithMaxTransactionSize(64)
+            .WithMaxBatchWriteSize(10);
 
         extension1
             .Info


### PR DESCRIPTION
## Summary
- batch multi-root `SaveChangesAsync` through DynamoDB `BatchExecuteStatement` when `Database.AutoTransactionBehavior` is `Never`, while keeping single-root writes on the existing singleton path
- add `MaxBatchWriteSize` configuration at both startup and `DatabaseFacade` scope, and align tracker acceptance semantics with existing transactional chunking behavior
- document the non-atomic chunked behavior and add tests for configuration, `SaveChanges(false)` rejection, and partial-commit state handling

## Testing
- `EntityFrameworkCore.DynamoDb.Tests.Query.PaginationConfigurationTests`
- `EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable.TransactionalSaveChangesTests`