### PR TITLE
fix(query): honor configured attribute names for owned principal key reads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Build
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - beta
+      - release/*
+    tags:
+      - v*
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'ROADMAP.md'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+permissions: write-all
+jobs:
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v7.6
+    with:
+      hasTests: true
+      dotnet-version: |
+        10.0.x
+    secrets: inherit

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,18 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches:
+      - main
+permissions: write-all
+jobs:
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v7.6
+    with:
+      solution: EntityFrameworkCore.DynamoDb.slnx
+      hasTests: true
+      useMtpRunner: true
+      dotnetVersion: |
+        10.0.x
+      runCdk: false
+    secrets: inherit

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.1-alpha</Version>
+    <Version>0.0.2-alpha</Version>
     <!-- SPDX license identifier for MIT -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Other useful metadata -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.1-alpha.4</Version>
+    <Version>0.0.1-alpha</Version>
     <!-- SPDX license identifier for MIT -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Other useful metadata -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,27 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0"/>
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.3"/>
-    <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.4.1-beta.1"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5"/>
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.8" />
+    <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.4.1.37" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Testing Libraries -->
-    <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
-    <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17"/>
-    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.11.0"/>
-    <PackageVersion Include="Testcontainers.XunitV3" Version="4.11.0"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
-    <PackageVersion Include="xunit.v3" Version="3.2.2"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.2.0"/>
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.XunitV3" Version="4.11.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.2.0" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft EF Core (net10.0)">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -1279,7 +1279,7 @@ public class DynamoProjectionBindingRemovingExpressionVisitor(
         }
 
         valueExpression = CreateGetValueExpression(
-            principalProperty.Name,
+            principalProperty.GetAttributeName(),
             targetType,
             principalProperty.GetTypeMapping(),
             !principalProperty.IsNullable,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Data.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Data.cs
@@ -1,0 +1,96 @@
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+/// <summary>Deterministic seed items for naming convention tests.</summary>
+public static class NamingConventionsItems
+{
+    /// <summary>Provides functionality for this member.</summary>
+    public static readonly List<QuestionItem> Items =
+    [
+        new()
+        {
+            Game = "trivia",
+            RecordType = "question",
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Message = "What is the airspeed velocity of an unladen swallow?",
+            DateSubmitted = new DateTimeOffset(2026, 01, 01, 8, 30, 0, TimeSpan.Zero),
+            CategoryId = "general",
+            Tags = ["featured", "vip"],
+            BucketId = 1,
+            BucketKey = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Answers =
+            [
+                new() { Message = "African or European?" },
+                new() { Message = "About 24 mph." },
+                new() { Message = "Roughly 11 m/s." },
+                new() { Message = "It depends on the swallow." },
+            ],
+        },
+        new()
+        {
+            Game = "trivia",
+            RecordType = "question",
+            Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Message = "Name a primary color.",
+            DateSubmitted = new DateTimeOffset(2026, 01, 05, 9, 15, 0, TimeSpan.Zero),
+            CategoryId = null,
+            Tags = ["new"],
+            BucketId = 2,
+            BucketKey = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            Answers =
+            [
+                new() { Message = "Red" },
+                new() { Message = "Blue" },
+                new() { Message = "Yellow" },
+                new() { Message = "Green" },
+            ],
+        },
+        new()
+        {
+            Game = "trivia",
+            RecordType = "question",
+            Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Message = "What time zone is UTC?",
+            DateSubmitted = new DateTimeOffset(2026, 01, 09, 18, 45, 0, TimeSpan.Zero),
+            CategoryId = "general",
+            Tags = [],
+            BucketId = 3,
+            BucketKey = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            Answers =
+            [
+                new() { Message = "Coordinated Universal Time." },
+                new() { Message = "Greenwich Mean Time equivalent for offsets." },
+                new() { Message = "Offset +00:00." },
+                new() { Message = "Zulu time." },
+            ],
+        },
+        new()
+        {
+            Game = "trivia",
+            RecordType = "question",
+            Id = Guid.Parse("44444444-4444-4444-4444-444444444444"),
+            Message = "Edge case: null category and empty tags.",
+            DateSubmitted = new DateTimeOffset(2026, 01, 12, 5, 0, 0, TimeSpan.Zero),
+            CategoryId = null,
+            Tags = [],
+            BucketId = null,
+            BucketKey = null,
+            Answers =
+            [
+                new() { Message = "First option." },
+                new() { Message = "Second option." },
+                new() { Message = "Third option." },
+                new() { Message = "Fourth option." },
+            ],
+        },
+    ];
+
+    /// <summary>Provides functionality for this member.</summary>
+    public static readonly IReadOnlyList<Dictionary<string, AttributeValue>> AttributeValues =
+        CreateAttributeValues();
+
+    /// <summary>Converts deterministic test items to DynamoDB attribute maps.</summary>
+    private static IReadOnlyList<Dictionary<string, AttributeValue>> CreateAttributeValues()
+        => Items.Select(NamingConventionsItemMapper.ToItem).ToList();
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/DbContext.cs
@@ -1,0 +1,55 @@
+using Amazon.DynamoDBv2;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+/// <summary>Represents the OwnedTypesTableDbContext type.</summary>
+public class NamingConventionsTableDbContext(DbContextOptions options) : DbContext(options)
+{
+    /// <summary>Provides functionality for this member.</summary>
+    public DbSet<QuestionItem> Items => Set<QuestionItem>();
+
+    /// <summary>Creates a context configured to use the provided DynamoDB client instance.</summary>
+    public static NamingConventionsTableDbContext Create(IAmazonDynamoDB client)
+        => new(
+            new DbContextOptionsBuilder<NamingConventionsTableDbContext>()
+                .UseDynamo(options => options.DynamoDbClient(client))
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options);
+
+    /// <summary>Configures the owned-shape model used by materialization tests.</summary>
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<QuestionItem>(builder =>
+        {
+            builder.ToTable(NamingConventionsItemTable.TableName);
+            builder.HasPartitionKey(x => x.Pk);
+            builder.HasSortKey(x => x.Sk);
+            builder.Property(x => x.Pk).HasAttributeName("pk");
+            builder.Property(x => x.Sk).HasAttributeName("sk");
+            builder.HasGlobalSecondaryIndex("gs1-index", x => x.Gs1Pk, x => x.Gs1Sk);
+            builder.HasGlobalSecondaryIndex("gs2-index", x => x.Gs2Pk, x => x.Gs2Sk);
+            builder.Property(x => x.Gs1Pk).HasAttributeName("gs1-pk");
+            builder.Property(x => x.Gs1Sk).HasAttributeName("gs1-sk");
+            builder.Property(x => x.Gs2Pk).HasAttributeName("gs2-pk");
+            builder.Property(x => x.Gs2Sk).HasAttributeName("gs2-sk");
+
+            builder.Property(x => x.Id).HasAttributeName("id");
+            builder.Property(x => x.Message).HasAttributeName("message");
+            builder.Property(x => x.RecordType).HasAttributeName("recordType");
+            builder.Property(x => x.DateSubmitted).HasAttributeName("dateSubmitted");
+            builder.Property(x => x.Game).HasAttributeName("game");
+            // b.Property(x => x.Answers).HasAttributeName("answers");
+            builder.Property(x => x.CategoryId).HasAttributeName("categoryId");
+            builder.Property(x => x.Tags).HasAttributeName("tags");
+            builder.Property(x => x.BucketId).HasAttributeName("bucketId");
+            builder.Property(x => x.BucketKey).HasAttributeName("bucketKey");
+            builder.OwnsMany(x => x.Answers, answer =>
+            {
+                answer.HasAttributeName("answers");
+                answer.Property(a => a.Message).HasAttributeName("message");
+            });
+
+            // Intentionally rely on EF Core convention-based owned type discovery in this suite.
+        });
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/DbContext.cs
@@ -39,7 +39,6 @@ public class NamingConventionsTableDbContext(DbContextOptions options) : DbConte
             builder.Property(x => x.RecordType).HasAttributeName("recordType");
             builder.Property(x => x.DateSubmitted).HasAttributeName("dateSubmitted");
             builder.Property(x => x.Game).HasAttributeName("game");
-            // b.Property(x => x.Answers).HasAttributeName("answers");
             builder.Property(x => x.CategoryId).HasAttributeName("categoryId");
             builder.Property(x => x.Tags).HasAttributeName("tags");
             builder.Property(x => x.BucketId).HasAttributeName("bucketId");

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Mappers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Mappers.cs
@@ -1,0 +1,17 @@
+using Amazon.DynamoDBv2.Model;
+using LayeredCraft.DynamoMapper.Runtime;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+
+[DynamoMapper]
+[DynamoField(nameof(QuestionItem.Gs1Pk), AttributeName = "gs1-pk")]
+[DynamoField(nameof(QuestionItem.Gs1Sk), AttributeName = "gs1-sk")]
+[DynamoField(nameof(QuestionItem.Gs2Pk), AttributeName = "gs2-pk")]
+[DynamoField(nameof(QuestionItem.Gs2Sk), AttributeName = "gs2-sk")]
+[DynamoIgnore("IsQuestionRecordType")]
+internal static partial class NamingConventionsItemMapper
+{
+    internal static partial Dictionary<string, AttributeValue> ToItem(QuestionItem source);
+    internal static partial QuestionItem FromItem(Dictionary<string, AttributeValue> item);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Models.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Models.cs
@@ -1,0 +1,106 @@
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+/// <summary>Represents the QuestionItem type.</summary>
+public sealed record QuestionItem
+{
+    private string _pk = null!;
+    private string _sk = null!;
+    private string? _gs1Pk;
+    private string? _gs1Sk;
+    private string? _gs2Pk;
+    private string? _gs2Sk;
+
+    public string Pk => _pk;
+    public string Sk => _sk;
+
+    public Guid Id
+    {
+        get;
+        set
+        {
+            field = value;
+            RecomputeKeys();
+        }
+    }
+
+    public required string Message { get; set; }
+    public required string RecordType
+    {
+        get;
+        set
+        {
+            field = value ?? throw new ArgumentNullException(nameof(value));
+            RecomputeKeys();
+        }
+    }
+    public required string Game
+    {
+        get;
+        set
+        {
+            field = value ?? throw new ArgumentNullException(nameof(value));
+            RecomputeKeys();
+        }
+    }
+
+    public List<AnswerItem> Answers { get; set; } =
+    [
+        new() { Message = string.Empty },
+        new() { Message = string.Empty },
+        new() { Message = string.Empty },
+        new() { Message = string.Empty }
+    ];
+    public DateTimeOffset DateSubmitted { get; set; } = DateTimeOffset.UtcNow;
+    public string? CategoryId
+    {
+        get;
+        set
+        {
+            field = value;
+            RecomputeKeys();
+        }
+    }
+    // TODO: After migration and ensuring this is always set, make this non-nullable.
+    public List<string>? Tags { get; set; } = [];
+    public string? Gs1Pk => _gs1Pk;
+    public string? Gs1Sk => _gs1Sk;
+    public string? Gs2Pk => _gs2Pk;
+    public string? Gs2Sk => _gs2Sk;
+    public int? BucketId
+    {
+        get;
+        set
+        {
+            field = value;
+            RecomputeKeys();
+        }
+    }
+
+    public Guid? BucketKey
+    {
+        get;
+        set
+        {
+            field = value;
+            RecomputeKeys();
+        }
+    }
+    private bool IsQuestionRecordType => string.Equals(RecordType, "question", StringComparison.OrdinalIgnoreCase);
+
+    public void RecomputeKeys()
+    {
+        _pk = $"game#{Game}";
+        _sk = $"record-type#{RecordType}#id#{Id}";
+
+        _gs1Pk = IsQuestionRecordType ? $"game#{Game}#bucket#{BucketId}#" : null;
+        _gs1Sk = IsQuestionRecordType ? $"key#{BucketKey}" : null;
+
+        _gs2Pk = IsQuestionRecordType ? $"game#{Game}#category#{CategoryId ?? "general"}#" : null;
+        _gs2Sk = IsQuestionRecordType ? $"bucket#{BucketId:00}#key#{BucketKey}" : null;
+    }
+
+    public record AnswerItem
+    {
+        public required string Message { get; set; }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Table.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/Table.cs
@@ -1,0 +1,125 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+public static class NamingConventionsItemTable
+{
+    public const string TableName = "NamingConventionsItems";
+
+    public static async Task CreateTable(
+        IAmazonDynamoDB dynamoDb,
+        CancellationToken cancellationToken)
+    {
+        await dynamoDb.CreateTableAsync(
+            new CreateTableRequest
+            {
+                TableName = TableName,
+                AttributeDefinitions =
+                [
+                    new AttributeDefinition
+                    {
+                        AttributeName = "pk", AttributeType = ScalarAttributeType.S,
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "sk", AttributeType = ScalarAttributeType.S,
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "gs1-pk", AttributeType = ScalarAttributeType.S,
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "gs1-sk", AttributeType = ScalarAttributeType.S,
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "gs2-pk", AttributeType = ScalarAttributeType.S,
+                    },
+                    new AttributeDefinition
+                    {
+                        AttributeName = "gs2-sk", AttributeType = ScalarAttributeType.S,
+                    },
+                ],
+                KeySchema =
+                [
+                    new KeySchemaElement { AttributeName = "pk", KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = "sk", KeyType = KeyType.RANGE },
+                ],
+                GlobalSecondaryIndexes =
+                [
+                    new GlobalSecondaryIndex
+                    {
+                        IndexName = "gs1-index",
+                        KeySchema =
+                        [
+                            new KeySchemaElement
+                            {
+                                AttributeName = "gs1-pk",
+                                KeyType = KeyType.HASH,
+                            },
+                            new KeySchemaElement
+                            {
+                                AttributeName = "gs1-sk",
+                                KeyType = KeyType.RANGE,
+                            },
+                        ],
+                        Projection =
+                            new Projection { ProjectionType = ProjectionType.ALL },
+                    },
+                    new GlobalSecondaryIndex
+                    {
+                        IndexName = "gs2-index",
+                        KeySchema =
+                        [
+                            new KeySchemaElement
+                            {
+                                AttributeName = "gs2-pk",
+                                KeyType = KeyType.HASH,
+                            },
+                            new KeySchemaElement
+                            {
+                                AttributeName = "gs2-sk",
+                                KeyType = KeyType.RANGE,
+                            },
+                        ],
+                        Projection =
+                            new Projection { ProjectionType = ProjectionType.ALL },
+                    },
+                ],
+                BillingMode = BillingMode.PAY_PER_REQUEST,
+            },
+            cancellationToken);
+
+        var writeRequests =
+            NamingConventionsItems
+                .AttributeValues
+                .Select(item => new WriteRequest { PutRequest = new PutRequest { Item = item } })
+                .ToList();
+
+        for (var i = 0; i < writeRequests.Count; i += 25)
+        {
+            var batch = writeRequests.Skip(i).Take(25).ToList();
+            await BatchWriteWithRetriesAsync(dynamoDb, batch, cancellationToken);
+        }
+    }
+
+    private static async Task BatchWriteWithRetriesAsync(
+        IAmazonDynamoDB dynamoDb,
+        List<WriteRequest> writeRequests,
+        CancellationToken cancellationToken)
+    {
+        var request = new BatchWriteItemRequest
+        {
+            RequestItems =
+                new Dictionary<string, List<WriteRequest>> { [TableName] = writeRequests },
+        };
+
+        while (request.RequestItems.Count > 0)
+        {
+            var response = await dynamoDb.BatchWriteItemAsync(request, cancellationToken);
+            request.RequestItems = response.UnprocessedItems;
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/Infra/TestFixture.cs
@@ -1,0 +1,27 @@
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+
+public abstract class NamingConventionsTableTestFixture(DynamoContainerFixture fixture)
+    : DynamoTestFixtureBase(fixture), IClassFixture<DynamoContainerFixture>
+{
+    protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
+
+    public NamingConventionsTableDbContext Db
+    {
+        get
+        {
+            field ??= new NamingConventionsTableDbContext(
+                CreateOptions<NamingConventionsTableDbContext>(options => options.DynamoDbClient(Client)));
+            return field;
+        }
+    }
+
+    protected Task PutItemAsync(
+        Dictionary<string, AttributeValue> item,
+        CancellationToken cancellationToken)
+        => Client.PutItemAsync(
+            new PutItemRequest { TableName = NamingConventionsItemTable.TableName, Item = item },
+            cancellationToken);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/SelectTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/SelectTests.cs
@@ -1,0 +1,17 @@
+using EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions;
+
+public class SelectTests(DynamoContainerFixture fixture)
+    : NamingConventionsTableTestFixture(fixture)
+{
+    [Fact]
+    public async Task ToListAsync_MaterializesNamingConventionsAndCollections()
+    {
+        var results = await Db.Items.ToListAsync(CancellationToken);
+
+        var expected = NamingConventionsItems.Items.ToList();
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/SelectTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingConventions/SelectTests.cs
@@ -13,5 +13,13 @@ public class SelectTests(DynamoContainerFixture fixture)
         var results = await Db.Items.ToListAsync(CancellationToken);
 
         var expected = NamingConventionsItems.Items.ToList();
+
+        results.Should().BeEquivalentTo(expected);
+
+        AssertSql(
+            """
+            SELECT "pk", "sk", "bucketId", "bucketKey", "categoryId", "dateSubmitted", "game", "gs1-pk", "gs1-sk", "gs2-pk", "gs2-sk", "id", "message", "recordType", "tags", "answers"
+            FROM "NamingConventionsItems"
+            """);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexWithoutIndexTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexWithoutIndexTests.cs
@@ -46,7 +46,7 @@ public class SecondaryIndexWithoutIndexTests(DynamoContainerFixture fixture)
         await Db
             .Orders
             .WithoutIndex()
-            .Where(o => o.Status == "PENDING")
+            .Where(o => o.Status == "SHIPPED")
             .ToListAsync(CancellationToken);
 
         LoggerFactory

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2;
+using Amazon.Runtime;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.CompetingGsiTable;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.OwnedTypesTable;
@@ -26,6 +27,7 @@ public sealed class DynamoContainerFixture(IMessageSink messageSink)
         get
         {
             field ??= new AmazonDynamoDBClient(
+                new BasicAWSCredentials("test", "test"),
                 new AmazonDynamoDBConfig { ServiceURL = Container.GetConnectionString() });
             return field;
         }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.CompetingGsiTable;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.Infra;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.OwnedTypesTable;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.PkSkTable;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.PrimitiveCollectionsTable;
@@ -47,5 +48,6 @@ public sealed class DynamoContainerFixture(IMessageSink messageSink)
         await SaveChangesItemTable.CreateTable(Client, ct);
         await SecondaryIndexOrdersTable.CreateTable(Client, ct);
         await SecondaryIndexProjectionOrdersTable.CreateTable(Client, ct);
+        await NamingConventionsItemTable.CreateTable(Client, ct);
     }
 }


### PR DESCRIPTION
## Summary
- Fix owned principal-key materialization to read DynamoDB values by configured attribute name metadata (instead of CLR property names), resolving missing `QuestionItem.Pk` under naming conventions.
- Add naming-conventions integration fixtures/models/table setup and deterministic seed data to exercise mapped key/attribute-name and owned collection behavior.
- Update the naming-conventions SELECT baseline assertion and include branch-local CI/package metadata updates currently in this working set.

## Validation
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj --filter-method "EntityFrameworkCore.DynamoDb.IntegrationTests.NamingConventions.SelectTests.ToListAsync_MaterializesNamingConventionsAndCollections" --output Detailed`