### PR TITLE
fix(dynamodb): align key mapping and naming behavior for table keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,31 @@ b.HasPartitionKey("CustomerId");
 b.HasSortKey("OrderId");
 ```
 
+### Key property requirements
+
+Partition/sort key properties must be mapped as real EF properties that can be materialized.
+
+- Supported: normal settable properties, private-set properties, or getter-only properties with a
+    mapped backing field.
+- Not supported: getter-only computed properties with no setter/backing field (for example
+    `public string Pk => $"game#{Game}";`).
+- Not supported: shadow properties as table keys.
+
+Recommended patterns:
+
+```csharp
+private string _pk = null!;
+public string Pk => _pk;
+
+private void RecomputeKeys() => _pk = $"game#{Game}";
+```
+
+```csharp
+public string Pk { get; private set; } = null!;
+
+private void RecomputeKeys() => Pk = $"game#{Game}";
+```
+
 ## Attribute names
 
 By default, a property is stored in DynamoDB under its CLR property name. Use `HasAttributeName`
@@ -397,6 +422,8 @@ The provider validates the key configuration during model finalization and raise
 `InvalidOperationException` for:
 
 - A partition or sort key property that does not exist on the entity type.
+- A partition or sort key mapped to a runtime-only provider property.
+- A partition or sort key mapped to a shadow property.
 - An explicit root EF primary key configured with `HasKey(...)` or `[Key]`.
 - An internally derived EF primary key that does not match the configured DynamoDB key shape.
 - Entity types sharing a DynamoDB table that disagree on the partition key attribute name or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,10 @@ Properties named `PK` or `PartitionKey` are automatically designated as the Dyna
 key. Properties named `SK` or `SortKey` are automatically designated as the sort key. The
 comparison is case-insensitive (ordinal ignore-case).
 
+Convention-based key discovery only evaluates mapped EF properties. Getter-only/computed members
+are often not included by EF conventions, so configure keys explicitly with
+`HasPartitionKey(...)` / `HasSortKey(...)` for those models.
+
 ```csharp
 public class Order
 {

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
@@ -128,8 +128,8 @@ public static class DynamoEntityTypeBuilderExtensions
         /// <remarks>
         ///     <para>
         ///         At model finalization, the convention is applied to every declared scalar property that
-        ///         does not already have an explicit <c>HasAttributeName(...)</c> override. Shadow properties
-        ///         (provider-internal) are not affected.
+        ///         does not already have an explicit <c>HasAttributeName(...)</c> override. Provider-internal
+        ///         runtime-only and owned-ordinal shadow properties are not affected.
         ///     </para>
         ///     <para>
         ///         Owned entity types without their own convention configured inherit this entity's
@@ -154,8 +154,8 @@ public static class DynamoEntityTypeBuilderExtensions
         ///     <para>
         ///         At model finalization, <paramref name="translator" /> is called with each declared scalar
         ///         property's CLR name and the return value is used as the DynamoDB attribute name. Properties
-        ///         with an explicit <c>HasAttributeName(...)</c> override are not affected. Shadow properties
-        ///         (provider-internal) are not affected.
+        ///         with an explicit <c>HasAttributeName(...)</c> override are not affected. Provider-internal
+        ///         runtime-only and owned-ordinal shadow properties are not affected.
         ///     </para>
         ///     <para>
         ///         Owned entity types without their own convention configured inherit this entity's
@@ -199,8 +199,11 @@ public static class DynamoEntityTypeBuilderExtensions
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
         public EntityTypeBuilder<TEntity> HasPartitionKey(
             Expression<Func<TEntity, object?>> keyExpression)
-            => (EntityTypeBuilder<TEntity>)entityTypeBuilder.HasPartitionKey(
-                EntityTypeBuilder<TEntity>.GetPropertyName(keyExpression));
+        {
+            var propertyName = EntityTypeBuilder<TEntity>.GetPropertyName(keyExpression);
+            _ = entityTypeBuilder.Property(keyExpression);
+            return (EntityTypeBuilder<TEntity>)entityTypeBuilder.HasPartitionKey(propertyName);
+        }
 
         /// <summary>
         ///     Configures which property provides the DynamoDB sort key attribute name for this entity
@@ -217,8 +220,11 @@ public static class DynamoEntityTypeBuilderExtensions
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
         public EntityTypeBuilder<TEntity> HasSortKey(
             Expression<Func<TEntity, object?>> keyExpression)
-            => (EntityTypeBuilder<TEntity>)entityTypeBuilder.HasSortKey(
-                EntityTypeBuilder<TEntity>.GetPropertyName(keyExpression));
+        {
+            var propertyName = EntityTypeBuilder<TEntity>.GetPropertyName(keyExpression);
+            _ = entityTypeBuilder.Property(keyExpression);
+            return (EntityTypeBuilder<TEntity>)entityTypeBuilder.HasSortKey(propertyName);
+        }
 
         /// <summary>Configures a DynamoDB global secondary index that uses only a partition key.</summary>
         /// <returns>A builder for chaining DynamoDB secondary index configuration.</returns>

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -1,5 +1,3 @@
-using EntityFrameworkCore.DynamoDb.Extensions;
-using EntityFrameworkCore.DynamoDb.Metadata;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
@@ -290,6 +288,8 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
                     $"The partition key property '{pkName}' configured on entity type "
                     + $"'{entityType.DisplayName()}' does not exist.");
 
