### PR TITLE
test(integration): speed up integration tests via shared fixtures

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/AssemblyFixtures.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/AssemblyFixtures.cs
@@ -1,0 +1,4 @@
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+[assembly: AssemblyFixture(typeof(DynamoContainerFixture))]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/Infra/TestFixture.cs
@@ -3,11 +3,17 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.CompetingGsiTable;
 
-public abstract class CompetingGsiTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class CompetingGsiTableTestFixture : DynamoTestFixtureBase
 {
+    protected CompetingGsiTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            CompetingGsiOrdersTable.TableName,
+            CompetingGsiOrdersTable.CreateTable);
+
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
         => DynamoAutomaticIndexSelectionMode.Off;
+
+    protected override bool UseSharedInternalServiceProvider => false;
 
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/Infra/TestFixture.cs
@@ -3,9 +3,13 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.OwnedTypesTable;
 
-public abstract class OwnedTypesTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class OwnedTypesTableTestFixture : DynamoTestFixtureBase
 {
+    protected OwnedTypesTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            OwnedTypesItemTable.TableName,
+            OwnedTypesItemTable.CreateTable);
+
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 
     public OwnedTypesTableDbContext Db

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/OwnedTypesModelValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/OwnedTypesModelValidationTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.OwnedTypesTable;
 
 /// <summary>Represents the OwnedTypesModelValidationTests type.</summary>
-public class OwnedTypesModelValidationTests : IClassFixture<DynamoContainerFixture>
+public class OwnedTypesModelValidationTests
 {
     private readonly DynamoContainerFixture _fixture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/SelectTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/SelectTests.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 using Microsoft.EntityFrameworkCore;
 
@@ -163,23 +164,39 @@ public class SelectTests(DynamoContainerFixture fixture) : OwnedTypesTableTestFi
         item.Remove("Profile");
         await PutItemAsync(item, CancellationToken);
 
-        var result =
-            await Db
-                .Items
-                .Where(x => x.Pk == "OWNED#MISSINGPROFILE")
-                .Select(x => new { x.Pk, x.Profile!.Address!.City })
-                .AsAsyncEnumerable()
-                .SingleAsync(CancellationToken);
+        try
+        {
+            var result =
+                await Db
+                    .Items
+                    .Where(x => x.Pk == "OWNED#MISSINGPROFILE")
+                    .Select(x => new { x.Pk, x.Profile!.Address!.City })
+                    .AsAsyncEnumerable()
+                    .SingleAsync(CancellationToken);
 
-        result.Pk.Should().Be("OWNED#MISSINGPROFILE");
-        result.City.Should().BeNull();
+            result.Pk.Should().Be("OWNED#MISSINGPROFILE");
+            result.City.Should().BeNull();
 
-        AssertSql(
-            """
-            SELECT "Pk", "Profile"
-            FROM "OwnedTypesItems"
-            WHERE "Pk" = 'OWNED#MISSINGPROFILE'
-            """);
+            AssertSql(
+                """
+                SELECT "Pk", "Profile"
+                FROM "OwnedTypesItems"
+                WHERE "Pk" = 'OWNED#MISSINGPROFILE'
+                """);
+        }
+        finally
+        {
+            await Client.DeleteItemAsync(
+                new DeleteItemRequest
+                {
+                    TableName = OwnedTypesItemTable.TableName,
+                    Key = new Dictionary<string, AttributeValue>
+                    {
+                        ["Pk"] = new() { S = "OWNED#MISSINGPROFILE" },
+                    },
+                },
+                CancellationToken);
+        }
     }
 
     /// <summary>Provides functionality for this member.</summary>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PkSkTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PkSkTable/Infra/TestFixture.cs
@@ -2,9 +2,11 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.PkSkTable;
 
