### PR TITLE
feat(storage): add PartiQL statement-length guard and SaveChanges edge-case tests

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -271,7 +271,9 @@ public class DynamoDatabaseWrapper(
         string tableName,
         string statement,
         List<AttributeValue> parameters)
-        => operations.Add(
+    {
+        ValidateStatementLength(statement);
+        operations.Add(
             new CompiledWriteOperation(
                 entry,
                 entityState,
@@ -279,6 +281,27 @@ public class DynamoDatabaseWrapper(
                 statement,
                 parameters,
                 BuildTargetItemIdentity(entry, tableName)));
+    }
+
+    /// <summary>
+    ///     Guards against PartiQL statements that exceed DynamoDB's 8 KB statement-size limit,
+    ///     failing fast before the statement is queued for execution. Mirrors the pattern used by
+    ///     <see cref="ValidateTransactionalDuplicateTargets" />.
+    /// </summary>
+    private static void ValidateStatementLength(string statement)
+    {
+        if (statement.Length <= MaxPartiQlStatementLength)
+            return;
+
+        throw new InvalidOperationException(
+            $"The generated PartiQL statement is {statement.Length} characters, which exceeds "
+            + $"DynamoDB's {MaxPartiQlStatementLength}-character statement-size limit. "
+            + "Consider reducing the number of mapped scalar properties or splitting the "
+            + "write unit across multiple SaveChanges calls.");
+    }
+
+    /// <summary>The maximum allowed length for a PartiQL statement sent to DynamoDB.</summary>
+    internal const int MaxPartiQlStatementLength = 8192;
 
     private static InvalidOperationException CreateAlwaysOverflowException(
         int operationCount,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesEdgeCasesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesEdgeCasesTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>
+///     Integration tests for DynamoDB- and PartiQL-specific edge cases outside the happy-path
+///     CRUD stories: no-op saves, <c>acceptAllChangesOnSuccess</c> semantics, and the statement-size
+///     guard.
+/// </summary>
+public class SaveChangesEdgeCasesTests(SaveChangesTableDynamoFixture fixture)
+    : SaveChangesTableTestBase(fixture)
+{
+    // ── No-op ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ZeroChanges_ReturnsZero_AndNoWritesEmitted()
+    {
+        // Fresh context with nothing tracked — SaveChanges should be a no-op.
+        var affected = await Db.SaveChangesAsync(CancellationToken);
+
+        affected.Should().Be(0);
+        AssertSql(); // No PartiQL statements should have been emitted.
+    }
+
+    // ── acceptAllChangesOnSuccess = false ─────────────────────────────────────
+
+    [Fact]
+    public async Task AcceptAllChangesFalse_SingleRoot_PersistsButKeepsEntryPending()
+    {
+        // EF Core standard behavior: SaveChanges(false) persists the write but skips the
+        // AcceptAllChanges() call, leaving entries in their pre-save state until the caller
+        // explicitly calls ChangeTracker.AcceptAllChanges().
+        const string pk = "TENANT#EDGE";
+        const string sk = "CUSTOMER#ACCEPT-FALSE";
+
+        var customer = new CustomerItem
+        {
+            Pk = pk,
+            Sk = sk,
+            Version = 1,
+            Email = "edge@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+
+        Db.Customers.Add(customer);
+
+        // SaveChanges with acceptAllChangesOnSuccess = false.
+        var affected = await Db.SaveChangesAsync(false, CancellationToken);
+
+        // Write reached DynamoDB.
+        affected.Should().Be(1);
+        (await GetItemAsync(pk, sk, CancellationToken)).Should().NotBeNull();
+
+        AssertSql(
+            """
+            INSERT INTO "AppItems"
+            VALUE {'Pk': ?, 'Sk': ?, '$type': ?, 'CreatedAt': ?, 'Email': ?, 'IsPreferred': ?, 'Notes': ?, 'NullableNote': ?, 'Preferences': ?, 'ReferenceIds': ?, 'Tags': ?, 'Version': ?, 'Contacts': ?}
+            """);
+
+        // Entry still in Added state — AcceptAllChanges was not called.
+        Db.Entry(customer).State.Should().Be(EntityState.Added);
+
+        // After explicit AcceptAllChanges, entry becomes Unchanged.
+        Db.ChangeTracker.AcceptAllChanges();
+        Db.Entry(customer).State.Should().Be(EntityState.Unchanged);
+    }
+
+    // ── Statement-length guard ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Insert_WithStatementExceeding8192Chars_ThrowsBeforeAnyWrite()
+    {
+        // This test verifies the provider's PartiQL statement-size guard fires before
+        // any write reaches DynamoDB. The LongStatementItem entity maps 15 scalar properties
+        // to attribute names that are each 600 characters long. The resulting INSERT statement
+        // comfortably exceeds DynamoDB's 8192-character limit.
+        const string pk = "TENANT#EDGE";
+        const string sk = "ITEM#LONG-STATEMENT";
+
+        var item = new LongStatementItem { Pk = pk, Sk = sk };
+
+        var act = async () =>
+        {
+            await using var context = CreateLongStatementContext();
+            context.Items.Add(item);
+            await context.SaveChangesAsync(CancellationToken);
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*8192*character*");
+
+        // Guard fired before the write — item must not exist in DynamoDB.
+        (await GetItemAsync(pk, sk, CancellationToken)).Should().BeNull();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private LongStatementContext CreateLongStatementContext()
+        => new(
+            new DbContextOptionsBuilder<LongStatementContext>().UseDynamo(options
+                    => options.DynamoDbClient(Client))
+                .Options);
+
+    // ── Private model ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    ///     A purpose-built entity whose DynamoDB attribute names are intentionally long so that the
+    ///     generated INSERT statement exceeds 8192 characters.
+    /// </summary>
+    private sealed class LongStatementItem
+    {
+        public string Pk { get; set; } = null!;
+
+        public string Sk { get; set; } = null!;
+
+        public string? P01 { get; set; }
+        public string? P02 { get; set; }
+        public string? P03 { get; set; }
+        public string? P04 { get; set; }
+        public string? P05 { get; set; }
+        public string? P06 { get; set; }
+        public string? P07 { get; set; }
+        public string? P08 { get; set; }
+        public string? P09 { get; set; }
+        public string? P10 { get; set; }
+        public string? P11 { get; set; }
+        public string? P12 { get; set; }
+        public string? P13 { get; set; }
+        public string? P14 { get; set; }
+        public string? P15 { get; set; }
+    }
+
+    /// <summary>
+    ///     DbContext that maps <see cref="LongStatementItem" /> with exaggerated attribute names to
+    ///     reliably trigger the statement-length guard without requiring hundreds of properties.
+    /// </summary>
+    private sealed class LongStatementContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<LongStatementItem> Items => Set<LongStatementItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Each attribute name is 600 characters long. With 15 properties the INSERT
+            // statement will be ~9100 characters, well above the 8192-char guard threshold.
+            const string LongName =
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                + // 100
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+                + // 100
+                "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+                + // 100
+                "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+                + // 100
+                "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+                + // 100
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"; // 100
+
+            modelBuilder.Entity<LongStatementItem>(builder =>
+            {
+                builder.ToTable(SaveChangesTableDynamoFixture.TableName);
+                builder.HasPartitionKey(x => x.Pk);
+                builder.HasSortKey(x => x.Sk);
+
+                builder.Property(x => x.P01).HasAttributeName(LongName + "_01");
+                builder.Property(x => x.P02).HasAttributeName(LongName + "_02");
+                builder.Property(x => x.P03).HasAttributeName(LongName + "_03");
+                builder.Property(x => x.P04).HasAttributeName(LongName + "_04");
+                builder.Property(x => x.P05).HasAttributeName(LongName + "_05");
+                builder.Property(x => x.P06).HasAttributeName(LongName + "_06");
+                builder.Property(x => x.P07).HasAttributeName(LongName + "_07");
+                builder.Property(x => x.P08).HasAttributeName(LongName + "_08");
+                builder.Property(x => x.P09).HasAttributeName(LongName + "_09");
+                builder.Property(x => x.P10).HasAttributeName(LongName + "_10");
+                builder.Property(x => x.P11).HasAttributeName(LongName + "_11");
+                builder.Property(x => x.P12).HasAttributeName(LongName + "_12");
+                builder.Property(x => x.P13).HasAttributeName(LongName + "_13");
+                builder.Property(x => x.P14).HasAttributeName(LongName + "_14");
+                builder.Property(x => x.P15).HasAttributeName(LongName + "_15");
+            });
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesModelValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesModelValidationTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>
+///     Integration tests that verify unsupported write model shapes fail before any write is
+///     sent.
+/// </summary>
+public class SaveChangesModelValidationTests(SaveChangesTableDynamoFixture fixture)
+    : SaveChangesTableTestBase(fixture)
+{
+    [Fact]
+    public async Task SaveChanges_UnmappedScalarProperty_ThrowsBeforeWrite()
+    {
+        var item = new UnmappedScalarItem
+        {
+            Pk = "TENANT#VALIDATION",
+            Sk = "MODEL#UNMAPPED-SCALAR",
+            Metadata = new CustomPayload(),
+        };
+
+        var act = async () =>
+        {
+            await using var context = CreateUnmappedScalarContext();
+            context.Items.Add(item);
+            await context.SaveChangesAsync(CancellationToken);
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*HasConversion*");
+
+        (await GetItemAsync(item.Pk, item.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SaveChanges_RowVersionConcurrencyShape_ThrowsBeforeWrite()
+    {
+        var item = new RowVersionItem
+        {
+            Pk = "TENANT#VALIDATION", Sk = "MODEL#ROWVERSION", Token = 1,
+        };
+
+        var act = async () =>
+        {
+            await using var context = CreateRowVersionContext();
+            context.Items.Add(item);
+            await context.SaveChangesAsync(CancellationToken);
+        };
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*IsRowVersion()*not currently support*");
+
+        (await GetItemAsync(item.Pk, item.Sk, CancellationToken)).Should().BeNull();
+    }
+
+    private UnmappedScalarContext CreateUnmappedScalarContext()
+        => new(
+            new DbContextOptionsBuilder<UnmappedScalarContext>().UseDynamo(options
+                    => options.DynamoDbClient(Client))
+                .Options);
+
+    private RowVersionContext CreateRowVersionContext()
+        => new(
+            new DbContextOptionsBuilder<RowVersionContext>().UseDynamo(options
+                    => options.DynamoDbClient(Client))
+                .Options);
+
+    private sealed class UnmappedScalarContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<UnmappedScalarItem> Items => Set<UnmappedScalarItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<UnmappedScalarItem>(builder =>
+            {
+                builder.ToTable(SaveChangesTableDynamoFixture.TableName);
+                builder.HasPartitionKey(x => x.Pk);
+                builder.HasSortKey(x => x.Sk);
+                builder.Property(x => x.Metadata);
+            });
+    }
+
+    private sealed class RowVersionContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<RowVersionItem> Items => Set<RowVersionItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<RowVersionItem>(builder =>
+            {
+                builder.ToTable(SaveChangesTableDynamoFixture.TableName);
+                builder.HasPartitionKey(x => x.Pk);
+                builder.HasSortKey(x => x.Sk);
+                builder.Property(x => x.Token).IsConcurrencyToken().ValueGeneratedOnAddOrUpdate();
+            });
+    }
+
+    private sealed class UnmappedScalarItem
+    {
+        public string Pk { get; set; } = null!;
+
+        public string Sk { get; set; } = null!;
+
+        public CustomPayload Metadata { get; set; } = null!;
+    }
+
+    private sealed class RowVersionItem
+    {
+        public string Pk { get; set; } = null!;
+
+        public string Sk { get; set; } = null!;
+
+        public long Token { get; set; }
+    }
+
+    private sealed class CustomPayload { }
+}


### PR DESCRIPTION
## Summary

Closes out the `6gu.9` story by adding the remaining SaveChanges edge-case coverage. Most acceptance criteria were already satisfied by prior stories; this PR adds the three missing items: a no-op save test, an `acceptAllChangesOnSuccess=false` happy-path test, and a production guard (+ test) for PartiQL statements that exceed DynamoDB's 8192-character size limit.

## Changes

**`DynamoDatabaseWrapper.cs`**
- Added `ValidateStatementLength` — fires in `AddCompiledOperation` before any statement is queued, matching the pattern of `ValidateTransactionalDuplicateTargets`.
- Exposed `MaxPartiQlStatementLength = 8192` as an `internal const`.

**`SaveChangesEdgeCasesTests.cs`** (new)
- `ZeroChanges_ReturnsZero_AndNoWritesEmitted` — fresh context → returns 0, no SQL emitted.
- `AcceptAllChangesFalse_SingleRoot_PersistsButKeepsEntryPending` — verifies EF Core semantics: write reaches DynamoDB, entry stays `Added` until `ChangeTracker.AcceptAllChanges()` is called.
- `Insert_WithStatementExceeding8192Chars_ThrowsBeforeAnyWrite` — `LongStatementContext` with 15 properties × 600-char attribute names triggers the guard; asserts nothing written to DynamoDB.

## Validation

317 integration tests pass, 1 pre-existing skip, 0 failures.

## Related Issues

Closes `dynamodb-efcore-provider-6gu.9`