+            ValidateConfiguredKeyPropertyIsSupported(entityType, pkName, "partition key");
+
             if (entityType[DynamoAnnotationNames.SortKeyPropertyName] is not string skName)
                 continue;
 
@@ -297,7 +297,30 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
                 ?? throw new InvalidOperationException(
                     $"The sort key property '{skName}' configured on entity type "
                     + $"'{entityType.DisplayName()}' does not exist.");
+
+            ValidateConfiguredKeyPropertyIsSupported(entityType, skName, "sort key");
         }
+    }
+
+    private static void ValidateConfiguredKeyPropertyIsSupported(
+        IEntityType entityType,
+        string propertyName,
+        string keyRole)
+    {
+        var property = entityType.FindProperty(propertyName);
+        if (property is null)
+            return;
+
+        if (property.IsRuntimeOnly())
+            throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' configures property '{propertyName}' as DynamoDB {keyRole}, "
+                + "but the property is runtime-only provider metadata and cannot be used as a table key.");
+
+        if (property.IsShadowProperty())
+            throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' configures property '{propertyName}' as DynamoDB {keyRole}, "
+                + "but shadow key properties are not supported. Map the key to a CLR property (optionally with "
+                + "a backing field) and call HasPartitionKey(...) / HasSortKey(...) on that member.");
     }
 
     /// <summary>
@@ -790,8 +813,7 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
     /// </summary>
     /// <remarks>
     ///     EF Core's base <c>ValidatePropertyMapping</c> calls this virtual when it finds an
-    ///     explicitly-configured property with no type mapping. Overriding it here lets us surface a
-    ///     DynamoDB-specific message before the generic EF error is emitted.
+    ///     explicitly-configured property with no type mapping. Overriding it here lets usDbLoggerCategory.Model.Validationpecific message before the generic EF error is emitted.
     /// </remarks>
     protected override void
         ThrowPropertyNotMappedException(

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -1,3 +1,5 @@
+using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Metadata;
 using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoAttributeNamingConventionApplier.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoAttributeNamingConventionApplier.cs
@@ -52,10 +52,9 @@ public sealed class DynamoAttributeNamingConventionApplier : IModelFinalizingCon
 
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                // Skip provider-internal shadow properties (owned ordinal keys,
-                // ExecuteStatementResponse metadata, etc.) — they are not DynamoDB
-                // item attributes and should not be renamed.
-                if (property.IsShadowProperty())
+                // Skip provider-internal properties that are never persisted as
+                // user-facing DynamoDB item attributes.
+                if (property.IsRuntimeOnly() || property.IsOwnedOrdinalKeyProperty())
                     continue;
 
                 // Explicit HasAttributeName() or a data annotation always wins —
@@ -99,11 +98,8 @@ public sealed class DynamoAttributeNamingConventionApplier : IModelFinalizingCon
         var current = (IReadOnlyEntityType)entityType;
         while (current is not null)
         {
-            var descriptor =
-                current.FindAnnotation(DynamoAnnotationNames.AttributeNamingConvention)?.Value as
-                    DynamoNamingConventionDescriptor;
-
-            if (descriptor is not null)
+            if (current.FindAnnotation(DynamoAnnotationNames.AttributeNamingConvention)?.Value is
+                DynamoNamingConventionDescriptor descriptor)
                 return descriptor;
 
             current = current.FindOwnership()?.PrincipalEntityType;

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingOverrideTable/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/NamingOverrideTable/Infra/DbContext.cs
@@ -25,8 +25,6 @@ public class NamingConventionsTableDbContext(DbContextOptions options) : DbConte
             builder.ToTable(NamingConventionsItemTable.TableName);
             builder.HasPartitionKey(x => x.Pk);
             builder.HasSortKey(x => x.Sk);
-            builder.Property(x => x.Pk).HasAttributeName("pk");
-            builder.Property(x => x.Sk).HasAttributeName("sk");
             builder.HasGlobalSecondaryIndex("gs1-index", x => x.Gs1Pk, x => x.Gs1Sk);
             builder.HasGlobalSecondaryIndex("gs2-index", x => x.Gs2Pk, x => x.Gs2Sk);
             builder.Property(x => x.Gs1Pk).HasAttributeName("gs1-pk");

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoAttributeNamingConventionApplierTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoAttributeNamingConventionApplierTests.cs
@@ -473,7 +473,7 @@ public class DynamoAttributeNamingConventionApplierTests
     }
 
     // -------------------------------------------------------------------
-    // Shadow properties are skipped
+    // Provider-internal shadow properties are skipped
     // -------------------------------------------------------------------
 
     private sealed record OwnedItem
@@ -502,7 +502,7 @@ public class DynamoAttributeNamingConventionApplierTests
     }
 
     [Fact]
