### PR TITLE
feat(dynamodb): expose per-entity ExecuteStatementResponse metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.1-alpha.3</Version>
+    <Version>0.0.1-alpha.4</Version>
     <!-- SPDX license identifier for MIT -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Other useful metadata -->

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -111,6 +111,54 @@ services.AddLogging(builder =>
 - Query execution emits structured command diagnostics around each `ExecuteStatement` call.
 - Pagination-related warning helps catch unbounded first-page scans on row-limiting queries.
 
+## Response metadata
+
+After a tracking query executes, the raw `ExecuteStatementResponse` from each DynamoDB page is
+accessible on the entity entry:
+
+```csharp
+var item = await context.Items
+    .Where(x => x.Pk == "ITEM#1")
+    .FirstAsync();
+
+var response = context.Entry(item).GetExecuteStatementResponse();
+
+// Always populated — useful for AWS support cases and distributed tracing
+var requestId = response?.ResponseMetadata.RequestId;
+
+// Populated only when ReturnConsumedCapacity was set on the request
+var capacity = response?.ConsumedCapacity;
+```
+
+### Page semantics
+
+- One `ExecuteStatementResponse` is captured per DynamoDB page fetch.
+- Entities from the **same page** share the **same object reference**.
+- Entities from **different pages** hold **different response objects** — useful to correlate
+    cost and request ID by page.
+- The `NextToken` on a non-last-page entity's response has already been consumed by the provider
+    for internally auto-paged queries; do not use it for manual pagination.
+
+### `ConsumedCapacity`
+
+`ConsumedCapacity` is `null` unless `ReturnConsumedCapacity` is set on the underlying
+`ExecuteStatementRequest`. To configure this today, use the low-level client directly:
+
+```csharp
+var client = context.Database.GetDynamoClient();
+// Use client.ExecuteStatementAsync(...) with ReturnConsumedCapacity set
+```
+
+Provider-level configuration for consumed capacity reporting is tracked for a future release.
+
+### `ResponseMetadata.RequestId`
+
+`RequestId` is always populated by DynamoDB. Include it in support tickets or correlation headers:
+
+```csharp
+logger.LogInformation("DynamoDB request {RequestId}", response?.ResponseMetadata.RequestId);
+```
+
 ## External references
 
 - AWS ExecuteStatement API: <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -205,6 +205,26 @@ type or is MISSING, because DynamoDB PartiQL SQL semantics return MISSING (not T
 equality comparisons involving NULL. There is no workaround for this shape at the provider
 level today.
 
+## Per-entity response metadata requires tracking queries
+
+`context.Entry(entity).GetExecuteStatementResponse()` returns `null` for entities loaded via
+`AsNoTracking()` because shadow properties require a tracked `InternalEntityEntry`. The
+`ExecuteStatementResponse` is written into the entity's value buffer during materialization — that
+buffer does not exist for detached entities.
+
+```csharp
+// ✅ Tracking query — response is populated
+var item = await context.Items.Where(x => x.Pk == pk).FirstAsync();
+var response = context.Entry(item).GetExecuteStatementResponse(); // non-null
+
+// ❌ No-tracking query — response is null
+var item = await context.Items.AsNoTracking().Where(x => x.Pk == pk).FirstAsync();
+var response = context.Entry(item).GetExecuteStatementResponse(); // null
+```
+
+To access response metadata on no-tracking queries, use `GetDynamoClient()` to call
+`ExecuteStatementAsync` directly.
+
 ## Owned types query limitations
 
 ### Direct owned collection queries (not supported)

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityEntryExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityEntryExtensions.cs
@@ -1,0 +1,40 @@
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>DynamoDB-specific extension methods for <see cref="EntityEntry" />.</summary>
+public static class DynamoEntityEntryExtensions
+{
+    /// <summary>
+    ///     Returns the <see cref="ExecuteStatementResponse" /> from the DynamoDB page that produced
+    ///     this entity, or <see langword="null" /> when the entity was not loaded from DynamoDB or was
+    ///     loaded via a no-tracking query.
+    /// </summary>
+    /// <param name="entry">The entity entry for the tracked entity.</param>
+    /// <returns>
+    ///     The <see cref="ExecuteStatementResponse" /> for the page that produced this entity, or
+    ///     <see langword="null" /> if unavailable.
+    /// </returns>
+    /// <remarks>
+    ///     <para>
+    ///         For auto-paged queries, entities from different pages return different response objects;
+    ///         entities from the same page share the same object reference.
+    ///     </para>
+    ///     <para>
+    ///         The <c>NextToken</c> on the response represents the pagination cursor after this entity's
+    ///         page — for internally auto-paged queries it has already been consumed by the provider.
+    ///     </para>
+    ///     <para>
+    ///         The <c>ConsumedCapacity</c> field is populated only when <c>ReturnConsumedCapacity</c>
+    ///         was set on the underlying <c>ExecuteStatementRequest</c>. Use
+    ///         <c>context.Database.GetDynamoClient()</c> to configure the request directly.
+    ///     </para>
+    ///     <para>
+    ///         <c>ResponseMetadata.RequestId</c> is always populated and is useful for AWS support cases
+    ///         and distributed tracing.
+    ///     </para>
+    /// </remarks>
+    public static ExecuteStatementResponse? GetExecuteStatementResponse(this EntityEntry entry)
+        => (ExecuteStatementResponse?)entry.Property("__executeStatementResponse").CurrentValue;
+}

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityEntryExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityEntryExtensions.cs
@@ -6,6 +6,8 @@ namespace Microsoft.EntityFrameworkCore;
 /// <summary>DynamoDB-specific extension methods for <see cref="EntityEntry" />.</summary>
 public static class DynamoEntityEntryExtensions
 {
+    private const string ExecuteStatementResponsePropertyName = "__executeStatementResponse";
+
     /// <summary>
     ///     Returns the <see cref="ExecuteStatementResponse" /> from the DynamoDB page that produced
     ///     this entity, or <see langword="null" /> when the entity was not loaded from DynamoDB or was
@@ -36,5 +38,11 @@ public static class DynamoEntityEntryExtensions
     ///     </para>
     /// </remarks>
     public static ExecuteStatementResponse? GetExecuteStatementResponse(this EntityEntry entry)
-        => (ExecuteStatementResponse?)entry.Property("__executeStatementResponse").CurrentValue;
+    {
+        if (entry.Metadata.FindProperty(ExecuteStatementResponsePropertyName) is null)
+            return null;
+
+        return (ExecuteStatementResponse?)entry.Property(ExecuteStatementResponsePropertyName)
+            .CurrentValue;
+    }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
@@ -37,6 +37,10 @@ public static class DynamoPropertyExtensions
         /// <summary>Returns whether this property is runtime-only provider metadata.</summary>
         public bool IsRuntimeOnly()
             => property[DynamoAnnotationNames.RuntimeOnlyProperty] as bool? == true;
+
+        /// <summary>Gets the runtime value source identifier for a runtime-only property.</summary>
+        public string? GetRuntimeValueSource()
+            => property[DynamoAnnotationNames.RuntimeValueSource] as string;
     }
 
     extension(IMutableProperty property)
@@ -50,6 +54,12 @@ public static class DynamoPropertyExtensions
             => property.SetOrRemoveAnnotation(
                 DynamoAnnotationNames.RuntimeOnlyProperty,
                 runtimeOnly ? true : null);
+
+        /// <summary>Sets or clears the runtime value source identifier for this property.</summary>
+        public void SetRuntimeValueSource(string? runtimeValueSource)
+            => property.SetOrRemoveAnnotation(
+                DynamoAnnotationNames.RuntimeValueSource,
+                runtimeValueSource);
     }
 
     extension(IConventionProperty property)
@@ -70,6 +80,19 @@ public static class DynamoPropertyExtensions
             => (bool?)property.SetOrRemoveAnnotation(
                     DynamoAnnotationNames.RuntimeOnlyProperty,
                     runtimeOnly ? true : null,
+                    fromDataAnnotation)
+                ?.Value;
+
+        /// <summary>
+        ///     Sets the runtime value source identifier for this property, recording the configuration
+        ///     source.
+        /// </summary>
+        public string? SetRuntimeValueSource(
+            string? runtimeValueSource,
+            bool fromDataAnnotation = false)
+            => (string?)property.SetOrRemoveAnnotation(
+                    DynamoAnnotationNames.RuntimeValueSource,
+                    runtimeValueSource,
                     fromDataAnnotation)
                 ?.Value;
     }

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
@@ -33,6 +33,10 @@ public static class DynamoPropertyExtensions
         /// </summary>
         public string GetAttributeName()
             => (string?)property[DynamoAnnotationNames.AttributeName] ?? property.Name;
