### PR TITLE
chore(project): refresh solution items and prerelease install docs

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,21 +5,21 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.3.15"
+        "@opencode-ai/plugin": "1.4.1"
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.3.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.15.tgz",
-      "integrity": "sha512-jZJbuvUXc5Limz8pacQl+ffATjjKGlq+xaA4wTUeW+/spwOf7Yr5Ryyvan8eNlYM8wy6h5SLfznl1rlFpjYC8w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.1.tgz",
+      "integrity": "sha512-5PqQGUAVeNPNM6PyQATSe5q7ICwFSIFYEMFHzD6Efw2fSd1ij5vskgtxEZFl/oiXkPx/w8/DPR9EZS9bkoHYnA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.3.15",
+        "@opencode-ai/sdk": "1.4.1",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.96",
-        "@opentui/solid": ">=0.1.96"
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.3.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.15.tgz",
-      "integrity": "sha512-Uk59C7wsK20wpdr277yx7Xz7TqG5jGqlZUpSW3wDH/7a2K2iBg0lXc2wskHuCXLRXMhXpPZtb4a3SOpPENkkbg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.1.tgz",
+      "integrity": "sha512-7wWHs8Og5W5+fuJmHDi7oy1yK6c9mmVfK1Ll9hPHZZ5xj357fVl+oI4i0jeUdjonEoXb3Svq/U5blraSArX5OQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/EntityFrameworkCore.DynamoDb.slnx
+++ b/EntityFrameworkCore.DynamoDb.slnx
@@ -1,25 +1,39 @@
 <Solution>
+  <Folder Name="/docs/">
+    <File Path="docs\architecture.md" />
+    <File Path="docs\concurrency.md" />
+    <File Path="docs\configuration.md" />
+    <File Path="docs\diagnostics.md" />
+    <File Path="docs\index.md" />
+    <File Path="docs\indexes.md" />
+    <File Path="docs\limitations.md" />
+    <File Path="docs\operators.md" />
+    <File Path="docs\owned-types.md" />
+    <File Path="docs\pagination.md" />
+    <File Path="docs\projections.md" />
+  </Folder>
+  <Folder Name="/docs/images/">
+    <File Path="docs\images\icon.png" />
+  </Folder>
   <Folder Name="/examples/">
-    <File Path="examples\Directory.Build.props"/>
-    <Project Path="examples/Example.Simple/Example.Simple.csproj"/>
+    <File Path="examples\Directory.Build.props" />
+    <Project Path="examples/Example.Simple/Example.Simple.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
-    <File Path="CLAUDE.md"/>
-    <File Path="Directory.Build.props"/>
-    <File Path="Directory.Packages.props"/>
-    <File Path="EntityFrameworkCore.DynamoDb.sln.DotSettings"/>
-    <File Path="global.json"/>
-    <File Path="README.md"/>
+    <File Path="CLAUDE.md" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Packages.props" />
+    <File Path="EntityFrameworkCore.DynamoDb.sln.DotSettings" />
+    <File Path="global.json" />
+    <File Path="README.md" />
   </Folder>
   <Folder Name="/src/">
-    <File Path="src\Directory.Build.props"/>
-    <Project Path="src\EntityFrameworkCore.DynamoDb\EntityFrameworkCore.DynamoDb.csproj"/>
+    <File Path="src\Directory.Build.props" />
+    <Project Path="src\EntityFrameworkCore.DynamoDb\EntityFrameworkCore.DynamoDb.csproj" />
   </Folder>
   <Folder Name="/tests/">
-    <File Path="tests\Directory.Build.props"/>
-    <Project
-      Path="tests\EntityFrameworkCore.DynamoDb.IntegrationTests\EntityFrameworkCore.DynamoDb.IntegrationTests.csproj"/>
-    <Project
-      Path="tests\EntityFrameworkCore.DynamoDb.Tests\EntityFrameworkCore.DynamoDb.Tests.csproj"/>
+    <File Path="tests\Directory.Build.props" />
+    <Project Path="tests\EntityFrameworkCore.DynamoDb.IntegrationTests\EntityFrameworkCore.DynamoDb.IntegrationTests.csproj" />
+    <Project Path="tests\EntityFrameworkCore.DynamoDb.Tests\EntityFrameworkCore.DynamoDb.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ This provider translates LINQ queries to PartiQL and executes them with the AWS 
 ## Install
 
 ```bash
-dotnet add package EntityFrameworkCore.DynamoDb
+dotnet add package --prerelease EntityFrameworkCore.DynamoDb
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
Updates the install command in `docs/index.md` to use `--prerelease`, refreshes the tracked items/formatting in `EntityFrameworkCore.DynamoDb.slnx`, and bumps the OpenCode plugin lockfile.

## Changes
- `docs/index.md`: switch install snippet to `dotnet add package --prerelease EntityFrameworkCore.DynamoDb`.
- `EntityFrameworkCore.DynamoDb.slnx`: include docs files/folders and normalize formatting.
- `.opencode/package-lock.json`: bump `@opencode-ai/plugin` (and SDK) to `1.4.1`.

## Validation
Not run locally (docs/tooling-only change).