-    public void ShadowProperty_IsSkipped_ByNamingConvention()
+    public void ProviderInternalShadowProperty_IsSkipped_ByNamingConvention()
     {
         var client = Substitute.For<IAmazonDynamoDB>();
         using var ctx = new ShadowPropertyContext(BuildOptions<ShadowPropertyContext>(client));
@@ -512,10 +512,137 @@ public class DynamoAttributeNamingConventionApplierTests
         // CLR property gets snake_case applied
         ownedType.FindProperty(nameof(OwnedItem.Label))!.GetAttributeName().Should().Be("label");
 
-        // The shadow ordinal key (__OwnedOrdinal) must not be renamed — it stays as-is
-        var shadowProps = ownedType.GetProperties().Where(p => p.IsShadowProperty()).ToList();
-        foreach (var shadow in shadowProps)
-            // Shadow property attribute name should equal its original (untransformed) name
-            shadow.GetAttributeName().Should().Be(shadow.Name);
+        // Provider-internal owned ordinal key must not be renamed — it stays as-is
+        var ownedOrdinalProperty =
+            ownedType.GetProperties().Single(p => p.IsOwnedOrdinalKeyProperty());
+        ownedOrdinalProperty.GetAttributeName().Should().Be(ownedOrdinalProperty.Name);
+    }
+
+    private sealed record UserShadowEntity
+    {
+        public string Pk { get; set; } = null!;
+    }
+
+    private sealed class UserShadowPropertyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<UserShadowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<UserShadowEntity>(b =>
+            {
+                b.ToTable("UserShadow");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasAttributeNamingConvention(DynamoAttributeNamingConvention.SnakeCase);
+                b.Property<string>("ShadowValue");
+            });
+    }
+
+    [Fact]
+    public void UserShadowProperty_GetsNamingConventionTranslation()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx =
+            new UserShadowPropertyContext(BuildOptions<UserShadowPropertyContext>(client));
+        var entityType = ctx.Model.FindEntityType(typeof(UserShadowEntity))!;
+
+        entityType.FindProperty("ShadowValue")!.GetAttributeName().Should().Be("shadow_value");
+    }
+
+    private sealed class UserShadowPropertyOverrideContext(DbContextOptions options) : DbContext(
+        options)
+    {
+        public DbSet<UserShadowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<UserShadowEntity>(b =>
+            {
+                b.ToTable("UserShadow");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasAttributeNamingConvention(DynamoAttributeNamingConvention.SnakeCase);
+                b.Property<string>("ShadowValue").HasAttributeName("shadow");
+            });
+    }
+
+    [Fact]
+    public void UserShadowProperty_ExplicitOverride_WinsOverConvention()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx =
+            new UserShadowPropertyOverrideContext(
+                BuildOptions<UserShadowPropertyOverrideContext>(client));
+        var entityType = ctx.Model.FindEntityType(typeof(UserShadowEntity))!;
+
+        entityType.FindProperty("ShadowValue")!.GetAttributeName().Should().Be("shadow");
+    }
+
+    private sealed record AcronymEntity
+    {
+        public string PK { get; set; } = null!;
+        public string SK { get; set; } = null!;
+        public string URLValue { get; set; } = null!;
+    }
+
+    private sealed class AcronymSnakeCaseContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<AcronymEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<AcronymEntity>(b =>
+            {
+                b.ToTable("Acronyms");
+                b.HasPartitionKey(x => x.PK);
+                b.HasSortKey(x => x.SK);
+                b.HasAttributeNamingConvention(DynamoAttributeNamingConvention.SnakeCase);
+            });
+    }
+
+    [Fact]
+    public void Acronyms_UseHumanizerTranslationBehavior()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = new AcronymSnakeCaseContext(BuildOptions<AcronymSnakeCaseContext>(client));
+        var entityType = ctx.Model.FindEntityType(typeof(AcronymEntity))!;
+
+        entityType.FindProperty(nameof(AcronymEntity.PK))!.GetAttributeName().Should().Be("pk");
+        entityType.FindProperty(nameof(AcronymEntity.SK))!.GetAttributeName().Should().Be("sk");
+        entityType.FindProperty(nameof(AcronymEntity.URLValue))!
+            .GetAttributeName()
+            .Should()
+            .Be("url_value");
+    }
+
+    private sealed class ReadOnlyKeyEntity
+    {
+        public string Pk { get; } = string.Empty;
+
+        public string Sk { get; } = string.Empty;
+
+        public string Value { get; set; } = null!;
+    }
+
+    private sealed class ReadOnlyKeyEntityContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ReadOnlyKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<ReadOnlyKeyEntity>(b =>
+            {
+                b.ToTable("ReadOnlyKeyEntity");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasSortKey(x => x.Sk);
+                b.HasAttributeNamingConvention(DynamoAttributeNamingConvention.SnakeCase);
+            });
+    }
+
+    [Fact]
+    public void HasPartitionKeyAndSortKey_LambdaOverloads_MapReadOnlyMembers()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx =
+            new ReadOnlyKeyEntityContext(BuildOptions<ReadOnlyKeyEntityContext>(client));
+        var entityType = ctx.Model.FindEntityType(typeof(ReadOnlyKeyEntity))!;
+
+        entityType.FindProperty(nameof(ReadOnlyKeyEntity.Pk))!.GetAttributeName().Should().Be("pk");
+        entityType.FindProperty(nameof(ReadOnlyKeyEntity.Sk))!.GetAttributeName().Should().Be("sk");
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
@@ -1,6 +1,7 @@
 using Amazon.DynamoDBv2;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using NSubstitute;
 
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
@@ -122,7 +123,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
     }
 
     // -------------------------------------------------------------------
