### PR TITLE
fix(ci): define VersionPrefix for package-build workflow

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <VersionPrefix>0.0.2-alpha</VersionPrefix>
     <Version>0.0.2-alpha</Version>
     <!-- SPDX license identifier for MIT -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -26,8 +27,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False"/>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="" Visible="False" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="False" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub">


### PR DESCRIPTION
## Summary
- Add `<VersionPrefix>0.0.2-alpha</VersionPrefix>` to `Directory.Build.props`.
- This allows the reusable `package-build` workflow to compose `VERSION` as `<VersionPrefix>.<run_number>`.
- Fixes restore failures caused by an empty `VERSION_PREFIX` producing invalid versions like `.1`.

## Validation
- Confirmed `Directory.Build.props` now contains `VersionPrefix`.
- Expected CI behavior: `dotnet restore` no longer errors with `'.1' is not a valid version string`.