### PR TITLE
feat(extensions): add `GetDynamoClient` to `DatabaseFacade`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,9 @@ The same acceptance rule applies to non-atomic `BatchExecuteStatement` chunk ite
     1. `DynamoDbClientConfig(...)` (base SDK config)
     1. `ConfigureDynamoDbClientConfig(...)` (callback adjustments)
 
+Use `context.Database.GetDynamoClient()` to retrieve the resolved `IAmazonDynamoDB` instance from
+a configured context — useful for direct SDK calls or test assertions.
+
 ```csharp
 var sharedClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig
 {

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDatabaseFacadeExtensions.cs
@@ -1,5 +1,7 @@
+using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.Infrastructure;
 using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
+using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -95,6 +97,23 @@ public static class DynamoDatabaseFacadeExtensions
 
         return runtimeOptions.MaxBatchWriteSizeOverride
             ?? GetDynamoOptionsExtension(databaseFacade).MaxBatchWriteSize;
+    }
+
+    /// <summary>Returns the underlying <see cref="IAmazonDynamoDB" /> client used by this context.</summary>
+    /// <param name="databaseFacade">The <see cref="DatabaseFacade" /> for the current context.</param>
+    /// <returns>The <see cref="IAmazonDynamoDB" /> client instance.</returns>
+    public static IAmazonDynamoDB GetDynamoClient(this DatabaseFacade databaseFacade)
+        => GetService<IDynamoClientWrapper>(databaseFacade).Client;
+
+    private static TService GetService<TService>(IInfrastructure<IServiceProvider> databaseFacade)
+        where TService : class
+    {
+        var service = databaseFacade.GetService<TService>();
+        if (service == null)
+            throw new InvalidOperationException(
+                $"Service of type '{typeof(TService).FullName}' is not available.");
+
+        return service;
     }
 
     private static DynamoTransactionRuntimeOptions GetRuntimeOptions(DatabaseFacade databaseFacade)

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Extensions/DynamoDatabaseFacadeExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Extensions/DynamoDatabaseFacadeExtensionsTests.cs
@@ -1,0 +1,162 @@
+using Amazon.DynamoDBv2;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Extensions;
+
+/// <summary>Unit tests for <see cref="DynamoDatabaseFacadeExtensions" />.</summary>
+public class DynamoDatabaseFacadeExtensionsTests
+{
+    // ── GetDynamoClient ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetDynamoClient_ReturnsDynamoClientFromWrapper()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client);
+
+        var result = context.Database.GetDynamoClient();
+
+        result.Should().BeSameAs(client);
+    }
+
+    // ── TransactionOverflowBehavior ──────────────────────────────────────────
+
+    [Fact]
+    public void SetTransactionOverflowBehavior_OverridesConfiguredDefault()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, TransactionOverflowBehavior.Throw);
+
+        context.Database.SetTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking);
+
+        context
+            .Database
+            .GetTransactionOverflowBehavior()
+            .Should()
+            .Be(TransactionOverflowBehavior.UseChunking);
+    }
+
+    [Fact]
+    public void GetTransactionOverflowBehavior_FallsBackToConfiguredDefault_WhenNoOverride()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, TransactionOverflowBehavior.Throw);
+
+        context
+            .Database
+            .GetTransactionOverflowBehavior()
+            .Should()
+            .Be(TransactionOverflowBehavior.Throw);
+    }
+
+    // ── MaxTransactionSize ───────────────────────────────────────────────────
+
+    [Fact]
+    public void SetMaxTransactionSize_OverridesConfiguredDefault()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, maxTransactionSize: 50);
+
+        context.Database.SetMaxTransactionSize(10);
+
+        context.Database.GetMaxTransactionSize().Should().Be(10);
+    }
+
+    [Fact]
+    public void GetMaxTransactionSize_FallsBackToConfiguredDefault_WhenNoOverride()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, maxTransactionSize: 50);
+
+        context.Database.GetMaxTransactionSize().Should().Be(50);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public void SetMaxTransactionSize_InvalidValue_ThrowsInvalidOperationException(int value)
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client);
+
+        var act = () => context.Database.SetMaxTransactionSize(value);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage($"*'{value}'*");
+    }
+
+    // ── MaxBatchWriteSize ────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetMaxBatchWriteSize_OverridesConfiguredDefault()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, maxBatchWriteSize: 20);
+
+        context.Database.SetMaxBatchWriteSize(5);
+
+        context.Database.GetMaxBatchWriteSize().Should().Be(5);
+    }
+
+    [Fact]
+    public void GetMaxBatchWriteSize_FallsBackToConfiguredDefault_WhenNoOverride()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client, maxBatchWriteSize: 20);
+
+        context.Database.GetMaxBatchWriteSize().Should().Be(20);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(26)]
+    public void SetMaxBatchWriteSize_InvalidValue_ThrowsInvalidOperationException(int value)
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client);
+
+        var act = () => context.Database.SetMaxBatchWriteSize(value);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage($"*'{value}'*");
+    }
+
+    // ── Support types ────────────────────────────────────────────────────────
+
+    private sealed record TestEntity
+    {
+        public string Pk { get; set; } = null!;
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<TestEntity> Items => Set<TestEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<TestEntity>(b =>
+            {
+                b.ToTable("TestTable");
+                b.HasPartitionKey(x => x.Pk);
+            });
+
+        public static TestDbContext Create(
+            IAmazonDynamoDB client,
+            TransactionOverflowBehavior transactionOverflowBehavior =
+                TransactionOverflowBehavior.UseChunking,
+            int maxTransactionSize = 100,
+            int maxBatchWriteSize = 25)
+            => new(
+                new DbContextOptionsBuilder<TestDbContext>()
+                    .UseDynamo(options => options
+                        .DynamoDbClient(client)
+                        .TransactionOverflowBehavior(transactionOverflowBehavior)
+                        .MaxTransactionSize(maxTransactionSize)
+                        .MaxBatchWriteSize(maxBatchWriteSize))
+                    .ConfigureWarnings(w
+                        => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .Options);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `context.Database.GetDynamoClient()` as a public escape hatch to retrieve the resolved `IAmazonDynamoDB` instance from a configured context. This is useful for direct SDK calls, advanced scenarios, and test assertions without needing to pass the client around separately.

## Changes

**Provider**
- `DynamoDatabaseFacadeExtensions.GetDynamoClient` — new extension method that resolves the `IDynamoClientWrapper` service and returns its `.Client`
- XML doc comment added

**Tests**
- `DynamoDatabaseFacadeExtensionsTests` — new test class covering `GetDynamoClient` happy path, and roundtrip/validation/fallback behaviour for all existing `DatabaseFacade` extension methods (`SetTransactionOverflowBehavior`, `GetTransactionOverflowBehavior`, `SetMaxTransactionSize`, `GetMaxTransactionSize`, `SetMaxBatchWriteSize`, `GetMaxBatchWriteSize`)

**Docs**
- `configuration.md` — one-line entry under "Client configuration precedence" documenting the new method

## Validation

- All 13 new unit tests pass (`DynamoDatabaseFacadeExtensionsTests`)
- No changes to existing tests