-    // Shadow properties added after key annotations — synthesis should retry
+    // Shadow properties used as configured table keys are rejected
     // -------------------------------------------------------------------
 
     private sealed record LateShadowKeyEntity;
@@ -136,7 +137,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<LateShadowKeyEntity>(b =>
             {
-                b.ToTable("LateShadowKeyTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "LateShadowKeyTable");
                 b.HasPartitionKey("PK");
                 b.HasSortKey("SK");
                 b.Property<string>("PK");
@@ -151,19 +152,17 @@ public class DynamoKeyInPrimaryKeyConventionTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact]
     /// <summary>Provides functionality for this member.</summary>
-    public void HasPartitionAndSortKey_BeforeShadowProperties_AutoConfiguresCompositeEfPrimaryKey()
+    public void HasPartitionAndSortKey_BeforeShadowProperties_ThrowsValidationError()
     {
         var client = Substitute.For<IAmazonDynamoDB>();
-        using var ctx = LateShadowKeyContext.Create(client);
+        var ctx = LateShadowKeyContext.Create(client);
 
-        var entityType = ctx.Model.FindEntityType(typeof(LateShadowKeyEntity))!;
-        var primaryKey = entityType.FindPrimaryKey()!;
+        var act = () => ctx.Model;
 
-        primaryKey.Properties.Should().HaveCount(2);
-        primaryKey.Properties[0].Name.Should().Be("PK");
-        primaryKey.Properties[1].Name.Should().Be("SK");
-        entityType.GetPartitionKeyPropertyName().Should().Be("PK");
-        entityType.GetSortKeyPropertyName().Should().Be("SK");
+        act
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*shadow key properties are not supported*");
     }
 
     // -------------------------------------------------------------------
@@ -189,7 +188,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<SortKeyWithAutoDiscoveredPkEntity>(b =>
             {
-                b.ToTable("AutoDiscoveredPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "AutoDiscoveredPkTable");
                 b.HasSortKey(x => x.Category);
                 // No HasKey, no HasPartitionKey — 'Id' is auto-discovered as the partition key
             });
@@ -238,7 +237,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<RedundantAnnotationEntity>(b =>
             {
-                b.ToTable("RedundantAnnotationTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "RedundantAnnotationTable");
                 b.HasPartitionKey(x => x.Id);
                 // EF would have auto-discovered 'Id' anyway
             });
@@ -286,7 +285,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<ExplicitKeyEntity>(b =>
             {
-                b.ToTable("ExplicitKeyTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "ExplicitKeyTable");
                 b.HasKey(x => new { x.PkProp, x.SkProp });
                 b.HasPartitionKey(x => x.PkProp);
                 b.HasSortKey(x => x.SkProp);
@@ -340,7 +339,7 @@ public class DynamoKeyInPrimaryKeyConventionTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<OwnerWithAnnotationEntity>(b =>
             {
-                b.ToTable("OwnedPartTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "OwnedPartTable");
                 b.HasPartitionKey(x => x.Id);
                 b.OwnsOne(x => x.Detail);
             });

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/TableKeySchemaValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/TableKeySchemaValidationTests.cs
@@ -1,6 +1,7 @@
 using Amazon.DynamoDBv2;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NSubstitute;
 
@@ -155,27 +156,33 @@ public class TableKeySchemaValidationTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact]
     /// <summary>Provides functionality for this member.</summary>
-    public void HasPartitionKey_ShadowProperty_DoesNotThrow()
+    public void HasPartitionKey_ShadowProperty_ThrowsOnValidation()
     {
         var ctx = ShadowPartitionKeyContext.Create(MockClient());
         var act = () => ctx.Model;
-        act.Should().NotThrow();
+        act
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*shadow key properties are not supported*");
     }
 
     /// <summary>Provides functionality for this member.</summary>
     [Fact]
     /// <summary>Provides functionality for this member.</summary>
-    public void HasPartitionKeyAndSortKey_ShadowProperties_DoesNotThrow()
+    public void HasPartitionKeyAndSortKey_ShadowProperties_ThrowOnValidation()
     {
         var ctx = ShadowPartitionAndSortKeyContext.Create(MockClient());
         var act = () => ctx.Model;
-        act.Should().NotThrow();
+        act
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*shadow key properties are not supported*");
     }
 
     /// <summary>Provides functionality for this member.</summary>
     [Fact]
     /// <summary>Provides functionality for this member.</summary>
-    public void SharedTable_ShadowKeyProperties_WithMatchingAttributeNames_DoesNotThrow()
+    public void SharedTable_KeyProperties_WithMatchingAttributeNames_DoesNotThrow()
     {
         var ctx = SharedTableShadowKeyConsistentContext.Create(MockClient());
         var act = () => ctx.Model;
@@ -185,7 +192,7 @@ public class TableKeySchemaValidationTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact]
     /// <summary>Provides functionality for this member.</summary>
-    public void SharedTable_ShadowKeyProperties_WithConflictingPartitionAttributeNames_Throws()
+    public void SharedTable_KeyProperties_WithConflictingPartitionAttributeNames_Throws()
     {
         var ctx = SharedTableShadowKeyConflictingPkContext.Create(MockClient());
         var act = () => ctx.Model;
@@ -319,15 +326,15 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityA>(b =>
             {
-                b.ToTable("SharedTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName("PK1");
+                b.Property(x => x.Id).HasAttributeName<>("PK1");
             });
             modelBuilder.Entity<EntityB>(b =>
             {
-                b.ToTable("SharedTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName("PK2");
+                b.Property(x => x.Id).HasAttributeName<>("PK2");
             });
         }
 
@@ -368,19 +375,19 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityC>(b =>
             {
-                b.ToTable("SharedTable2");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable2");
                 b.HasPartitionKey(x => x.Id);
                 // Map to "PK" so both entities share the same partition key attribute name
-                b.Property(x => x.Id).HasAttributeName("PK");
+                b.Property(x => x.Id).HasAttributeName<>("PK");
                 // single-part key → no sort key detected
             });
             modelBuilder.Entity<EntityD>(b =>
             {
-                b.ToTable("SharedTable2");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable2");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
                 // Map first PK property to "PK" so partition key names match
-                b.Property(x => x.PartId).HasAttributeName("PK");
+                b.Property(x => x.PartId).HasAttributeName<>("PK");
                 // two-part key → sort key "SortId" detected
             });
         }
@@ -425,18 +432,18 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityE>(b =>
             {
-                b.ToTable("SharedTable3");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable3");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
                 // Both share same PK attribute name; differ on SK
-                b.Property(x => x.SortId).HasAttributeName("SK1");
+                b.Property(x => x.SortId).HasAttributeName<>("SK1");
             });
             modelBuilder.Entity<EntityF>(b =>
             {
-                b.ToTable("SharedTable3");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable3");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.SortId).HasAttributeName("SK2");
+                b.Property(x => x.SortId).HasAttributeName<>("SK2");
             });
         }
 
@@ -474,13 +481,13 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityG>(b =>
             {
-                b.ToTable("SharedTable4");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable4");
                 b.HasPartitionKey(x => x.Id);
                 // Both auto-detect "Id" as the PK attribute name (same CLR property name)
             });
             modelBuilder.Entity<EntityH>(b =>
             {
-                b.ToTable("SharedTable4");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable4");
                 b.HasPartitionKey(x => x.Id);
             });
         }
@@ -525,14 +532,14 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityI>(b =>
             {
-                b.ToTable("SharedTable5");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable5");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
                 // Both auto-detect "PartId"/"SortId" as PK/SK attribute names
             });
             modelBuilder.Entity<EntityJ>(b =>
             {
-                b.ToTable("SharedTable5");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable5");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
             });
@@ -575,17 +582,17 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<EntityK>(b =>
             {
-                b.ToTable("TableAlpha");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "TableAlpha");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName("MY_PK");
+                b.Property(x => x.Id).HasAttributeName<>("MY_PK");
             });
             modelBuilder.Entity<EntityL>(b =>
             {
-                b.ToTable("TableBeta");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "TableBeta");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName("HASH");
-                b.Property(x => x.SortId).HasAttributeName("RANGE");
+                b.Property(x => x.PartId).HasAttributeName<>("HASH");
+                b.Property(x => x.SortId).HasAttributeName<>("RANGE");
             });
         }
 
@@ -613,7 +620,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GhostPropEntity>(b =>
             {
-                b.ToTable("GhostPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GhostPkTable");
                 b.HasPartitionKey("Ghost");
             });
 
@@ -631,7 +638,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GhostPropEntity>(b =>
             {
-                b.ToTable("GhostSkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GhostSkTable");
                 b.HasPartitionKey(x => x.Id);
                 b.HasSortKey("Ghost");
             });
@@ -664,7 +671,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<KeyMismatchEntity>(b =>
             {
-                b.ToTable("MismatchPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "MismatchPkTable");
                 b.HasKey(x => x.Id);
                 // SomeProp exists but is NOT in the EF primary key
                 b.HasPartitionKey(x => x.SomeProp);
@@ -684,7 +691,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<KeyMismatchEntity>(b =>
             {
-                b.ToTable("MismatchSkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "MismatchSkTable");
                 b.HasKey(x => x.Id);
                 b.HasPartitionKey(x => x.Id);
                 // SomeProp exists but is NOT in the EF primary key
@@ -723,7 +730,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<NoDiscoverablePkEntity>(b =>
             {
-                b.ToTable("SortKeyOnlyTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SortKeyOnlyTable");
                 // HasSortKey set, but no HasPartitionKey and no auto-discoverable PK property.
                 b.HasSortKey(x => x.RangeAttr);
             });
@@ -734,7 +741,7 @@ public class TableKeySchemaValidationTests
     }
 
     // -------------------------------------------------------------------
-    // Shadow key properties
+    // Shadow key properties (unsupported)
     // -------------------------------------------------------------------
 
     private sealed record ShadowKeyEntity;
@@ -748,7 +755,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<ShadowKeyEntity>(b =>
             {
-                b.ToTable("ShadowPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "ShadowPkTable");
                 b.Property<string>("PK");
                 b.HasPartitionKey("PK");
             });
@@ -768,7 +775,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<ShadowKeyEntity>(b =>
             {
-                b.ToTable("ShadowPkSkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "ShadowPkSkTable");
                 b.Property<string>("PK");
                 b.Property<string>("SK");
                 b.HasPartitionKey("PK");
@@ -780,9 +787,17 @@ public class TableKeySchemaValidationTests
             => new(BuildOptions<ShadowPartitionAndSortKeyContext>(client));
     }
 
-    private sealed record SharedShadowEntityA;
+    private sealed record SharedShadowEntityA
+    {
+        public string InternalPK { get; set; } = null!;
+        public string InternalSK { get; set; } = null!;
+    }
 
-    private sealed record SharedShadowEntityB;
+    private sealed record SharedShadowEntityB
+    {
+        public string OtherPk { get; set; } = null!;
+        public string OtherSk { get; set; } = null!;
+    }
 
     private sealed class SharedTableShadowKeyConsistentContext(DbContextOptions options)
         : DbContext(options)
@@ -798,18 +813,18 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedShadowEntityA>(b =>
             {
-                b.ToTable("SharedShadowTable");
-                b.Property<string>("InternalPK").HasAttributeName("PK");
-                b.Property<string>("InternalSK").HasAttributeName("SK");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowTable");
+                b.Property(x => x.InternalPK).HasAttributeName<>("PK");
+                b.Property(x => x.InternalSK).HasAttributeName<>("SK");
                 b.HasPartitionKey("InternalPK");
                 b.HasSortKey("InternalSK");
             });
 
             modelBuilder.Entity<SharedShadowEntityB>(b =>
             {
-                b.ToTable("SharedShadowTable");
-                b.Property<string>("OtherPk").HasAttributeName("PK");
-                b.Property<string>("OtherSk").HasAttributeName("SK");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowTable");
+                b.Property(x => x.OtherPk).HasAttributeName<>("PK");
+                b.Property(x => x.OtherSk).HasAttributeName<>("SK");
                 b.HasPartitionKey("OtherPk");
                 b.HasSortKey("OtherSk");
             });
@@ -834,18 +849,18 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedShadowEntityA>(b =>
             {
-                b.ToTable("SharedShadowConflictTable");
-                b.Property<string>("InternalPK").HasAttributeName("PK");
-                b.Property<string>("InternalSK").HasAttributeName("SK");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowConflictTable");
+                b.Property(x => x.InternalPK).HasAttributeName<>("PK");
+                b.Property(x => x.InternalSK).HasAttributeName<>("SK");
                 b.HasPartitionKey("InternalPK");
                 b.HasSortKey("InternalSK");
             });
 
             modelBuilder.Entity<SharedShadowEntityB>(b =>
             {
-                b.ToTable("SharedShadowConflictTable");
-                b.Property<string>("OtherPk").HasAttributeName("PK2");
-                b.Property<string>("OtherSk").HasAttributeName("SK");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowConflictTable");
+                b.Property(x => x.OtherPk).HasAttributeName<>("PK2");
+                b.Property(x => x.OtherSk).HasAttributeName<>("SK");
                 b.HasPartitionKey("OtherPk");
                 b.HasSortKey("OtherSk");
             });
@@ -875,7 +890,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<BoolPartitionKeyEntity>(b =>
             {
-                b.ToTable("BoolPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "BoolPkTable");
                 b.HasPartitionKey(x => x.Id);
             });
 
@@ -902,7 +917,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<BoolSortKeyEntity>(b =>
             {
-                b.ToTable("BoolSkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "BoolSkTable");
                 b.HasPartitionKey(x => x.PK);
                 b.HasSortKey(x => x.SK);
             });
@@ -928,7 +943,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
             {
-                b.ToTable("GuidPkNoConverter");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GuidPkNoConverter");
                 b.HasPartitionKey(x => x.Id);
             });
 
@@ -947,7 +962,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
             {
-                b.ToTable("GuidPkWithConverter");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GuidPkWithConverter");
                 b.HasPartitionKey(x => x.Id);
                 b
                     .Property(x => x.Id)
@@ -978,7 +993,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<DateTimeOffsetPartitionKeyEntity>(b =>
             {
-                b.ToTable("DateTimeOffsetPkNoConverter");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "DateTimeOffsetPkNoConverter");
                 b.HasPartitionKey(x => x.Id);
             });
 
@@ -1004,7 +1019,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<NullableProviderPartitionKeyEntity>(b =>
             {
-                b.ToTable("NullableProviderPkTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "NullableProviderPkTable");
                 b.HasPartitionKey(x => x.Id);
                 b
                     .Property(x => x.Id)
@@ -1049,16 +1064,16 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedPartitionTypeEntityA>(b =>
             {
-                b.ToTable("SharedPartitionTypeMismatchTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedPartitionTypeMismatchTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName("PK");
+                b.Property(x => x.Id).HasAttributeName<>("PK");
             });
 
             modelBuilder.Entity<SharedPartitionTypeEntityB>(b =>
             {
-                b.ToTable("SharedPartitionTypeMismatchTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedPartitionTypeMismatchTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName("PK");
+                b.Property(x => x.Id).HasAttributeName<>("PK");
             });
         }
 
@@ -1099,20 +1114,20 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedSortTypeEntityA>(b =>
             {
-                b.ToTable("SharedSortTypeMismatchTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedSortTypeMismatchTable");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName("PK");
-                b.Property(x => x.SortId).HasAttributeName("SK");
+                b.Property(x => x.PartId).HasAttributeName<>("PK");
+                b.Property(x => x.SortId).HasAttributeName<>("SK");
             });
 
             modelBuilder.Entity<SharedSortTypeEntityB>(b =>
             {
-                b.ToTable("SharedSortTypeMismatchTable");
+                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedSortTypeMismatchTable");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName("PK");
-                b.Property(x => x.SortId).HasAttributeName("SK");
+                b.Property(x => x.PartId).HasAttributeName<>("PK");
+                b.Property(x => x.SortId).HasAttributeName<>("SK");
             });
         }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/TableKeySchemaValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/TableKeySchemaValidationTests.cs
@@ -328,13 +328,13 @@ public class TableKeySchemaValidationTests
             {
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName<>("PK1");
+                b.Property(x => x.Id).HasAttributeName("PK1");
             });
             modelBuilder.Entity<EntityB>(b =>
             {
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName<>("PK2");
+                b.Property(x => x.Id).HasAttributeName("PK2");
             });
         }
 
@@ -378,7 +378,7 @@ public class TableKeySchemaValidationTests
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable2");
                 b.HasPartitionKey(x => x.Id);
                 // Map to "PK" so both entities share the same partition key attribute name
-                b.Property(x => x.Id).HasAttributeName<>("PK");
+                b.Property(x => x.Id).HasAttributeName("PK");
                 // single-part key → no sort key detected
             });
             modelBuilder.Entity<EntityD>(b =>
@@ -387,7 +387,7 @@ public class TableKeySchemaValidationTests
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
                 // Map first PK property to "PK" so partition key names match
-                b.Property(x => x.PartId).HasAttributeName<>("PK");
+                b.Property(x => x.PartId).HasAttributeName("PK");
                 // two-part key → sort key "SortId" detected
             });
         }
@@ -436,14 +436,14 @@ public class TableKeySchemaValidationTests
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
                 // Both share same PK attribute name; differ on SK
-                b.Property(x => x.SortId).HasAttributeName<>("SK1");
+                b.Property(x => x.SortId).HasAttributeName("SK1");
             });
             modelBuilder.Entity<EntityF>(b =>
             {
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedTable3");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.SortId).HasAttributeName<>("SK2");
+                b.Property(x => x.SortId).HasAttributeName("SK2");
             });
         }
 
@@ -584,15 +584,15 @@ public class TableKeySchemaValidationTests
             {
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "TableAlpha");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName<>("MY_PK");
+                b.Property(x => x.Id).HasAttributeName("MY_PK");
             });
             modelBuilder.Entity<EntityL>(b =>
             {
                 DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "TableBeta");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName<>("HASH");
-                b.Property(x => x.SortId).HasAttributeName<>("RANGE");
+                b.Property(x => x.PartId).HasAttributeName("HASH");
+                b.Property(x => x.SortId).HasAttributeName("RANGE");
             });
         }
 
@@ -813,18 +813,18 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedShadowEntityA>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowTable");
-                b.Property(x => x.InternalPK).HasAttributeName<>("PK");
-                b.Property(x => x.InternalSK).HasAttributeName<>("SK");
+                ((EntityTypeBuilder)b).ToTable("SharedShadowTable");
+                b.Property(x => x.InternalPK).HasAttributeName("PK");
+                b.Property(x => x.InternalSK).HasAttributeName("SK");
                 b.HasPartitionKey("InternalPK");
                 b.HasSortKey("InternalSK");
             });
 
             modelBuilder.Entity<SharedShadowEntityB>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowTable");