-public abstract class PkSkTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class PkSkTableTestFixture : DynamoTestFixtureBase
 {
+    protected PkSkTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(PkSkItemTable.TableName, PkSkItemTable.CreateTable);
+
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 
     public PkSkTableDbContext Db

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PrimitiveCollectionsTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PrimitiveCollectionsTable/Infra/TestFixture.cs
@@ -2,9 +2,13 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.PrimitiveCollectionsTable;
 
-public abstract class PrimitiveCollectionsTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class PrimitiveCollectionsTableTestFixture : DynamoTestFixtureBase
 {
+    protected PrimitiveCollectionsTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            PrimitiveCollectionsItemTable.TableName,
+            PrimitiveCollectionsItemTable.CreateTable);
+
     public PrimitiveCollectionsDbContext Db
     {
         get

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PrimitiveCollectionsTable/StrictShapeValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/PrimitiveCollectionsTable/StrictShapeValidationTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.PrimitiveCollectionsTable;
 
 /// <summary>Represents the StrictShapeValidationTests type.</summary>
-public class StrictShapeValidationTests : IClassFixture<DynamoContainerFixture>
+public class StrictShapeValidationTests
 {
     private readonly DynamoContainerFixture _fixture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
@@ -3,9 +3,13 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
-public abstract class SaveChangesTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class SaveChangesTableTestFixture : DynamoTestFixtureBase
 {
+    protected SaveChangesTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            SaveChangesItemTable.TableName,
+            SaveChangesItemTable.CreateTable);
+
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 
     public SaveChangesTableDbContext Db

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/Infra/TestFixture.cs
@@ -3,9 +3,14 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SecondaryIndexProjectionTable;
 
-public abstract class SecondaryIndexProjectionTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class SecondaryIndexProjectionTableTestFixture : DynamoTestFixtureBase
 {
+    protected SecondaryIndexProjectionTableTestFixture(DynamoContainerFixture fixture) :
+        base(fixture)
+        => EnsureClassTableInitialized(
+            SecondaryIndexProjectionOrdersTable.TableName,
+            SecondaryIndexProjectionOrdersTable.CreateTable);
+
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
         => DynamoAutomaticIndexSelectionMode.Off;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/Infra/TestFixture.cs
@@ -3,11 +3,17 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SecondaryIndexTable;
 
-public abstract class SecondaryIndexTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class SecondaryIndexTableTestFixture : DynamoTestFixtureBase
 {
+    protected SecondaryIndexTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            SecondaryIndexOrdersTable.TableName,
+            SecondaryIndexOrdersTable.CreateTable);
+
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
         => DynamoAutomaticIndexSelectionMode.Off;
+
+    protected override bool UseSharedInternalServiceProvider => false;
 
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
@@ -31,21 +31,4 @@ public sealed class DynamoContainerFixture(IMessageSink messageSink)
     }
 
     protected override DynamoDbBuilder Configure() => new("amazon/dynamodb-local:latest");
-
-    protected override async ValueTask InitializeAsync()
-    {
-        await base.InitializeAsync();
-
-        var ct = TestContext.Current.CancellationToken;
-        await SimpleItemTable.CreateTable(Client, ct);
-        await SharedItemTable.CreateTable(Client, ct);
-        await SharedTableWithIndexesItemTable.CreateTable(Client, ct);
-        await CompetingGsiOrdersTable.CreateTable(Client, ct);
-        await OwnedTypesItemTable.CreateTable(Client, ct);
-        await PkSkItemTable.CreateTable(Client, ct);
-        await PrimitiveCollectionsItemTable.CreateTable(Client, ct);
-        await SaveChangesItemTable.CreateTable(Client, ct);
-        await SecondaryIndexOrdersTable.CreateTable(Client, ct);
-        await SecondaryIndexProjectionOrdersTable.CreateTable(Client, ct);
-    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
@@ -1,7 +1,12 @@
+using System.Collections.Concurrent;
 using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Extensions;
 using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
@@ -16,19 +21,42 @@ namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 ///     fresh for every test. The buffer is also cleared after each <see cref="AssertSql" /> call,
 ///     allowing multiple assertions within a single test.
 /// </remarks>
-public abstract class DynamoTestFixtureBase(DynamoContainerFixture container)
+public abstract class DynamoTestFixtureBase
 {
+    private readonly DynamoContainerFixture _container;
+
+    private static readonly ConcurrentDictionary<Type, SemaphoreSlim> ClassInitializationLocks =
+        new();
+
+    private static readonly ConcurrentDictionary<Type, bool> InitializedClasses = new();
+
+    private static readonly TestPartiQlLoggerFactory SharedSqlCapture = new();
+
+    private static readonly IServiceProvider SharedServiceProvider = new ServiceCollection()
+        .AddLogging()
+        .AddSingleton<ILoggerFactory>(SharedSqlCapture)
+        .AddEntityFrameworkDynamo()
+        .BuildServiceProvider();
+
     /// <summary>
     ///     The per-test SQL capture logger. Exposed for advanced assertions (pagination,
     ///     diagnostics).
     /// </summary>
-    protected TestPartiQlLoggerFactory SqlCapture { get; } = new();
+    protected TestPartiQlLoggerFactory SqlCapture => SharedSqlCapture;
 
     /// <summary>The shared DynamoDB client backed by the Testcontainers instance.</summary>
-    public IAmazonDynamoDB Client => container.Client;
+    public IAmazonDynamoDB Client => _container.Client;
 
     /// <summary>Cancellation token for the currently executing test.</summary>
     protected CancellationToken CancellationToken => TestContext.Current.CancellationToken;
+
+    protected DynamoTestFixtureBase(DynamoContainerFixture container)
+    {
+        _container = container;
+        SqlCapture.Clear();
+    }
+
+    protected virtual bool UseSharedInternalServiceProvider => true;
 
     /// <summary>
     ///     Builds <see cref="DbContextOptions{TContext}" /> with the DynamoDB provider configured and
@@ -41,10 +69,110 @@ public abstract class DynamoTestFixtureBase(DynamoContainerFixture container)
         // UseDynamo/UseLoggerFactory return the non-generic DbContextOptionsBuilder, so we keep a
         // reference to the typed builder and read Options from it to preserve DbContextOptions<T>.
         var builder = new DbContextOptionsBuilder<T>();
+        if (UseSharedInternalServiceProvider)
+            builder.UseInternalServiceProvider(SharedServiceProvider);
+        else
+            builder.UseLoggerFactory(SqlCapture);
+
         builder.UseDynamo(configure);
-        builder.UseLoggerFactory(SqlCapture);
         builder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
         return builder.Options;
+    }
+
+    protected void EnsureClassTableInitialized(
+        string tableName,
+        Func<IAmazonDynamoDB, CancellationToken, Task> createTable)
+    {
+        var classType = GetType();
+        if (InitializedClasses.ContainsKey(classType))
+            return;
+
+        var gate = ClassInitializationLocks.GetOrAdd(classType, _ => new SemaphoreSlim(1, 1));
+        gate.Wait();
+
+        try
+        {
+            if (InitializedClasses.ContainsKey(classType))
+                return;
+
+            RecreateTable(tableName, createTable);
+            InitializedClasses[classType] = true;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private void RecreateTable(
+        string tableName,
+        Func<IAmazonDynamoDB, CancellationToken, Task> createTable)
+        => RecreateTableAsync(tableName, createTable, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+
+    private async Task RecreateTableAsync(
+        string tableName,
+        Func<IAmazonDynamoDB, CancellationToken, Task> createTable,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Client.DeleteTableAsync(
+                new DeleteTableRequest { TableName = tableName },
+                cancellationToken);
+            await WaitForTableDeletedAsync(tableName, cancellationToken);
+        }
+        catch (ResourceNotFoundException) { }
+
+        await createTable(Client, cancellationToken);
+        await WaitForTableActiveAsync(tableName, cancellationToken);
+    }
+
+    private async Task WaitForTableDeletedAsync(
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                await Client.DescribeTableAsync(
+                    new DescribeTableRequest { TableName = tableName },
+                    cancellationToken);
+            }
+            catch (ResourceNotFoundException)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        }
+    }
+
+    private async Task WaitForTableActiveAsync(
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                var response = await Client.DescribeTableAsync(
+                    new DescribeTableRequest { TableName = tableName },
+                    cancellationToken);
+
+                var table = response.Table;
+                if (table.TableStatus == TableStatus.ACTIVE
+                    && (table.GlobalSecondaryIndexes is null
+                        || table.GlobalSecondaryIndexes.All(i
+                            => i.IndexStatus == IndexStatus.ACTIVE)))
+                    return;
+            }
+            catch (ResourceNotFoundException) { }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        }
     }
 
     /// <summary>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/TestPartiQlLoggerFactory.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/TestPartiQlLoggerFactory.cs
@@ -13,22 +13,49 @@ namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 /// </summary>
 public sealed class TestPartiQlLoggerFactory : ILoggerFactory
 {
-    private readonly TestPartiQlLogger _logger = new();
+    private readonly object _sync = new();
+    private readonly TestPartiQlLogger _logger;
+    private CaptureState _state = new();
     private bool _disposed;
 
+    public TestPartiQlLoggerFactory() => _logger = new TestPartiQlLogger(this);
+
     /// <summary>PartiQL statements captured since the last <see cref="Clear" />.</summary>
-    public IReadOnlyList<string> PartiQlStatements => _logger.PartiQlStatements;
+    public IReadOnlyList<string> PartiQlStatements
+    {
+        get
+        {
+            lock (_sync)
+                return _state.PartiQlStatements.ToArray();
+        }
+    }
 
     /// <summary>ExecuteStatement call metadata captured since the last <see cref="Clear" />.</summary>
     public IReadOnlyList<ExecuteStatementCall> ExecuteStatementCalls
-        => _logger.ExecuteStatementCalls;
+    {
+        get
+        {
+            lock (_sync)
+                return _state.ExecuteStatementCalls.ToArray();
+        }
+    }
 
     /// <summary>Query diagnostic events (index selection) captured since the last <see cref="Clear" />.</summary>
     public IReadOnlyList<QueryDiagnosticEvent> QueryDiagnosticEvents
-        => _logger.QueryDiagnosticEvents;
+    {
+        get
+        {
+            lock (_sync)
+                return _state.QueryDiagnosticEvents.ToArray();
+        }
+    }
 
     /// <summary>Clears all captured state.</summary>
-    public void Clear() => _logger.Clear();
+    public void Clear()
+    {
+        lock (_sync)
+            _state = new CaptureState();
+    }
 
     /// <inheritdoc />
     public ILogger CreateLogger(string categoryName)
@@ -81,19 +108,14 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
         }
     }
 
-    private sealed class TestPartiQlLogger : ILogger
+    private void UpdateState(Action<CaptureState> update)
     {
-        public List<string> PartiQlStatements { get; } = [];
-        public List<ExecuteStatementCall> ExecuteStatementCalls { get; } = [];
-        public List<QueryDiagnosticEvent> QueryDiagnosticEvents { get; } = [];
+        lock (_sync)
+            update(_state);
+    }
 
-        public void Clear()
-        {
-            PartiQlStatements.Clear();
-            ExecuteStatementCalls.Clear();
-            QueryDiagnosticEvents.Clear();
-        }
-
+    private sealed class TestPartiQlLogger(TestPartiQlLoggerFactory factory) : ILogger
+    {
         public bool IsEnabled(LogLevel logLevel) => true;
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
@@ -116,7 +138,7 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
                         .FirstOrDefault()
                     ?? string.Empty;
 
-                PartiQlStatements.Add(commandText);
+                factory.UpdateState(s => s.PartiQlStatements.Add(commandText));
             }
 
             if (eventId.Id == DynamoEventId.ExecutingExecuteStatement.Id
@@ -135,8 +157,9 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
                         .FirstOrDefault()
                     ?? false;
 
-                ExecuteStatementCalls.Add(
-                    new ExecuteStatementCall(limit, nextTokenPresent, null, null));
+                factory.UpdateState(s
+                    => s.ExecuteStatementCalls.Add(
+                        new ExecuteStatementCall(limit, nextTokenPresent, null, null)));
             }
 
             if (eventId.Id == DynamoEventId.ExecutedExecuteStatement.Id
@@ -154,15 +177,18 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
                         .Select(i => (bool?)i.Value)
                         .FirstOrDefault();
 
-                if (ExecuteStatementCalls.Count > 0)
+                factory.UpdateState(captureState =>
                 {
-                    var lastIndex = ExecuteStatementCalls.Count - 1;
-                    var existing = ExecuteStatementCalls[lastIndex];
-                    ExecuteStatementCalls[lastIndex] = existing with
+                    if (captureState.ExecuteStatementCalls.Count == 0)
+                        return;
+
+                    var lastIndex = captureState.ExecuteStatementCalls.Count - 1;
+                    var existing = captureState.ExecuteStatementCalls[lastIndex];
+                    captureState.ExecuteStatementCalls[lastIndex] = existing with
                     {
                         ItemsCount = itemsCount, ResponseNextTokenPresent = nextTokenPresent,
                     };
-                }
+                });
             }
 
             if (eventId.Id == DynamoEventId.NoCompatibleSecondaryIndexFound.Id // IDX001
@@ -171,8 +197,9 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
                 || eventId.Id == DynamoEventId.ExplicitIndexSelected.Id // IDX004
                 || eventId.Id == DynamoEventId.SecondaryIndexCandidateRejected.Id // IDX005
                 || eventId.Id == DynamoEventId.ExplicitIndexSelectionDisabled.Id) // IDX006