+
+        /// <summary>Returns whether this property is runtime-only provider metadata.</summary>
+        public bool IsRuntimeOnly()
+            => property[DynamoAnnotationNames.RuntimeOnlyProperty] as bool? == true;
     }
 
     extension(IMutableProperty property)
@@ -40,6 +44,12 @@ public static class DynamoPropertyExtensions
         /// <summary>Sets or clears the DynamoDB attribute name override for this property.</summary>
         public void SetAttributeName(string? name)
             => property.SetOrRemoveAnnotation(DynamoAnnotationNames.AttributeName, name);
+
+        /// <summary>Marks this property as runtime-only provider metadata.</summary>
+        public void SetRuntimeOnly(bool runtimeOnly)
+            => property.SetOrRemoveAnnotation(
+                DynamoAnnotationNames.RuntimeOnlyProperty,
+                runtimeOnly ? true : null);
     }
 
     extension(IConventionProperty property)
@@ -49,6 +59,17 @@ public static class DynamoPropertyExtensions
             => (string?)property.SetOrRemoveAnnotation(
                     DynamoAnnotationNames.AttributeName,
                     name,
+                    fromDataAnnotation)
+                ?.Value;
+
+        /// <summary>
+        ///     Sets whether this property is runtime-only provider metadata, recording the configuration
+        ///     source.
+        /// </summary>
+        public bool? SetRuntimeOnly(bool runtimeOnly, bool fromDataAnnotation = false)
+            => (bool?)property.SetOrRemoveAnnotation(
+                    DynamoAnnotationNames.RuntimeOnlyProperty,
+                    runtimeOnly ? true : null,
                     fromDataAnnotation)
                 ?.Value;
     }

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -836,6 +836,11 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
     {
         foreach (var property in typeBase.GetDeclaredProperties())
         {
+            // __executeStatementResponse is a runtime-only shadow property populated by the query
+            // shaper. It holds per-page SDK response metadata and is never serialized to DynamoDB.
+            if (property.Name == "__executeStatementResponse")
+                continue;
+
             // Null-mapping and non-DynamoTypeMapping cases are caught earlier by EF Core's
             // ValidatePropertyMapping via our ThrowPropertyNotMappedException override. Skip
             // those here; only check CanWriteToAttributeValue as defense-in-depth for mappings that

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -836,9 +836,9 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
     {
         foreach (var property in typeBase.GetDeclaredProperties())
         {
-            // __executeStatementResponse is a runtime-only shadow property populated by the query
-            // shaper. It holds per-page SDK response metadata and is never serialized to DynamoDB.
-            if (property.Name == "__executeStatementResponse")
+            // Runtime-only provider metadata is populated outside DynamoDB attribute mapping and
+            // never serialized to the store.
+            if (property.IsRuntimeOnly())
                 continue;
 
             // Null-mapping and non-DynamoTypeMapping cases are caught earlier by EF Core's

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
@@ -27,6 +27,8 @@ public sealed class DynamoConventionSetBuilder(
 
         conventionSet.ModelFinalizingConventions.Add(new OwnedTypePrimaryKeyConvention());
 
+        conventionSet.EntityTypeAddedConventions.Add(new DynamoResponseShadowPropertyConvention());
+
         return conventionSet;
     }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -17,6 +18,8 @@ namespace EntityFrameworkCore.DynamoDb.Metadata.Conventions;
 /// </remarks>
 public sealed class DynamoResponseShadowPropertyConvention : IEntityTypeAddedConvention
 {
+    internal const string ExecuteStatementResponsePropertyName = "__executeStatementResponse";
+
     /// <summary>
     ///     Adds the <c>__executeStatementResponse</c> shadow property when a root entity type is
     ///     registered in the model.
@@ -33,8 +36,12 @@ public sealed class DynamoResponseShadowPropertyConvention : IEntityTypeAddedCon
         if (entityType.BaseType != null || entityType.IsOwned())
             return;
 
-        builder
-            .Property(typeof(ExecuteStatementResponse), "__executeStatementResponse")
+        var propertyBuilder = builder
+            .Property(typeof(ExecuteStatementResponse), ExecuteStatementResponsePropertyName)
             ?.ValueGenerated(ValueGenerated.OnAddOrUpdate);
+
+        propertyBuilder?.Metadata.SetOrRemoveAnnotation(
+            DynamoAnnotationNames.RuntimeOnlyProperty,
+            true);
     }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -40,8 +41,8 @@ public sealed class DynamoResponseShadowPropertyConvention : IEntityTypeAddedCon
             .Property(typeof(ExecuteStatementResponse), ExecuteStatementResponsePropertyName)
             ?.ValueGenerated(ValueGenerated.OnAddOrUpdate);
 
-        propertyBuilder?.Metadata.SetOrRemoveAnnotation(
-            DynamoAnnotationNames.RuntimeOnlyProperty,
-            true);
+        propertyBuilder?.Metadata.SetRuntimeOnly(true);
+        propertyBuilder?.Metadata.SetRuntimeValueSource(
+            DynamoRuntimeValueSources.CurrentPageResponse);
     }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoResponseShadowPropertyConvention.cs
@@ -1,0 +1,40 @@
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EntityFrameworkCore.DynamoDb.Metadata.Conventions;
+
+/// <summary>
+///     Adds an <see cref="ExecuteStatementResponse" /> shadow property to root (non-owned,
+///     non-derived) entity types so that per-entity response metadata can be populated during query
+///     materialization.
+/// </summary>
+/// <remarks>
+///     The property is named <c>__executeStatementResponse</c> and is marked
+///     <see cref="ValueGenerated.OnAddOrUpdate" /> so EF Core treats it as store-managed — it is never
+///     serialized to DynamoDB and is excluded from write plans.
+/// </remarks>
+public sealed class DynamoResponseShadowPropertyConvention : IEntityTypeAddedConvention
+{
+    /// <summary>
+    ///     Adds the <c>__executeStatementResponse</c> shadow property when a root entity type is
+    ///     registered in the model.
+    /// </summary>
+    /// <param name="builder">The entity type builder.</param>
+    /// <param name="context">The convention context.</param>
+    public void ProcessEntityTypeAdded(
+        IConventionEntityTypeBuilder builder,
+        IConventionContext<IConventionEntityTypeBuilder> context)
+    {
+        var entityType = builder.Metadata;
+
+        // Only root, non-owned types — owned types share the page that materialized their owner.
+        if (entityType.BaseType != null || entityType.IsOwned())
+            return;
+
+        builder
+            .Property(typeof(ExecuteStatementResponse), "__executeStatementResponse")
+            ?.ValueGenerated(ValueGenerated.OnAddOrUpdate);
+    }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
@@ -41,4 +41,7 @@ public static class DynamoAnnotationNames
     ///     validation checks.
     /// </summary>
     public const string RuntimeOnlyProperty = Prefix + "RuntimeOnlyProperty";
+
+    /// <summary>Identifies the runtime value source used to materialize a runtime-only property.</summary>
+    public const string RuntimeValueSource = Prefix + "RuntimeValueSource";
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
@@ -34,4 +34,11 @@ public static class DynamoAnnotationNames
 
     /// <summary>Provides functionality for this member.</summary>
     public const string RuntimeTableModel = Prefix + "RuntimeTableModel";
+
+    /// <summary>
+    ///     Marks a property as runtime-only provider metadata. Runtime-only properties are not
+    ///     projected from DynamoDB item attributes and are excluded from write serialization and model
+    ///     validation checks.
+    /// </summary>
+    public const string RuntimeOnlyProperty = Prefix + "RuntimeOnlyProperty";
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoRuntimeValueSources.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoRuntimeValueSources.cs
@@ -1,0 +1,7 @@
+namespace EntityFrameworkCore.DynamoDb.Metadata.Internal;
+
+/// <summary>Known runtime value source identifiers for runtime-only properties.</summary>
+internal static class DynamoRuntimeValueSources
+{
+    internal const string CurrentPageResponse = "CurrentPageResponse";
+}

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -1034,6 +1034,23 @@ public class DynamoProjectionBindingRemovingExpressionVisitor(
                 var property = (IProperty)((ConstantExpression)node.Arguments[2]).Value!;
                 var targetType = node.Type == typeof(object) ? property.ClrType : node.Type;
 
+                // __executeStatementResponse is not stored in the DynamoDB item dictionary —
+                // it is sourced directly from the per-page SDK response held on the query context.
+                if (property.Name == "__executeStatementResponse")
+                {
+                    // Emit: ((DynamoQueryContext)queryContext).CurrentPageResponse
+                    var ctxExpr = Convert(
+                        QueryCompilationContext.QueryContextParameter,
+                        typeof(DynamoQueryContext));
+                    var responseExpr = Property(
+                        ctxExpr,
+                        nameof(DynamoQueryContext.CurrentPageResponse));
+
+                    return responseExpr.Type != node.Type
+                        ? Convert(responseExpr, node.Type)
+                        : responseExpr;
+                }
+
                 // Get type mapping for converter support
                 var typeMapping = property.GetTypeMapping();
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -1034,10 +1034,15 @@ public class DynamoProjectionBindingRemovingExpressionVisitor(
                 var property = (IProperty)((ConstantExpression)node.Arguments[2]).Value!;
                 var targetType = node.Type == typeof(object) ? property.ClrType : node.Type;
 
-                // __executeStatementResponse is not stored in the DynamoDB item dictionary —
-                // it is sourced directly from the per-page SDK response held on the query context.
-                if (property.Name == "__executeStatementResponse")
+                // Runtime-only properties are not stored in the DynamoDB item dictionary.
+                // They must be materialized from query/runtime context.
+                if (property.IsRuntimeOnly())
                 {
+                    if (property.ClrType != typeof(ExecuteStatementResponse))
+                        throw new InvalidOperationException(
+                            $"Runtime-only property '{property.DeclaringType.DisplayName()}.{property.Name}' "
+                            + $"of type '{property.ClrType.ShortDisplayName()}' has no materialization source.");
+
                     // Emit: ((DynamoQueryContext)queryContext).CurrentPageResponse
                     var ctxExpr = Convert(
                         QueryCompilationContext.QueryContextParameter,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
@@ -98,6 +99,16 @@ public class DynamoProjectionBindingRemovingExpressionVisitor(
         typeof(DynamoProjectionBindingRemovingExpressionVisitor).GetMethod(
             nameof(PopulateCollectionOnOwner),
             BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static readonly IReadOnlyDictionary<string, Func<Expression, Expression>>
+        RuntimeValueSourceFactories =
+            new Dictionary<string, Func<Expression, Expression>>(StringComparer.Ordinal)
+            {
+                [DynamoRuntimeValueSources.CurrentPageResponse] = static queryContextParameter
+                    => Property(
+                        Convert(queryContextParameter, typeof(DynamoQueryContext)),
+                        nameof(DynamoQueryContext.CurrentPageResponse)),
+            };
 
     private readonly Stack<ParameterExpression> _attributeContextStack = new([itemParameter]);
     private readonly Stack<ParameterExpression> _ownerAttributeContextStack = new();
@@ -1038,22 +1049,35 @@ public class DynamoProjectionBindingRemovingExpressionVisitor(
                 // They must be materialized from query/runtime context.
                 if (property.IsRuntimeOnly())
                 {
-                    if (property.ClrType != typeof(ExecuteStatementResponse))
+                    var runtimeValueSource = property.GetRuntimeValueSource();
+                    if (string.IsNullOrEmpty(runtimeValueSource))
                         throw new InvalidOperationException(
                             $"Runtime-only property '{property.DeclaringType.DisplayName()}.{property.Name}' "
-                            + $"of type '{property.ClrType.ShortDisplayName()}' has no materialization source.");
+                            + "is missing a runtime value source annotation.");
 
-                    // Emit: ((DynamoQueryContext)queryContext).CurrentPageResponse
-                    var ctxExpr = Convert(
-                        QueryCompilationContext.QueryContextParameter,
-                        typeof(DynamoQueryContext));
-                    var responseExpr = Property(
-                        ctxExpr,
-                        nameof(DynamoQueryContext.CurrentPageResponse));
+                    if (!RuntimeValueSourceFactories.TryGetValue(
+                        runtimeValueSource,
+                        out var runtimeValueFactory))
+                        throw new InvalidOperationException(
+                            $"Runtime-only property '{property.DeclaringType.DisplayName()}.{property.Name}' "
+                            + $"references unknown runtime value source '{runtimeValueSource}'.");
 
-                    return responseExpr.Type != node.Type
-                        ? Convert(responseExpr, node.Type)
-                        : responseExpr;
+                    var runtimeValueExpression = runtimeValueFactory(
+                        QueryCompilationContext.QueryContextParameter);
+                    if (!property.ClrType.IsAssignableFrom(runtimeValueExpression.Type))
+                        throw new InvalidOperationException(
+                            $"Runtime-only property '{property.DeclaringType.DisplayName()}.{property.Name}' "
+                            + $"of type '{property.ClrType.ShortDisplayName()}' cannot be bound from runtime "
+                            + $"value source '{runtimeValueSource}' of type "
+                            + $"'{runtimeValueExpression.Type.ShortDisplayName()}'.");
+
+                    var runtimeBoundExpression = runtimeValueExpression.Type == property.ClrType
+                        ? runtimeValueExpression
+                        : Convert(runtimeValueExpression, property.ClrType);
+
+                    return runtimeBoundExpression.Type != node.Type
+                        ? Convert(runtimeBoundExpression, node.Type)
+                        : runtimeBoundExpression;
                 }
 
                 // Get type mapping for converter support

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContext.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContext.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -20,4 +21,11 @@ public class DynamoQueryContext(
     {
         get;
     } = commandLogger;
+
+    /// <summary>
+    ///     The <see cref="ExecuteStatementResponse" /> from the most recently fetched DynamoDB page.
+    ///     Set by <see cref="DynamoClientWrapper" /> before items from each page are yielded, and read by
+    ///     the shaper expression during materialization to populate the per-entity shadow property.
+    /// </summary>
+    public ExecuteStatementResponse? CurrentPageResponse { get; set; }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -139,7 +139,10 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
                             // Maps directly to ExecuteStatementRequest.Limit (evaluation budget).
                             Limit = _limit,
                         },
-                        _singlePageOnly);
+                        _singlePageOnly,
+                        // Store the raw response on the query context so the shaper can bind it
+                        // to the __executeStatementResponse shadow property of each entity.
+                        response => _queryContext.CurrentPageResponse = response);
 
                     _dataEnumerator = asyncEnumerable.GetAsyncEnumerator(_cancellationToken);
                     _queryContext.InitializeStateManager(_standAloneStateManager);

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/OwnedProjectionMetadata.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/OwnedProjectionMetadata.cs
@@ -65,6 +65,11 @@ internal static class OwnedProjectionMetadata
         if (property.IsOwnedOrdinalKeyProperty())
             return false;
 
+        // Runtime-only metadata is sourced from query/runtime context rather than item attributes,
+        // so it must not be added to SELECT projections.
+        if (property.IsRuntimeOnly())
+            return false;
+
         if (!property.IsShadowProperty())
             return property.GetTypeMapping() != null;
 

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -48,8 +48,9 @@ public class DynamoClientWrapper : IDynamoClientWrapper
     /// <summary>Creates a reusable async enumerable over PartiQL result pages.</summary>
     public IAsyncEnumerable<Dictionary<string, AttributeValue>> ExecutePartiQl(
         ExecuteStatementRequest statementRequest,
-        bool singlePageOnly = false)
-        => new DynamoAsyncEnumerable(this, statementRequest, singlePageOnly);
+        bool singlePageOnly = false,
+        Action<ExecuteStatementResponse>? onPageFetched = null)
+        => new DynamoAsyncEnumerable(this, statementRequest, singlePageOnly, onPageFetched);
 
     /// <summary>Executes a write PartiQL statement (INSERT, UPDATE, DELETE) and discards any result items.</summary>
     /// <param name="statement">The PartiQL write statement to execute.</param>
@@ -152,11 +153,19 @@ public class DynamoClientWrapper : IDynamoClientWrapper
     private sealed class DynamoAsyncEnumerable(
         DynamoClientWrapper dynamoClientWrapper,
         ExecuteStatementRequest statementRequest,
-        bool singlePageOnly) : IAsyncEnumerable<Dictionary<string, AttributeValue>>
+        bool singlePageOnly,
+        Action<ExecuteStatementResponse>? onPageFetched)
+        : IAsyncEnumerable<Dictionary<string, AttributeValue>>
     {
         private readonly DynamoClientWrapper _dynamoClientWrapper = dynamoClientWrapper;
         private readonly bool _singlePageOnly = singlePageOnly;
         private readonly ExecuteStatementRequest _statementRequestPrototype = statementRequest;
+
+        /// <summary>
+        ///     Invoked with the raw SDK response immediately after each page is fetched, before items
+        ///     from that page are yielded. Used to propagate per-page response metadata.
+        /// </summary>
+        private readonly Action<ExecuteStatementResponse>? _onPageFetched = onPageFetched;
 
         /// <summary>Provides functionality for this member.</summary>
         public IAsyncEnumerator<Dictionary<string, AttributeValue>> GetAsyncEnumerator(
@@ -262,6 +271,9 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                 dynamoEnumerable._dynamoClientWrapper._commandLogger.ExecutedExecuteStatement(
                     response.Items?.Count ?? 0,
                     response.NextToken is not null);
+
+                // Notify before items are yielded so callers can capture per-page metadata.
+                dynamoEnumerable._onPageFetched?.Invoke(response);
 
                 _hasExecutedRequest = true;
                 _currentItems = response.Items;

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
@@ -18,9 +18,9 @@ internal sealed class DynamoEntityWritePlanFactory
         var properties = entityType
             .GetProperties()
             .Where(static p => !(p.IsShadowProperty() && p.IsKey()))
-            // __executeStatementResponse is a runtime-only shadow property populated by the shaper;
-            // it must never be serialized to DynamoDB.
-            .Where(static p => p.Name != "__executeStatementResponse")
+            // Runtime-only properties are populated by query/runtime pipelines and must never be
+            // serialized to DynamoDB.
+            .Where(static p => !p.IsRuntimeOnly())
             .ToList();
 
         var propertyWriters = new List<PropertyWriteAction>(properties.Count);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
@@ -18,6 +18,9 @@ internal sealed class DynamoEntityWritePlanFactory
         var properties = entityType
             .GetProperties()
             .Where(static p => !(p.IsShadowProperty() && p.IsKey()))
+            // __executeStatementResponse is a runtime-only shadow property populated by the shaper;
+            // it must never be serialized to DynamoDB.
+            .Where(static p => p.Name != "__executeStatementResponse")
             .ToList();
 
         var propertyWriters = new List<PropertyWriteAction>(properties.Count);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
+using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -41,6 +42,12 @@ public class DynamoTypeMappingSource(TypeMappingSourceDependencies dependencies)
         var clrType = mappingInfo.ClrType;
         if (clrType == null)
             return null;
+
+        // ExecuteStatementResponse is never serialized to DynamoDB — it is held only in the
+        // value buffer as a shadow property. A no-op mapping prevents a null return here which
+        // would cause a model build failure.
+        if (clrType == typeof(ExecuteStatementResponse))
+            return new DynamoTypeMapping(clrType);
 
         var nonNullableType = Nullable.GetUnderlyingType(clrType) ?? clrType;
         if (IsPrimitiveType(nonNullableType))

--- a/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/IDynamoClientWrapper.cs
@@ -9,10 +9,21 @@ public interface IDynamoClientWrapper
     /// <summary>Provides functionality for this member.</summary>
     IAmazonDynamoDB Client { get; }
 
-    /// <summary>Executes a PartiQL statement and streams projected item dictionaries.</summary>
+    /// <summary>Executes a PartiQL statement and streams projected item dictionaries page by page.</summary>
+    /// <param name="statementRequest">The PartiQL statement and execution parameters.</param>
+    /// <param name="singlePageOnly">
+    ///     When <see langword="true" />, stops after the first page regardless of
+    ///     pagination tokens.
+    /// </param>
+    /// <param name="onPageFetched">
+    ///     Optional callback invoked with the raw
+    ///     <see cref="ExecuteStatementResponse" /> immediately after each page is fetched and before its
+    ///     items are yielded.
+    /// </param>
     IAsyncEnumerable<Dictionary<string, AttributeValue>> ExecutePartiQl(
         ExecuteStatementRequest statementRequest,
-        bool singlePageOnly = false);
+        bool singlePageOnly = false,
+        Action<ExecuteStatementResponse>? onPageFetched = null);
 
     /// <summary>Executes a write PartiQL statement (INSERT, UPDATE, DELETE) and discards any result items.</summary>
     /// <param name="statement">The PartiQL write statement to execute.</param>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/ExecuteStatementResponseTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/ExecuteStatementResponseTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SimpleTable;
+
+/// <summary>
+///     Integration tests for per-entity
+///     <see cref="Amazon.DynamoDBv2.Model.ExecuteStatementResponse" /> access via
+///     <c>context.Entry(entity).GetExecuteStatementResponse()</c>.
+/// </summary>
+public class ExecuteStatementResponseTests(SimpleTableDynamoFixture fixture)
+    : SimpleTableTestBase(fixture)
+{
+    // -----------------------------------------------------------------------
+    // Single-page queries (FirstAsync, Limit(n))
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task FirstAsync_PopulatesResponseOnEntry()
+    {
+        var item = await Db.SimpleItems.Where(x => x.Pk == "ITEM#1").FirstAsync(CancellationToken);
+
+        var response = Db.Entry(item).GetExecuteStatementResponse();
+
+        response.Should().NotBeNull();
+        response!
+            .ResponseMetadata
+            .RequestId
+            .Should()
+            .NotBeNullOrEmpty("RequestId is always populated by DynamoDB");
+    }
+
+    [Fact]
+    public async Task ToListAsync_AllEntitiesFromSinglePage_ShareSameResponseReference()
+    {
+        // All 4 seed items fit on a single page — every entity should reference the same
+        // ExecuteStatementResponse object.
+        var items = await Db.SimpleItems.ToListAsync(CancellationToken);
+        items.Should().HaveCountGreaterThan(1);
+
+        var responses = items.Select(item => Db.Entry(item).GetExecuteStatementResponse()).ToList();
+
+        responses.Should().AllSatisfy(r => r.Should().NotBeNull());
+
+        // All entities from the same page share the exact same object reference.
+        var first = responses[0];
+        responses.Should().AllSatisfy(r => r.Should().BeSameAs(first));
+    }
+
+    [Fact]
+    public async Task ToListAsync_WithLimit_PopulatesResponseOnEntities()
+    {
+        var items = await Db.SimpleItems.Limit(2).ToListAsync(CancellationToken);
+        items.Should().HaveCount(2);
+
+        foreach (var item in items)
+        {
+            var response = Db.Entry(item).GetExecuteStatementResponse();
+            response.Should().NotBeNull();
+            response!.ResponseMetadata.RequestId.Should().NotBeNullOrEmpty();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // No-tracking queries
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task NoTracking_GetExecuteStatementResponse_ReturnsNull()
+    {
+        // For no-tracking queries the entity is never materialized into a tracked entry,
+        // so the shadow property value is not populated — GetExecuteStatementResponse returns null.
+        var items = await Db.SimpleItems.AsNoTracking().ToListAsync(CancellationToken);
+        items.Should().NotBeEmpty();
+
+        foreach (var item in items)
+        {
+            // Calling Db.Entry() on a detached entity does not throw, but the shadow
+            // property value was never written since no InternalEntityEntry tracked it.
+            var response = Db.Entry(item).GetExecuteStatementResponse();
+            response.Should().BeNull("per-entity response access requires a tracking query");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Successive queries — each entity carries the response from its own query
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SuccessiveQueries_EachEntityCarriesItsOwnResponse()
+    {
+        // First query
+        var first = await Db.SimpleItems.Where(x => x.Pk == "ITEM#1").FirstAsync(CancellationToken);
+
+        var firstResponse = Db.Entry(first).GetExecuteStatementResponse();
+        firstResponse.Should().NotBeNull();
+
+        // Second query for a different entity
+        var second =
+            await Db.SimpleItems.Where(x => x.Pk == "ITEM#2").FirstAsync(CancellationToken);
+
+        var secondResponse = Db.Entry(second).GetExecuteStatementResponse();
+        secondResponse.Should().NotBeNull();
+
+        // The two responses are distinct objects (different requests, different request IDs).
+        firstResponse!
+            .ResponseMetadata
+            .RequestId
+            .Should()
+            .NotBe(secondResponse!.ResponseMetadata.RequestId);
+
+        // The first entity's shadow property is not mutated by the second query.
+        Db.Entry(first).GetExecuteStatementResponse().Should().BeSameAs(firstResponse);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Extensions/DynamoEntityEntryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Extensions/DynamoEntityEntryExtensionsTests.cs
@@ -1,0 +1,77 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Extensions;
+
+public class DynamoEntityEntryExtensionsTests
+{
+    [Fact]
+    public void GetExecuteStatementResponse_ReturnsNull_ForOwnedEntry()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client);
+
+        var entity = new RootEntity { Pk = "PK#1", Address = new Address { Street = "Main St" } };
+
+        context.Attach(entity);
+
+        var ownedEntry = context.Entry(entity).Reference(x => x.Address).TargetEntry;
+        ownedEntry.Should().NotBeNull();
+
+        var response = ownedEntry!.GetExecuteStatementResponse();
+
+        response.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetExecuteStatementResponse_ReturnsShadowPropertyValue_ForRootEntity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = TestDbContext.Create(client);
+
+        var entity = new RootEntity { Pk = "PK#1", Address = new Address { Street = "Main St" } };
+        context.Attach(entity);
+
+        var expected = new ExecuteStatementResponse();
+        context.Entry(entity).Property("__executeStatementResponse").CurrentValue = expected;
+
+        var response = context.Entry(entity).GetExecuteStatementResponse();
+
+        response.Should().BeSameAs(expected);
+    }
+
+    private sealed record Address
+    {
+        public string Street { get; set; } = null!;
+    }
+
+    private sealed record RootEntity
+    {
+        public string Pk { get; set; } = null!;
+        public Address? Address { get; set; }
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<RootEntity> Items => Set<RootEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<RootEntity>(b =>
+            {
+                b.ToTable("TestTable");
+                b.HasPartitionKey(x => x.Pk);
+                b.OwnsOne(x => x.Address);
+            });
+
+        public static TestDbContext Create(IAmazonDynamoDB client)
+            => new(
+                new DbContextOptionsBuilder<TestDbContext>()
+                    .UseDynamo(options => options.DynamoDbClient(client))
+                    .ConfigureWarnings(w
+                        => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .Options);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoResponseShadowPropertyConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoResponseShadowPropertyConventionTests.cs
@@ -1,0 +1,139 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Metadata.Conventions;
+
+/// <summary>
+///     Tests for <see cref="DynamoResponseShadowPropertyConvention" /> — verifies that the
+///     <c>__executeStatementResponse</c> shadow property is added to root entity types only.
+/// </summary>
+public class DynamoResponseShadowPropertyConventionTests
+{
+    private static DbContextOptions BuildOptions<T>(IAmazonDynamoDB client) where T : DbContext
+        => new DbContextOptionsBuilder<T>()
+            .UseDynamo(o => o.DynamoDbClient(client))
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+    // -----------------------------------------------------------------------
+    // Root entity types receive the shadow property
+    // -----------------------------------------------------------------------
+
+    private sealed record RootEntity
+    {
+        public string PK { get; set; } = null!;
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class RootContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<RootEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<RootEntity>(b => b.ToTable("RootTable"));
+    }
+
+    [Fact]
+    public void Convention_AddsShadowProperty_ToRootEntityTypes()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = new RootContext(BuildOptions<RootContext>(client));
+
+        var entityType = ctx.Model.FindEntityType(typeof(RootEntity))!;
+        var property = entityType.FindProperty("__executeStatementResponse");
+
+        property.Should().NotBeNull();
+        property!.ClrType.Should().Be(typeof(ExecuteStatementResponse));
+        property.IsShadowProperty().Should().BeTrue();
+        property.ValueGenerated.Should().Be(ValueGenerated.OnAddOrUpdate);
+    }
+
+    // -----------------------------------------------------------------------
+    // Owned entity types do NOT receive the shadow property
+    // -----------------------------------------------------------------------
+
+    private sealed record Address
+    {
+        public string Street { get; set; } = null!;
+    }
+
+    private sealed record OrderEntity
+    {
+        public string PK { get; set; } = null!;
+        public Address? ShippingAddress { get; set; }
+    }
+
+    private sealed class OrderContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<OrderEntity> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<OrderEntity>(b =>
+            {
+                b.ToTable("Orders");
+                b.OwnsOne(o => o.ShippingAddress);
+            });
+    }
+
+    [Fact]
+    public void Convention_DoesNotAdd_ToOwnedEntityTypes()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = new OrderContext(BuildOptions<OrderContext>(client));
+
+        var ownedType = ctx.Model.FindEntityType(typeof(Address));
+        ownedType.Should().NotBeNull();
+        ownedType!.IsOwned().Should().BeTrue();
+
+        var property = ownedType.FindProperty("__executeStatementResponse");
+        property.Should().BeNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Derived entity types do NOT receive the shadow property
+    // -----------------------------------------------------------------------
+
+    private abstract class AnimalBase
+    {
+        public string PK { get; set; } = null!;
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class Dog : AnimalBase
+    {
+        public string Breed { get; set; } = null!;
+    }
+
+    private sealed class AnimalContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Dog> Dogs { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<AnimalBase>(b => b.ToTable("Animals"));
+    }
+
+    [Fact]
+    public void Convention_DoesNotAdd_ToDerivedEntityTypes()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = new AnimalContext(BuildOptions<AnimalContext>(client));
+
+        var derived = ctx.Model.FindEntityType(typeof(Dog))!;
+        derived.BaseType.Should().NotBeNull("Dog is a derived type");
+
+        // The property is defined on the root (AnimalBase), not re-added to the derived type
+        var ownDecl =
+            derived
+                .GetDeclaredProperties()
+                .FirstOrDefault(p => p.Name == "__executeStatementResponse");
+        ownDecl.Should().BeNull("derived types must not declare a second copy");
+
+        // But it IS accessible via inheritance on the root
+        var root = ctx.Model.FindEntityType(typeof(AnimalBase))!;
+        root.FindProperty("__executeStatementResponse").Should().NotBeNull();
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoResponseShadowPropertyTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoResponseShadowPropertyTests.cs
@@ -1,0 +1,93 @@
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Update;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
+
+/// <summary>
+///     Tests verifying that the <c>__executeStatementResponse</c> shadow property is correctly
+///     excluded from write plans and that <see cref="ExecuteStatementResponse" /> receives a valid
+///     no-op type mapping so the model builds without error.
+/// </summary>
+public class DynamoResponseShadowPropertyTests
+{
+    // -----------------------------------------------------------------------
+    // Shared fixture
+    // -----------------------------------------------------------------------
+
+    private sealed record Item
+    {
+        public string PK { get; set; } = null!;
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class ItemContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Item> Items { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Item>(b => b.ToTable("Items"));
+    }
+
+    private static ItemContext CreateContext()
+        => new(new DbContextOptionsBuilder<ItemContext>().UseDynamo().Options);
+
+    // -----------------------------------------------------------------------
+    // Write plan exclusion
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void BuildPlan_Excludes_ResponseShadowProperty()
+    {
+        using var ctx = CreateContext();
+
+        var serializer = ctx.GetService<DynamoEntityItemSerializerSource>();
+
+        var entity = new Item { PK = "pk#1", Name = "Test" };
+        ctx.Add(entity);
+
+        // BuildItem must not throw and must not contain the shadow property key.
+        var entry = (IUpdateEntry)ctx.Entry(entity).GetInfrastructure();
+        var item = serializer.BuildItem(entry);
+
+        item.Should().NotContainKey("__executeStatementResponse");
+    }
+
+    // -----------------------------------------------------------------------
+    // Type mapping: ExecuteStatementResponse shadow property gets a non-null mapping
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TypeMapping_FindMapping_ReturnsNonNull_ForExecuteStatementResponse()
+    {
+        using var ctx = CreateContext();
+
+        var entityType = ctx.Model.FindEntityType(typeof(Item))!;
+        var property = entityType.FindProperty("__executeStatementResponse")!;
+
+        // FindTypeMapping must return a non-null DynamoTypeMapping — a null return from
+        // DynamoTypeMappingSource.FindMapping would have caused model build failure already,
+        // but we verify it explicitly here.
+        var mapping = property.FindTypeMapping();
+        mapping.Should().NotBeNull();
+        mapping!.ClrType.Should().Be(typeof(ExecuteStatementResponse));
+    }
+
+    // -----------------------------------------------------------------------
+    // Model builds without error
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Model_BuildsWithoutError_WithResponseShadowProperty()
+    {
+        using var ctx = CreateContext();
+
+        var entityType = ctx.Model.FindEntityType(typeof(Item))!;
+        var shadowProperty = entityType.FindProperty("__executeStatementResponse");
+
+        // Convention should have added it; model finalization must not throw.
+        shadowProperty.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add a runtime-only response shadow property on root entity types and populate it from per-page `ExecuteStatementResponse` metadata during query materialization
- introduce generalized runtime-only property handling via metadata annotations (`RuntimeOnlyProperty` and `RuntimeValueSource`) so runtime values are not projected, validated, or serialized as DynamoDB attributes
- add integration/unit coverage and docs for `EntityEntry.GetExecuteStatementResponse()` semantics, including tracking/no-tracking behavior and page-level response sharing

## Validation
- `dotnet-test-mcp_run_all_tests_for_project` on `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj` (passed)
- `dotnet-test-mcp_run_all_tests_for_project` on `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` (passed)