-                b.Property(x => x.OtherPk).HasAttributeName<>("PK");
-                b.Property(x => x.OtherSk).HasAttributeName<>("SK");
+                ((EntityTypeBuilder)b).ToTable("SharedShadowTable");
+                b.Property(x => x.OtherPk).HasAttributeName("PK");
+                b.Property(x => x.OtherSk).HasAttributeName("SK");
                 b.HasPartitionKey("OtherPk");
                 b.HasSortKey("OtherSk");
             });
@@ -849,18 +849,18 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedShadowEntityA>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowConflictTable");
-                b.Property(x => x.InternalPK).HasAttributeName<>("PK");
-                b.Property(x => x.InternalSK).HasAttributeName<>("SK");
+                ((EntityTypeBuilder)b).ToTable("SharedShadowConflictTable");
+                b.Property(x => x.InternalPK).HasAttributeName("PK");
+                b.Property(x => x.InternalSK).HasAttributeName("SK");
                 b.HasPartitionKey("InternalPK");
                 b.HasSortKey("InternalSK");
             });
 
             modelBuilder.Entity<SharedShadowEntityB>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedShadowConflictTable");
-                b.Property(x => x.OtherPk).HasAttributeName<>("PK2");
-                b.Property(x => x.OtherSk).HasAttributeName<>("SK");
+                ((EntityTypeBuilder)b).ToTable("SharedShadowConflictTable");
+                b.Property(x => x.OtherPk).HasAttributeName("PK2");
+                b.Property(x => x.OtherSk).HasAttributeName("SK");
                 b.HasPartitionKey("OtherPk");
                 b.HasSortKey("OtherSk");
             });