-                QueryDiagnosticEvents.Add(
-                    new QueryDiagnosticEvent(eventId, logLevel, formatter(state, exception)));
+                factory.UpdateState(s
+                    => s.QueryDiagnosticEvents.Add(
+                        new QueryDiagnosticEvent(eventId, logLevel, formatter(state, exception))));
         }
 
         private static int? ToNullableInt(object? value)
@@ -193,4 +220,11 @@ public sealed class TestPartiQlLoggerFactory : ILoggerFactory
 
     /// <summary>A captured query diagnostic event (e.g. index selection).</summary>
     public sealed record QueryDiagnosticEvent(EventId EventId, LogLevel LogLevel, string Message);
+
+    private sealed class CaptureState
+    {
+        public List<string> PartiQlStatements { get; } = [];
+        public List<ExecuteStatementCall> ExecuteStatementCalls { get; } = [];
+        public List<QueryDiagnosticEvent> QueryDiagnosticEvents { get; } = [];
+    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/TestFixture.cs
@@ -7,9 +7,11 @@ namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedTable;
 ///     <see cref="DbContext" />; use <see cref="DynamoTestFixtureBase.CreateOptions{T}" /> directly
 ///     for the other context variants.
 /// </summary>
-public class SharedTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public class SharedTableTestFixture : DynamoTestFixtureBase
 {
+    public SharedTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(SharedItemTable.TableName, SharedItemTable.CreateTable);
+
     /// <summary>A fresh <see cref="SharedTableDbContext" /> wired to the per-test SQL capture logger.</summary>
     public SharedTableDbContext Db
         => new(CreateOptions<SharedTableDbContext>(o => o.DynamoDbClient(Client)));

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/SharedTableWithIndexes/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/SharedTableWithIndexes/Infra/TestFixture.cs
@@ -3,11 +3,17 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedTable.SharedTableWithIndexes;
 
-public abstract class SharedTableWithIndexesTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public abstract class SharedTableWithIndexesTestFixture : DynamoTestFixtureBase
 {
+    protected SharedTableWithIndexesTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(
+            SharedTableWithIndexesItemTable.TableName,
+            SharedTableWithIndexesItemTable.CreateTable);
+
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
         => DynamoAutomaticIndexSelectionMode.Conservative;
+
+    protected override bool UseSharedInternalServiceProvider => false;
 
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/Infra/TestFixture.cs
@@ -2,9 +2,11 @@ using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SimpleTable;
 
-public class SimpleTableTestFixture(DynamoContainerFixture fixture)
-    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+public class SimpleTableTestFixture : DynamoTestFixtureBase
 {
+    public SimpleTableTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(SimpleItemTable.TableName, SimpleItemTable.CreateTable);
+
     public SimpleTableDbContext Db
     {
         get


### PR DESCRIPTION
## Summary
This refactors the integration test infrastructure to reduce per-class overhead while keeping each test method on a fresh `DbContext`.

## Changes
- Share the DynamoDB Testcontainers instance across the entire test assembly via an xUnit assembly fixture.
- Reuse EF Core provider infrastructure where safe (shared internal service provider + shared capture logger) to avoid repeated model/provider setup.
- Restore isolation semantics by recreating/initializing tables once per fixture class, and disable test parallelization to prevent concurrent table re-creation.

## Validation
- `tests/EntityFrameworkCore.DynamoDb.IntegrationTests`: 325 passed / 1 skipped

## Notes for reviewers
- Index-selection diagnostic assertions are sensitive to shared logging; `SecondaryIndex*` and `SharedTableWithIndexes` fixtures opt out of the shared internal provider and use `UseLoggerFactory` to keep capture deterministic.