### PR TITLE
fix(query): omit Parameters from ExecuteStatementRequest when empty

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -146,7 +146,7 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
                         new ExecuteStatementRequest
                         {
                             Statement = sqlQuery.Sql,
-                            Parameters = sqlQuery.Parameters.ToList(),
+                            Parameters = sqlQuery.Parameters.Count > 0 ? sqlQuery.Parameters.ToList() : null,
                             // Maps directly to ExecuteStatementRequest.Limit (evaluation budget).
                             Limit = _limit,
                             NextToken = _seedNextToken,
@@ -293,7 +293,7 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
                     new ExecuteStatementRequest
                     {
                         Statement = sqlQuery.Sql,
-                        Parameters = sqlQuery.Parameters.ToList(),
+                        Parameters = sqlQuery.Parameters.Count > 0 ? sqlQuery.Parameters.ToList() : null,
                         Limit = _limit,
                         NextToken = _seedNextToken,
                     },

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -66,7 +66,8 @@ public class DynamoClientWrapper : IDynamoClientWrapper
             {
                 var request = new ExecuteStatementRequest
                 {
-                    Statement = state.statement, Parameters = state.parameters,
+                    Statement = state.statement,
+                    Parameters = state.parameters?.Count > 0 ? state.parameters : null,
                 };
 
                 await Client.ExecuteStatementAsync(request, ct).ConfigureAwait(false);

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/ParameterlessQueryTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/ParameterlessQueryTests.cs
@@ -1,0 +1,53 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedTable;
+
+/// <summary>
+///     Regression tests for the bug where ExecuteStatementRequest.Parameters was set to an empty
+///     list when a PartiQL query contained no parameterized placeholders, causing real DynamoDB to
+///     reject the request with a validation error (Members must have length >= 1). DynamoDB Local
+///     is lenient about this; the tests below use a mock client to verify the actual request shape.
+/// </summary>
+public class ParameterlessQueryTests
+{
+    private static IAmazonDynamoDB CreateMockClient(List<ExecuteStatementRequest> captured)
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(captured.Add),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new ExecuteStatementResponse { Items = [] }));
+        return client;
+    }
+
+    [Fact]
+    public async Task ToListAsync_SharedTableWithDiscriminator_SendsNullParameters()
+    {
+        var captured = new List<ExecuteStatementRequest>();
+        await using var ctx = SharedTableDbContext.Create(CreateMockClient(captured));
+
+        // Produces: WHERE "pk" = 'TENANT#U' AND "$type" = 'UserEntity' — all literals, no ?
+        _ = await ctx.Users.Where(u => u.Pk == "TENANT#U").ToListAsync();
+
+        captured.Should().ContainSingle();
+        captured[0].Parameters.Should().BeNullOrEmpty(
+            "DynamoDB rejects Parameters = [] — must be null or absent when there are no placeholders");
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_SharedTableWithDiscriminator_SendsNullParameters()
+    {
+        var captured = new List<ExecuteStatementRequest>();
+        await using var ctx = SharedTableDbContext.Create(CreateMockClient(captured));
+
+        _ = await ctx.Users.Where(u => u.Pk == "TENANT#U" && u.Sk == "USER#1").FirstOrDefaultAsync();
+
+        captured.Should().ContainSingle();
+        captured[0].Parameters.Should().BeNullOrEmpty();
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
@@ -194,6 +194,67 @@ public class DynamoClientWrapperTests
         wrapper.Client.Config.UseHttp.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ExecuteWriteAsync_WithEmptyParameters_OmitsParametersFromRequest()
+    {
+        var diagnosticsLogger =
+            Substitute.For<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
+        diagnosticsLogger.Logger.Returns(NullLogger.Instance);
+
+        var executionStrategy = new TestExecutionStrategy();
+        var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
+
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ExecuteStatementResponse()));
+
+        var wrapper = new TestDynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            client);
+
+        await wrapper.ExecuteWriteAsync("INSERT INTO \"Test\" VALUE {'pk': 'a', 'sk': 'b'}", []);
+
+        await client
+            .Received(1)
+            .ExecuteStatementAsync(
+                Arg.Is<ExecuteStatementRequest>(r => r.Parameters == null),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteWriteAsync_WithNonEmptyParameters_SendsParametersInRequest()
+    {
+        var diagnosticsLogger =
+            Substitute.For<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
+        diagnosticsLogger.Logger.Returns(NullLogger.Instance);
+
+        var executionStrategy = new TestExecutionStrategy();
+        var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
+
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ExecuteStatementResponse()));
+
+        var wrapper = new TestDynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            client);
+
+        var parameters = new List<AttributeValue> { new() { S = "val" } };
+        await wrapper.ExecuteWriteAsync("INSERT INTO \"Test\" VALUE {'pk': ?}", parameters);
+
+        await client
+            .Received(1)
+            .ExecuteStatementAsync(
+                Arg.Is<ExecuteStatementRequest>(r => r.Parameters != null && r.Parameters.Count == 1),
+                Arg.Any<CancellationToken>());
+    }
+
     private static async Task<List<Dictionary<string, AttributeValue>>> EnumerateAsync(
         IAsyncEnumerable<Dictionary<string, AttributeValue>> enumerable)
     {


### PR DESCRIPTION
## Summary

- DynamoDB rejects `ExecuteStatement` calls where `Parameters = []` (empty list) — it requires the field to be absent or contain ≥ 1 entry
- When PartiQL queries use only inlined literal values (no `?` placeholders), `sqlQuery.Parameters` is empty and was unconditionally sent as an empty list
- Fixed by guarding with `Count > 0` before setting `Parameters`, falling back to `null` — applies to both the paginated enumerable path and the single-page `ToList` path in `QueryingEnumerable.cs`, and the write path in `DynamoClientWrapper.cs`

## Test plan

- [ ] Existing tests pass
- [ ] Execute a GSI query where all predicate values are inlined literals (e.g. discriminator + partition key constant) — no `AmazonDynamoDBException` with `parameters` constraint violation

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)