### PR TITLE
test: suppress warnings for multiple service providers in test setups

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexMetadataTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexMetadataTests.cs
@@ -447,7 +447,7 @@ public class SecondaryIndexMetadataTests
     public void HasGlobalSecondaryIndex_DateTimeOffsetWithoutConverter_DoesNotThrow()
     {
         var optionsBuilder = new DbContextOptionsBuilder<DateTimeOffsetGlobalPartitionKeyContext>();
-        optionsBuilder.UseDynamo();
+        UseTestDynamo(optionsBuilder);
 
         var act = () =>
         {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
@@ -248,7 +248,9 @@ public class IndexQueryExtensionsTests
     private static TestDbContext CreateContext()
     {
         var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
-        optionsBuilder.UseDynamo();
+        optionsBuilder
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
         return new TestDbContext(optionsBuilder.Options);
     }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryCompilationContextTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryCompilationContextTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using EntityFrameworkCore.DynamoDb.Query;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -29,7 +30,9 @@ public class QueryCompilationContextTests
     private static QueryCompilationContextDependencies CreateDependencies()
     {
         var dbContextOptionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
-        dbContextOptionsBuilder.UseDynamo();
+        dbContextOptionsBuilder
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
         var dbContext = new TestDbContext(dbContextOptionsBuilder.Options);
         return dbContext.GetService<QueryCompilationContextDependencies>();
     }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
@@ -1,5 +1,6 @@
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Update;
 
@@ -19,7 +20,10 @@ public class DynamoEntityItemSerializerSourceTests
     [Fact]
     public async Task SaveChanges_TableNameWithDoubleQuote_ThrowsArgumentException()
     {
-        var options = new DbContextOptionsBuilder<QuotedTableDbContext>().UseDynamo().Options;
+        var options = new DbContextOptionsBuilder<QuotedTableDbContext>()
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
 
         await using var db = new QuotedTableDbContext(options);
         db.Gadgets.Add(new Gadget { Pk = "G#1", Sk = "G1" });
@@ -33,7 +37,10 @@ public class DynamoEntityItemSerializerSourceTests
     public void BuildItem_ListWithNullableEnumElements_UsesNullAttributeValueForNullElement()
     {
         using var db = new NullableCollectionDbContext(
-            new DbContextOptionsBuilder<NullableCollectionDbContext>().UseDynamo().Options);
+            new DbContextOptionsBuilder<NullableCollectionDbContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options);
 
         var entity = new NullableCollectionEntity
         {
@@ -55,7 +62,10 @@ public class DynamoEntityItemSerializerSourceTests
     public void BuildItem_DictionaryWithNullableEnumValues_UsesNullAttributeValueForNullValue()
     {
         using var db = new NullableCollectionDbContext(
-            new DbContextOptionsBuilder<NullableCollectionDbContext>().UseDynamo().Options);
+            new DbContextOptionsBuilder<NullableCollectionDbContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options);
 
         var entity = new NullableCollectionEntity
         {
@@ -81,7 +91,10 @@ public class DynamoEntityItemSerializerSourceTests
     public void BuildItem_SetWithNullableEnumElements_ThrowsWhenElementIsNull()
     {
         using var db = new NullableCollectionDbContext(
-            new DbContextOptionsBuilder<NullableCollectionDbContext>().UseDynamo().Options);
+            new DbContextOptionsBuilder<NullableCollectionDbContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options);
 
         var entity = new NullableCollectionEntity
         {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoResponseShadowPropertyTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoResponseShadowPropertyTests.cs
@@ -1,6 +1,7 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Update;
 
@@ -32,7 +33,11 @@ public class DynamoResponseShadowPropertyTests
     }
 
     private static ItemContext CreateContext()
-        => new(new DbContextOptionsBuilder<ItemContext>().UseDynamo().Options);
+        => new(
+            new DbContextOptionsBuilder<ItemContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options);
 
     // -----------------------------------------------------------------------
     // Write plan exclusion


### PR DESCRIPTION
## Summary
- Suppress EF Core `ManyServiceProvidersCreatedWarning` in unit tests that create many isolated `DbContext` instances.
- Make warning configuration consistent across affected tests so they do not fail once EF Core crosses the internal service-provider threshold.

## Changes
- Added `.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))` to test option builders in:
  - `IndexQueryExtensionsTests`
  - `QueryCompilationContextTests`
  - `DynamoResponseShadowPropertyTests`
  - `DynamoEntityItemSerializerSourceTests`
- Updated `SecondaryIndexMetadataTests.HasGlobalSecondaryIndex_DateTimeOffsetWithoutConverter_DoesNotThrow` to use the existing `UseTestDynamo(...)` helper for consistent warning behavior.
- Added `Microsoft.EntityFrameworkCore.Diagnostics` imports where required.

## Validation
- `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` (passed: 362)
- `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj` (passed: 331, skipped: 1)