@@ -943,7 +943,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GuidPkNoConverter");
+                ((EntityTypeBuilder)b).ToTable("GuidPkNoConverter");
                 b.HasPartitionKey(x => x.Id);
             });
 
@@ -962,7 +962,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "GuidPkWithConverter");
+                ((EntityTypeBuilder)b).ToTable("GuidPkWithConverter");
                 b.HasPartitionKey(x => x.Id);
                 b
                     .Property(x => x.Id)
@@ -993,7 +993,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<DateTimeOffsetPartitionKeyEntity>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "DateTimeOffsetPkNoConverter");
+                ((EntityTypeBuilder)b).ToTable("DateTimeOffsetPkNoConverter");
                 b.HasPartitionKey(x => x.Id);
             });
 
@@ -1019,7 +1019,7 @@ public class TableKeySchemaValidationTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<NullableProviderPartitionKeyEntity>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "NullableProviderPkTable");
+                ((EntityTypeBuilder)b).ToTable("NullableProviderPkTable");
                 b.HasPartitionKey(x => x.Id);
                 b
                     .Property(x => x.Id)
@@ -1064,16 +1064,16 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedPartitionTypeEntityA>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedPartitionTypeMismatchTable");
+                ((EntityTypeBuilder)b).ToTable("SharedPartitionTypeMismatchTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName<>("PK");
+                b.Property(x => x.Id).HasAttributeName("PK");
             });
 
             modelBuilder.Entity<SharedPartitionTypeEntityB>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedPartitionTypeMismatchTable");
