### PR TITLE
fix(storage): omit null GSI key attributes from PartiQL INSERT

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.1
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.1

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -19,7 +19,7 @@ jobs:
   # (e.g. release/net9) and wire up separate caller workflows targeting those branches.
 
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.1
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       dotnetVersion: 10.0.x

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -11,7 +11,7 @@ jobs:
   # (e.g. release/net9) and wire up separate caller workflows targeting those branches.
 
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.1
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       dotnetVersion: 10.0.x

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.1
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
@@ -49,6 +49,21 @@ internal sealed class DynamoSaveChangesPlanner(
                 {
                     var item = serializerSource.BuildItem(entry);
                     var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+
+                    // DynamoDB rejects { NULL: true } for GSI key attributes via PartiQL INSERT.
+                    // Sparse GSIs require these attributes to simply be absent when not applicable.
+                    foreach (var index in entry.EntityType.GetIndexes())
+                    {
+                        if (index.GetSecondaryIndexKind() is null)
+                            continue;
+                        foreach (var property in index.Properties)
+                        {
+                            var attrName = property.GetAttributeName();
+                            if (item.TryGetValue(attrName, out var val) && val.NULL == true)
+                                item.Remove(attrName);
+                        }
+                    }
+
                     var (sql, parameters) = statementFactory.BuildInsertStatement(tableName, item);
 
                     AddCompiledOperation(

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/DbContext.cs
@@ -25,6 +25,8 @@ public class SaveChangesTableDbContext(DbContextOptions options) : DbContext(opt
 
     public DbSet<QuotedAttributeItem> QuotedAttributeItems => Set<QuotedAttributeItem>();
 
+    public DbSet<SparseGsiItem> SparseGsiItems => Set<SparseGsiItem>();
+
     /// <summary>Creates a context configured to use the provided DynamoDB client instance.</summary>
     public static SaveChangesTableDbContext Create(IAmazonDynamoDB client)
         => new(
@@ -142,6 +144,20 @@ public class SaveChangesTableDbContext(DbContextOptions options) : DbContext(opt
             builder.HasSortKey(x => x.Sk);
             builder.Property(x => x.Version).IsConcurrencyToken();
             builder.Property(x => x.DisplayName).HasAttributeName("O'Brien");
+        });
+
+        modelBuilder.Entity<SparseGsiItem>(builder =>
+        {
+            builder.ToTable(SaveChangesItemTable.TableName);
+            builder.HasPartitionKey(x => x.Pk);
+            builder.HasSortKey(x => x.Sk);
+            builder.Property(x => x.Version).IsConcurrencyToken();
+            builder.Property(x => x.Gs1Pk).HasAttributeName("gs1-pk");
+            builder.Property(x => x.Gs1Sk).HasAttributeName("gs1-sk");
+            builder.HasGlobalSecondaryIndex(
+                "gs1-index",
+                nameof(SparseGsiItem.Gs1Pk),
+                nameof(SparseGsiItem.Gs1Sk));
         });
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Models.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Models.cs
@@ -305,3 +305,24 @@ public sealed record Address
 
     public string? PostalCode { get; set; }
 }
+
+/// <summary>
+///     Entity for testing sparse GSI inserts. <c>Gs1Pk</c> and <c>Gs1Sk</c> are nullable so only
+///     items that explicitly populate them participate in the index.
+/// </summary>
+public sealed record SparseGsiItem
+{
+    public string Pk { get; set; } = null!;
+
+    public string Sk { get; set; } = null!;
+
+    public long Version { get; set; }
+
+    public string Name { get; set; } = null!;
+
+    public string? OptionalNote { get; set; }
+
+    public string? Gs1Pk { get; set; }
+
+    public string? Gs1Sk { get; set; }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Table.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Table.cs
@@ -17,19 +17,28 @@ public static class SaveChangesItemTable
                 TableName = TableName,
                 AttributeDefinitions =
                 [
-                    new AttributeDefinition
-                    {
-                        AttributeName = "pk", AttributeType = ScalarAttributeType.S,
-                    },
-                    new AttributeDefinition
-                    {
-                        AttributeName = "sk", AttributeType = ScalarAttributeType.S,
-                    },
+                    new AttributeDefinition { AttributeName = "pk", AttributeType = ScalarAttributeType.S },
+                    new AttributeDefinition { AttributeName = "sk", AttributeType = ScalarAttributeType.S },
+                    new AttributeDefinition { AttributeName = "gs1-pk", AttributeType = ScalarAttributeType.S },
+                    new AttributeDefinition { AttributeName = "gs1-sk", AttributeType = ScalarAttributeType.S },
                 ],
                 KeySchema =
                 [
                     new KeySchemaElement { AttributeName = "pk", KeyType = KeyType.HASH },
                     new KeySchemaElement { AttributeName = "sk", KeyType = KeyType.RANGE },
+                ],
+                GlobalSecondaryIndexes =
+                [
+                    new GlobalSecondaryIndex
+                    {
+                        IndexName = "gs1-index",
+                        KeySchema =
+                        [
+                            new KeySchemaElement { AttributeName = "gs1-pk", KeyType = KeyType.HASH },
+                            new KeySchemaElement { AttributeName = "gs1-sk", KeyType = KeyType.RANGE },
+                        ],
+                        Projection = new Projection { ProjectionType = ProjectionType.ALL },
+                    },
                 ],
                 BillingMode = BillingMode.PAY_PER_REQUEST,
             },

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SparseGsiSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SparseGsiSaveChangesTests.cs
@@ -1,0 +1,94 @@
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>
+///     Verifies the sparse-GSI INSERT behaviour: null GSI key attributes must be absent from the
+///     persisted item (not written as <c>{ NULL: true }</c>), while unrelated nullable scalar
+///     properties retain their <c>{ NULL: true }</c> wire representation.
+/// </summary>
+public class SparseGsiSaveChangesTests(DynamoContainerFixture fixture)
+    : SaveChangesTableTestFixture(fixture)
+{
+    /// <summary>
+    ///     Inserting an item whose GSI key properties are null must succeed and produce a DynamoDB
+    ///     item that does not contain the GSI key attributes at all. DynamoDB rejects
+    ///     <c>{ NULL: true }</c> for attributes that participate in a GSI key definition.
+    /// </summary>
+    [Fact]
+    public async Task AddAsync_WithNullGsiKeys_GsiKeyAttributesAbsentFromItem()
+    {
+        var item = new SparseGsiItem
+        {
+            Pk = "SPARSE#no-gsi",
+            Sk = "ITEM#1",
+            Version = 1,
+            Name = "No GSI participation",
+            Gs1Pk = null,
+            Gs1Sk = null,
+        };
+
+        Db.SparseGsiItems.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
+        raw.Should().NotBeNull();
+        raw!.Should().NotContainKey("gs1-pk");
+        raw.Should().NotContainKey("gs1-sk");
+    }
+
+    /// <summary>
+    ///     A null nullable scalar that is NOT a GSI key must still be persisted as
+    ///     <c>{ NULL: true }</c>. The GSI-key omission must not bleed into unrelated nullable
+    ///     properties.
+    /// </summary>
+    [Fact]
+    public async Task AddAsync_WithNullGsiKeys_NullableScalar_IsWrittenAsNullType()
+    {
+        var item = new SparseGsiItem
+        {
+            Pk = "SPARSE#null-scalar",
+            Sk = "ITEM#2",
+            Version = 1,
+            Name = "Null note",
+            OptionalNote = null,
+            Gs1Pk = null,
+            Gs1Sk = null,
+        };
+
+        Db.SparseGsiItems.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
+        raw.Should().NotBeNull();
+        raw!["optionalNote"].NULL.Should().BeTrue();
+        raw.Should().NotContainKey("gs1-pk");
+        raw.Should().NotContainKey("gs1-sk");
+    }
+
+    /// <summary>
+    ///     When GSI key properties are populated the item must contain the GSI key attributes with
+    ///     the correct string values so the item is visible in the sparse index.
+    /// </summary>
+    [Fact]
+    public async Task AddAsync_WithPopulatedGsiKeys_WritesGsiKeyAttributesToItem()
+    {
+        var item = new SparseGsiItem
+        {
+            Pk = "SPARSE#with-gsi",
+            Sk = "ITEM#3",
+            Version = 1,
+            Name = "GSI participant",
+            Gs1Pk = "partition#active",
+            Gs1Sk = "sort#001",
+        };
+
+        Db.SparseGsiItems.Add(item);
+        await Db.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
+        raw.Should().NotBeNull();
+        raw!["gs1-pk"].S.Should().Be("partition#active");
+        raw["gs1-sk"].S.Should().Be("sort#001");
+    }
+}


### PR DESCRIPTION
## Summary

DynamoDB rejects `{ NULL: true }` for attributes that participate in a GSI key definition. When an entity uses a sparse GSI pattern (nullable GSI key properties that are `null` for items that should not appear in the index), `SaveChangesAsync` threw `AmazonDynamoDBException: Invalid attribute value type` because the provider was including those properties as `NULL`-typed AttributeValues in the PartiQL `INSERT INTO ... VALUE { ... }` statement.

`DynamoSaveChangesPlanner` now strips any GSI key attribute with a `{ NULL: true }` value from the item before building the INSERT statement, matching DynamoDB's natural sparse-GSI behaviour (absent attributes = item not indexed). Regular nullable scalar properties are unaffected and continue to write as `{ NULL: true }`.

## Changes

**Fix — `DynamoSaveChangesPlanner`**
- On `EntityState.Added`, iterate the entity type's indexes; for each GSI, remove any entry from the item where `value.NULL == true` before passing to `BuildInsertStatement`.
- `BuildInsertStatement` itself is unchanged — the fix is scoped to INSERT, where absent = sparse; UPDATE uses SET/REMOVE which already handles this correctly.

**Tests — `SaveChangesTable`**
- `Table.cs`: added `gs1-pk` / `gs1-sk` attribute definitions and a `gs1-index` GSI to the shared `AppItems` table.
- `Models.cs`: added `SparseGsiItem` — a record with nullable `Gs1Pk` / `Gs1Sk` properties.
- `DbContext.cs`: registered `SparseGsiItem` with `HasGlobalSecondaryIndex` configuration.
- `SparseGsiSaveChangesTests.cs`: three new integration tests:
  - `AddAsync_WithNullGsiKeys_GsiKeyAttributesAbsentFromItem` — verifies no exception and GSI attributes absent from raw item.
  - `AddAsync_WithNullGsiKeys_NullableScalar_IsWrittenAsNullType` — regression guard: non-GSI nullable scalars still write as `{ NULL: true }`.
  - `AddAsync_WithPopulatedGsiKeys_WritesGsiKeyAttributesToItem` — verifies GSI attributes present with correct values when populated.

## Validation

- `dotnet build` on provider and integration test project: 0 errors, 0 warnings.
- Integration tests exercised against DynamoDB Local via Testcontainers.

## Notes for Reviewers

The fix intentionally targets only the `EntityState.Added` path in `DynamoSaveChangesPlanner`. The `Modified` path uses PartiQL `UPDATE ... SET / REMOVE`, where `REMOVE` already handles absent-attribute semantics correctly for null GSI keys — no change needed there.

An earlier attempt applied the null-skip inside `BuildInsertStatement` unconditionally, which broke the existing `AddAsync_NullableScalar_IsWrittenAsNull` test (non-GSI nullable scalars must still write as `{ NULL: true }`). The per-GSI-key targeted approach fixes that regression.

## Related Issues

Closes #180