### PR TITLE
docs: add getting started guide and improve docs home

### DIFF
--- a/EntityFrameworkCore.DynamoDb.slnx
+++ b/EntityFrameworkCore.DynamoDb.slnx
@@ -26,6 +26,7 @@
     <File Path="EntityFrameworkCore.DynamoDb.sln.DotSettings" />
     <File Path="global.json" />
     <File Path="README.md" />
+    <File Path="Taskfile.yml"/>
   </Folder>
   <Folder Name="/src/">
     <File Path="src\Directory.Build.props" />

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,131 @@
+---
+icon: lucide/rocket
+---
+
+# Getting Started
+
+This guide walks through the first end-to-end setup for the provider: install the package, configure DynamoDB, define your context and entity mapping, then execute your first query.
+
+## Add package
+
+```bash
+dotnet add package --prerelease EntityFrameworkCore.DynamoDb
+```
+
+## Configure DynamoDB
+
+Configure the provider once in your application startup (for example `Program.cs`) using `UseDynamo(...)`.
+
+For local development (for example DynamoDB Local), configure the AWS SDK client endpoint in `AddDbContext`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+builder.Services.AddDbContext<AppDbContext>(optionsBuilder =>
+    optionsBuilder.UseDynamo(options =>
+    {
+        options.ConfigureDynamoDbClientConfig(config =>
+        {
+            config.ServiceURL = "http://localhost:8000";
+            config.AuthenticationRegion = "us-east-1";
+            config.UseHttp = true;
+        });
+    }));
+```
+
+!!! note
+
+    Use one configuration location for your app. Prefer startup/DI (`AddDbContext`) and keep
+    `DbContext` focused on model mapping. Use `OnConfiguring` only for special cases such as
+    small samples or tests where DI is not used.
+
+See [Configuration](configuration.md) for client precedence, advanced options, and transaction settings.
+
+## Create context
+
+Define a `DbContext` and register your `DbSet`.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public sealed class AppDbContext : DbContext
+{
+    public DbSet<User> Users => Set<User>();
+
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>(b =>
+        {
+            b.ToTable("App");
+            b.HasPartitionKey(x => x.PK);
+            b.HasSortKey(x => x.SK);
+        });
+    }
+}
+```
+
+## Define table/entity
+
+The provider maps to an existing DynamoDB table. Create the table in AWS (or DynamoDB Local) and map the entity to that table name and key schema.
+
+```csharp
+public sealed class User
+{
+    public required string PK { get; set; }
+    public required string SK { get; set; }
+    public required string Email { get; set; }
+    public required string DisplayName { get; set; }
+}
+```
+
+```csharp
+modelBuilder.Entity<User>(b =>
+{
+    b.ToTable("App");
+    b.HasPartitionKey(x => x.PK);
+    b.HasSortKey(x => x.SK);
+});
+```
+
+!!! note
+
+    Root DynamoDB entities should use `HasPartitionKey(...)` / `HasSortKey(...)`.
+    Do not configure `HasKey(...)` directly on root entities.
+
+See [Indexes](indexes.md) for key conventions and secondary index configuration.
+
+## Execute query
+
+Start with key-based query shapes for predictable behavior.
+Assuming `context` is resolved from DI:
+
+```csharp
+var profile = await context.Users
+    .Where(x => x.PK == "USER#42" && x.SK == "PROFILE")
+    .FirstOrDefaultAsync();
+```
+
+```csharp
+var users = await context.Users
+    .Where(x => x.PK == "ORG#7" && x.SK.StartsWith("USER#"))
+    .OrderBy(x => x.SK)
+    .ToListAsync();
+```
+
+!!! note
+
+    Operator support is intentionally strict. If a LINQ shape is unsupported, translation fails rather than silently switching to client evaluation.
+    Use [Operators](operators.md) as the source of truth.
+
+## Next steps
+
+- [Configuration](configuration.md)
+- [Indexes](indexes.md)
+- [Operators](operators.md)
+- [Limitations](limitations.md)
+- [Diagnostics](diagnostics.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,12 +18,62 @@ This provider translates LINQ queries to PartiQL and executes them with the AWS 
 dotnet add package --prerelease EntityFrameworkCore.DynamoDb
 ```
 
-## Quick Start
+## Start here
 
-1. Configure the provider in your `DbContext` via `UseDynamo(...)`; see [Configuration](configuration.md).
-1. Map your entities to DynamoDB tables and key schema; see [Indexes](indexes.md).
-1. Start with supported LINQ operators from [Operators](operators.md).
-1. Review [Limitations](limitations.md) before adopting query patterns.
+1. Follow [Getting Started](getting-started.md) for package install, DynamoDB configuration,
+    `DbContext` setup, entity/table mapping, and first query execution.
+1. Review [Configuration](configuration.md) for client setup and transaction behavior.
+1. Use [Operators](operators.md) to confirm which LINQ shapes translate today.
+1. Read [Limitations](limitations.md) before adopting production query patterns.
+
+## Hello world
+
+Single-file minimal example from model + context to first query:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public sealed class User
+{
+    public required string PK { get; set; }
+    public required string SK { get; set; }
+    public required string Email { get; set; }
+}
+
+public sealed class AppDbContext : DbContext
+{
+    public DbSet<User> Users => Set<User>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseDynamo(options =>
+        {
+            options.ConfigureDynamoDbClientConfig(config =>
+            {
+                config.ServiceURL = "http://localhost:8000";
+                config.AuthenticationRegion = "us-east-1";
+                config.UseHttp = true;
+            });
+        });
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>(b =>
+        {
+            b.ToTable("App");
+            b.HasPartitionKey(x => x.PK);
+            b.HasSortKey(x => x.SK);
+        });
+    }
+}
+
+await using var context = new AppDbContext();
+
+var profile = await context.Users
+    .Where(x => x.PK == "USER#42" && x.SK == "PROFILE")
+    .FirstOrDefaultAsync();
+```
+
+For the full setup path, use [Getting Started](getting-started.md).
 
 ## Current Scope
 
@@ -44,23 +94,3 @@ dotnet add package --prerelease EntityFrameworkCore.DynamoDb
 
 - Report bugs and request features on [GitHub Issues](https://github.com/LayeredCraft/dynamodb-efcore-provider/issues).
 - For local debugging guidance, use [Diagnostics](diagnostics.md).
-
-## Documentation
-
-- [Configuration](configuration.md)
-- [Indexes](indexes.md)
-- [Architecture](architecture.md)
-- [Concurrency](concurrency.md)
-- [Operators](operators.md)
-- [Pagination](pagination.md)
-- [Projections](projections.md)
-- [Owned Types](owned-types.md)
-- [Diagnostics](diagnostics.md)
-- [Limitations](limitations.md)
-- [Repository README](https://github.com/LayeredCraft/dynamodb-efcore-provider#readme)
-
-## Notes
-
-- `SaveChangesAsync` supports Added/Modified/Deleted root writes, including owned/nested mutations,
-    and follows EF Core `AutoTransactionBehavior` for execution policy (`WhenNeeded`/`Always`
-    transactional for multi-root, `Never` non-atomic batched for multi-root).

--- a/zensical.toml
+++ b/zensical.toml
@@ -36,6 +36,9 @@ line_spans = "__span"
 pygments_lang_class = true
 [project.markdown_extensions.pymdownx.inlinehilite]
 [project.markdown_extensions.pymdownx.snippets]
+[project.markdown_extensions.toc]
+permalink = true
+permalink_title = "Anchor link to this section"
 
 [project.theme]
 logo = "images/icon.png"

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,6 +11,7 @@ docs_dir = "docs"
 
 nav = [
   { "Home" = "index.md" },
+  { "Getting Started" = "getting-started.md" },
   { "Configuration" = "configuration.md" },
   { "Architecture" = "architecture.md" },
   { "Querying" = [


### PR DESCRIPTION
## Summary
- Add a dedicated `Getting Started` guide that walks from package install to first query execution.
- Restructure the docs home page into a concise entry point with a single-file "hello world" example and clear links to key docs.
- Enable heading anchor permalinks site-wide so sections can be deep-linked directly.

## Changes
- Added `docs/getting-started.md` with sections for package install, provider configuration, context setup, table/entity mapping, and query examples.
- Updated `docs/index.md` to include a compact "Start here" flow, a self-contained minimal example, and reduced duplicated/verbose content.
- Updated `zensical.toml` to add `Getting Started` to navigation and enable `[project.markdown_extensions.toc]` permalinks.
- Included `Taskfile.yml` in `EntityFrameworkCore.DynamoDb.slnx` solution items.

## Validation
- Built docs locally with:
  - `uv run zensical build -f zensical.toml`
- Verified generated HTML includes heading permalinks (`&para;`) and anchor title text.