+                ((EntityTypeBuilder)b).ToTable("SharedPartitionTypeMismatchTable");
                 b.HasPartitionKey(x => x.Id);
-                b.Property(x => x.Id).HasAttributeName<>("PK");
+                b.Property(x => x.Id).HasAttributeName("PK");
             });
         }
 
@@ -1114,20 +1114,20 @@ public class TableKeySchemaValidationTests
         {
             modelBuilder.Entity<SharedSortTypeEntityA>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedSortTypeMismatchTable");
+                ((EntityTypeBuilder)b).ToTable("SharedSortTypeMismatchTable");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName<>("PK");
-                b.Property(x => x.SortId).HasAttributeName<>("SK");
+                b.Property(x => x.PartId).HasAttributeName("PK");
+                b.Property(x => x.SortId).HasAttributeName("SK");
             });
 
             modelBuilder.Entity<SharedSortTypeEntityB>(b =>
             {
-                DynamoEntityTypeBuilderExtensions.ToTable((EntityTypeBuilder)b, "SharedSortTypeMismatchTable");
+                ((EntityTypeBuilder)b).ToTable("SharedSortTypeMismatchTable");
                 b.HasPartitionKey(x => x.PartId);
                 b.HasSortKey(x => x.SortId);
-                b.Property(x => x.PartId).HasAttributeName<>("PK");
-                b.Property(x => x.SortId).HasAttributeName<>("SK");
+                b.Property(x => x.PartId).HasAttributeName("PK");
+                b.Property(x => x.SortId).HasAttributeName("SK");
             });
         }
 


### PR DESCRIPTION
## Summary
- Apply attribute naming conventions to user-defined shadow properties while still skipping provider-internal runtime-only and owned-ordinal metadata properties.
- Make `HasPartitionKey(...)` and `HasSortKey(...)` lambda overloads map the selected member up front, and fail model validation early when configured table keys are shadow/runtime-only properties.
- Update unit/integration coverage and docs to clarify mapped-property key discovery, key materialization requirements, and supported key modeling patterns.

## Validation
- `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` (366 passed)
- `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj` (331 passed, 1 skipped)