### PR TITLE
feat(query)!: enable automatic index selection by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,37 +6,44 @@ execution.
 ## Quick Map
 
 - Provider code: `src/EntityFrameworkCore.DynamoDb/`
-- Tests: `tests/EntityFrameworkCore.DynamoDb.Tests/`
-- Query pipeline entry points:
-  - Translation:
-    `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs`
-  - Compilation:
-    `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.cs`
-  - PartiQL generation: `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs`
-  - Execution: `src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs`
-  - Type mapping: `src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs`
+- Unit tests: `tests/EntityFrameworkCore.DynamoDb.Tests/`
+- Integration tests: `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/`
+- Test placement rules: `tests/AGENTS.md`
+- Translation:
+  `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs`
+- Compilation:
+  `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.cs`
+- PartiQL generation: `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs`
+- Execution: `src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs`
+- Type mapping: `src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs`
+
+## Commands
+
+- Build: `dotnet build`
+- Run tests through the .NET test MCP server whenever available.
+- Unit test project:
+  `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj`
+- Integration test project:
+  `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj`
+- Docs: `task docs:build`
 
 ## Change Workflow
 
 - Start with a failing or new test.
-- For query behavior changes, update translation, add/adjust expressions if needed, update SQL
-  generation, and verify type mapping/materialization.
+- For query behavior changes, update translation, expressions if needed, PartiQL generation, and
+  materialization/type mapping.
 - Keep changes small; cover both translation and execution behavior.
 
 ## Docs Requirement (Behavior Changes)
 
-- Update `docs/operators.md` and relevant topical docs (`docs/pagination.md`, `docs/projections.md`,
-  `docs/configuration.md`, `docs/diagnostics.md`, `docs/limitations.md`, `docs/architecture.md`).
+- Query behavior docs: `docs/querying/`
+- Configuration/modeling docs: `docs/configuration/`, `docs/modeling/`
+- Saving docs: `docs/saving/`
+- Diagnostics/limits docs: `docs/diagnostics.md`, `docs/limitations.md`
 - Keep docs user-facing; do not add internal code/test references.
 - Ensure LINQ examples match current support.
 - Add AWS references when DynamoDB/PartiQL semantics matter.
 - Docs config is `zensical.toml`; verify with `uv run zensical build` (or `task docs:build`).
-
-## EF Core Internals
-
-- Internal EF Core API usage is expected.
-- Suppress `EF1001` per-file only with `#pragma warning disable EF1001` and a short reason comment.
-- Do not suppress warning globally.
 
 ## Repo Rules
 
@@ -48,7 +55,7 @@ execution.
 - Use modern C# pattern matching where possible.
 - Prefer collection expressions for collections.
 - Add comments only for non-obvious logic.
-- Add XML docs when writing or modifying all methods:
+- Add XML docs for all methods:
   - Always include `<summary>`.
   - Include `<param>`/`<returns>` where names are not self-explanatory.
   - Public methods should fully document parameters, returns, and thrown exceptions where relevant.

--- a/docs/configuration/dbcontext.md
+++ b/docs/configuration/dbcontext.md
@@ -156,25 +156,24 @@ batch boundaries.
 
 ### `DynamoAutomaticIndexSelectionMode`
 
-By default the provider executes every query against the base table. Enable automatic index
-selection to let the provider route compatible queries to a Global or Local Secondary Index:
+By default the provider automatically routes compatible queries to a Global or Local Secondary
+Index when exactly one safe candidate is found:
 
-| Mode            | Behavior                                                                                  |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| `Off` (default) | No automatic routing — use explicit `.WithIndex("name")` hints                            |
-| `SuggestOnly`   | Analyzes candidate indexes and emits `DYNAMO_IDX*` diagnostics; does not change the query |
-| `Conservative`  | Automatically routes queries to an unambiguous matching index                             |
+| Mode           | Behavior                                                                                  |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `Off`          | No automatic routing — use explicit `.WithIndex("name")` hints                            |
+| `SuggestOnly`  | Analyzes candidate indexes and emits `DYNAMO_IDX*` diagnostics; does not change the query |
+| `On` (default) | Automatically routes queries to an unambiguous matching index                             |
 
 Use `Off` when you want query behavior to stay completely explicit in application code. Use
 `SuggestOnly` while validating a schema or rolling the feature out, because it shows where an index
-would help without changing production behavior. Use `Conservative` when you want safer automatic
-routing for obvious matches, but still want the provider to avoid guessing between multiple
-plausible indexes.
+would help without changing production behavior. Use `On` when you want automatic routing for
+obvious matches, but still want the provider to avoid guessing between multiple plausible indexes.
 
 ```csharp
 optionsBuilder.UseDynamo(options =>
 {
-    options.UseAutomaticIndexSelection(DynamoAutomaticIndexSelectionMode.Conservative);
+    options.UseAutomaticIndexSelection(DynamoAutomaticIndexSelectionMode.Off);
 });
 ```
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -218,9 +218,9 @@ info: Microsoft.EntityFrameworkCore.Query[30106]
       Index 'ByStatus-index' on table 'Orders' was auto-selected.
 ```
 
-In `Conservative` mode the message reads "was auto-selected" and the query is rewritten to target
-the index. In `SuggestOnly` mode the message reads "would be selected in Conservative mode" and
-the query is not rewritten — useful for auditing which indexes would fire without changing
+In `On` mode the message reads "was auto-selected" and the query is rewritten to target the index.
+In `SuggestOnly` mode the message reads "would be auto-selected if automatic index selection were
+On" and the query is not rewritten — useful for auditing which indexes would fire without changing
 production query routing.
 
 ______________________________________________________________________

--- a/docs/dynamodb-concepts.md
+++ b/docs/dynamodb-concepts.md
@@ -158,7 +158,7 @@ strongly consistent reads.
 
 Both index types let you avoid full table scans for alternate access patterns. With this provider,
 you declare indexes in `OnModelCreating`. Use `.WithIndex("...")` for explicit index routing, or
-enable `UseAutomaticIndexSelection(...)` for opt-in automatic index selection.
+use the default automatic index selection for unambiguous compatible query shapes.
 
 See [Secondary Indexes](modeling/secondary-indexes.md) for configuration details, and
 [Using Global Secondary Indexes in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
@@ -328,8 +328,8 @@ b.ComplexCollection(o => o.LineItems, li => { /* configure nested members */ });
 ```
 
 **Secondary indexes enable alternate query patterns** — declare them in `OnModelCreating`, then use
-`.WithIndex("...")` for explicit routing or `UseAutomaticIndexSelection(...)` for opt-in automatic
-selection based on query shape. See
+`.WithIndex("...")` for explicit routing or the default automatic selection based on query shape.
+See
 [Secondary Indexes](modeling/secondary-indexes.md) and [Index Selection](querying/index-selection.md).
 
 **LINQ translates to PartiQL** — the provider compiles your LINQ expressions to

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -109,7 +109,7 @@ key must be the first `ORDER BY` column.
 
 ### Automatic Index Selection — `ALL` Projection Only
 
-Automatic index selection (`Conservative` or `SuggestOnly` mode) rejects GSI/LSI candidates
+Automatic index selection (`On` or `SuggestOnly` mode) rejects GSI/LSI candidates
 whose projection type is not `ALL`. `KEYS_ONLY` and `INCLUDE` index candidates are logged as
 rejected (`DYNAMO_IDX005`) and excluded from selection. Use an explicit `.WithIndex("name")`
 hint to route to a non-ALL index.
@@ -238,7 +238,7 @@ collection types throw during model validation.
 
 | Collection kind | Supported CLR shapes                                                                                                                     |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| List            | `T[]`, `List<T>`, `IList<T>`                                                                                                              |
+| List            | `T[]`, `List<T>`, `IList<T>`                                                                                                             |
 | Set             | `HashSet<T>`, `ISet<T>`, `IReadOnlySet<T>`                                                                                               |
 | Dictionary      | `Dictionary<string, TValue>`, `IDictionary<string, TValue>`, `IReadOnlyDictionary<string, TValue>`, `ReadOnlyDictionary<string, TValue>` |
 

--- a/docs/modeling/secondary-indexes.md
+++ b/docs/modeling/secondary-indexes.md
@@ -171,9 +171,9 @@ mode controls behavior:
 
 - `Off`: no automatic routing.
 - `SuggestOnly`: analyzes candidates and emits diagnostics, but does not change query source.
-- `Conservative`: routes compatible queries to an unambiguous index.
+- `On`: routes compatible queries to an unambiguous index. This is the default.
 
-In `Conservative`, automatic selection is conservative:
+Automatic selection uses conservative guardrails:
 
 - it requires the query's filter to cover the index partition key,
 - it only considers `All`-projection indexes,

--- a/docs/querying/index-selection.md
+++ b/docs/querying/index-selection.md
@@ -28,7 +28,7 @@ Rules and behavior:
 
 - `.WithIndex(...)` requires a non-empty index name.
 - The named index must exist on the mapped table; otherwise translation throws `InvalidOperationException`.
-- Explicit selection works regardless of automatic selection mode (`Off`, `SuggestOnly`, `Conservative`).
+- Explicit selection works regardless of automatic selection mode (`Off`, `SuggestOnly`, `On`).
 - Explicit selection can target `All`, `KeysOnly`, or `Include` projection indexes.
 - For explicit `.WithIndex(...)`, the provider does not pre-validate projection coverage.
 - On non-`All` indexes, missing required attributes throw during materialization; missing optional
@@ -36,13 +36,13 @@ Rules and behavior:
 
 ## Automatic Index Selection
 
-Configure automatic selection via `UseAutomaticIndexSelection(...)`:
+Automatic selection is `On` by default. Configure it via `UseAutomaticIndexSelection(...)`:
 
-- `Off` (default): no automatic routing.
+- `Off`: no automatic routing.
 - `SuggestOnly`: analyze and emit diagnostics, but keep base-table execution.
-- `Conservative`: auto-route only when exactly one safe candidate is found.
+- `On` (default): auto-route only when exactly one safe candidate is found.
 
-In `Conservative`, an index candidate is eligible only if all gates pass:
+When automatic selection is `On`, an index candidate is eligible only if all gates pass:
 
 1. The `WHERE` clause includes equality or `IN` on the index partition key.
 1. The predicate does not contain an unsafe `OR` shape.
@@ -59,7 +59,7 @@ Diagnostics emitted during analysis:
 
 - `DYNAMO_IDX001`: no compatible index found.
 - `DYNAMO_IDX002`: multiple compatible indexes tied.
-- `DYNAMO_IDX003`: index selected (or would be selected in `SuggestOnly`).
+- `DYNAMO_IDX003`: index selected (or would be auto-selected in `SuggestOnly`).
 - `DYNAMO_IDX004`: index explicitly selected via `.WithIndex(...)`.
 - `DYNAMO_IDX005`: candidate rejected with reason.
 

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoAutomaticIndexSelectionMode.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoAutomaticIndexSelectionMode.cs
@@ -4,11 +4,11 @@ namespace EntityFrameworkCore.DynamoDb.Infrastructure;
 public enum DynamoAutomaticIndexSelectionMode
 {
     /// <summary>Disables automatic index selection and uses only explicit hints.</summary>
-    Off,
+    Off = 0,
 
     /// <summary>Analyzes candidate indexes and emits diagnostics without changing the query source.</summary>
-    SuggestOnly,
+    SuggestOnly = 1,
 
-    /// <summary>Allows conservative automatic index selection when the query shape is unambiguous.</summary>
-    Conservative,
+    /// <summary>Automatically selects an unambiguous compatible secondary index.</summary>
+    On = 2,
 }

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -21,7 +21,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     public Action<AmazonDynamoDBConfig>? DynamoDbClientConfigAction { get; private set; }
 
     /// <summary>Controls whether the provider should automatically select compatible secondary indexes.</summary>
-    public DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode { get; private set; }
+    public DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode { get; private set; } =
+        DynamoAutomaticIndexSelectionMode.On;
 
     /// <summary>
     /// Controls how SaveChanges behaves when a transactional write unit exceeds max transaction size.

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoAutoIndexSelectionAnalyzer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoAutoIndexSelectionAnalyzer.cs
@@ -24,7 +24,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// <list type="bullet">
 ///   <item><c>DYNAMO_IDX001</c> — no candidate satisfies the predicate (Warning)</item>
 ///   <item><c>DYNAMO_IDX002</c> — multiple candidates tie (Warning)</item>
-///   <item><c>DYNAMO_IDX003</c> — a single candidate was selected or would be selected (Information)</item>
+///   <item><c>DYNAMO_IDX003</c> — a single candidate was selected or would be auto-selected (Information)</item>
 ///   <item><c>DYNAMO_IDX004</c> — explicit index selected via .WithIndex() (Information)</item>
 ///   <item><c>DYNAMO_IDX005</c> — candidate rejected during auto-selection (Information)</item>
 ///   <item><c>DYNAMO_IDX006</c> — index selection suppressed by .WithoutIndex() (Information)</item>
@@ -163,12 +163,12 @@ internal sealed class DynamoAutoIndexSelectionAnalyzer : IDynamoIndexSelectionAn
             new(
                 DynamoQueryDiagnosticLevel.Information,
                 "DYNAMO_IDX003",
-                mode == DynamoAutomaticIndexSelectionMode.Conservative
+                mode == DynamoAutomaticIndexSelectionMode.On
                     ? $"Index '{winner.IndexName}' on table '{context.SelectExpression.TableName}' was auto-selected."
-                    : $"Index '{winner.IndexName}' on table '{context.SelectExpression.TableName}' would be selected in Conservative mode."),
+                    : $"Index '{winner.IndexName}' on table '{context.SelectExpression.TableName}' would be auto-selected if automatic index selection were On."),
         };
 
-        if (mode == DynamoAutomaticIndexSelectionMode.Conservative)
+        if (mode == DynamoAutomaticIndexSelectionMode.On)
             return new DynamoIndexSelectionDecision(
                 winner.IndexName,
                 DynamoIndexSelectionReason.AutoSelected,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryTranslationPostprocessor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryTranslationPostprocessor.cs
@@ -78,7 +78,7 @@ internal sealed class DynamoQueryTranslationPostprocessor(
         var mode =
             dynamoQueryCompilationContext.ContextOptions.FindExtension<DynamoDbOptionsExtension>()
                 ?.AutomaticIndexSelectionMode
-            ?? DynamoAutomaticIndexSelectionMode.Off;
+            ?? DynamoAutomaticIndexSelectionMode.On;
 
         var analysisCtx = new DynamoIndexAnalysisContext
         {
@@ -471,7 +471,8 @@ internal sealed class DynamoQueryTranslationPostprocessor(
             SqlDiscriminatorPredicateExpression => false,
             // Nested path access (e.g. x.Profile.City → DynamoScalarAccessExpression): recurse
             // into the parent chain. The root of the chain is a SqlPropertyExpression whose name
-            // identifies the top-level DynamoDB attribute or a DynamoComplexPropertyAccessExpression
+            // identifies the top-level DynamoDB attribute or a
+            // DynamoComplexPropertyAccessExpression
             // when the chain starts from a complex property. PK and SK are always scalar types and
             // can never host nested properties, so any nested path is inherently non-key.
             DynamoScalarAccessExpression scalar => scalar.Parent is not SqlExpression parentSql

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/CompetingGsiAutoSelectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/CompetingGsiAutoSelectionTests.cs
@@ -11,10 +11,10 @@ public sealed class CompetingGsiAutoSelectionTests(DynamoContainerFixture fixtur
     : CompetingGsiTableTestFixture(fixture)
 {
     protected override DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_CompetingGsis_WithEqualScore_EmitsIdx002_UsesBaseTable()
+    public async Task On_CompetingGsis_WithEqualScore_EmitsIdx002_UsesBaseTable()
     {
         var results =
             await Db.Orders.Where(o => o.Status == "PENDING").ToListAsync(CancellationToken);
@@ -39,7 +39,7 @@ public sealed class CompetingGsiAutoSelectionTests(DynamoContainerFixture fixtur
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_CompetingGsis_OrderBySortKey_SelectsScoringWinner()
+    public async Task On_CompetingGsis_OrderBySortKey_SelectsScoringWinner()
     {
         _ = await Db
             .Orders

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/CompetingGsiTable/Infra/TestFixture.cs
@@ -11,7 +11,7 @@ public abstract class CompetingGsiTableTestFixture : DynamoTestFixtureBase
             CompetingGsiOrdersTable.CreateTable);
 
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Off;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     protected override bool UseSharedInternalServiceProvider => false;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/Infra/TestFixture.cs
@@ -12,7 +12,7 @@ public abstract class SecondaryIndexProjectionTableTestFixture : DynamoTestFixtu
             SecondaryIndexProjectionOrdersTable.CreateTable);
 
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Off;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     protected TestPartiQlLoggerFactory LoggerFactory => SqlCapture;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/SecondaryIndexProjectionAutoSelectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexProjectionTable/SecondaryIndexProjectionAutoSelectionTests.cs
@@ -10,10 +10,10 @@ public sealed class SecondaryIndexProjectionAutoSelectionTests(DynamoContainerFi
     : SecondaryIndexProjectionTableTestFixture(fixture)
 {
     protected override DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnKeysOnlyGsiPk_RejectsCandidate_UsesBaseTable()
+    public async Task On_WhereOnKeysOnlyGsiPk_RejectsCandidate_UsesBaseTable()
     {
         var results =
             await Db.Orders.Where(o => o.Status == "PENDING").ToListAsync(CancellationToken);
@@ -45,7 +45,7 @@ public sealed class SecondaryIndexProjectionAutoSelectionTests(DynamoContainerFi
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnIncludeGsiPk_RejectsCandidate_UsesBaseTable()
+    public async Task On_WhereOnIncludeGsiPk_RejectsCandidate_UsesBaseTable()
     {
         var results =
             await Db.Orders.Where(o => o.Region == "US-EAST").ToListAsync(CancellationToken);

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/Infra/TestFixture.cs
@@ -11,7 +11,7 @@ public abstract class SecondaryIndexTableTestFixture : DynamoTestFixtureBase
             SecondaryIndexOrdersTable.CreateTable);
 
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Off;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     protected override bool UseSharedInternalServiceProvider => false;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexAutoSelectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexAutoSelectionTests.cs
@@ -11,15 +11,20 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     : SecondaryIndexTableTestFixture(fixture)
 {
     protected override DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnGsiPk_AutoSelects_ByStatusIndex()
+    public async Task On_WhereOnGsiPkAndSk_AutoSelects_ByStatusIndex_AndEmitsDiagnostic()
     {
-        var results =
-            await Db.Orders.Where(o => o.Status == "PENDING").ToListAsync(CancellationToken);
+        var results = await Db
+            .Orders
+            .Where(o => o.Status == "PENDING" && o.CreatedAt == "2024-01-10")
+            .ToListAsync(CancellationToken);
 
-        var expected = OrderItems.Items.Where(o => o.Status == "PENDING").ToList();
+        var expected = OrderItems
+            .Items
+            .Where(o => o.Status == "PENDING" && o.CreatedAt == "2024-01-10")
+            .ToList();
         results.Should().BeEquivalentTo(expected);
 
         LoggerFactory
@@ -35,12 +40,32 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
             """
             SELECT "customerId", "orderId", "createdAt", "priority", "region", "status"
             FROM "SecondaryIndexOrders"."ByStatus"
+            WHERE "status" = 'PENDING' AND "createdAt" = '2024-01-10'
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DefaultMode_WhereOnGsiPk_AutoSelects_ByStatusIndex()
+    {
+        await using var db = new SecondaryIndexDbContext(
+            CreateOptions<SecondaryIndexDbContext>(options => options.DynamoDbClient(Client)));
+
+        var results =
+            await db.Orders.Where(o => o.Status == "PENDING").ToListAsync(CancellationToken);
+
+        var expected = OrderItems.Items.Where(o => o.Status == "PENDING").ToList();
+        results.Should().BeEquivalentTo(expected);
+
+        AssertSql(
+            """
+            SELECT "customerId", "orderId", "createdAt", "priority", "region", "status"
+            FROM "SecondaryIndexOrders"."ByStatus"
             WHERE "status" = 'PENDING'
             """);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnGsiPk_WithSkRange_AutoSelects_AndProducesCorrectResults()
+    public async Task On_WhereOnGsiPk_WithSkRange_AutoSelects_AndProducesCorrectResults()
     {
         var results = await Db
             .Orders
@@ -64,7 +89,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnTablePk_DoesNotAutoSelectGsi_StaysOnBaseTable()
+    public async Task On_WhereOnTablePk_DoesNotAutoSelectGsi_StaysOnBaseTable()
     {
         var results =
             await Db.Orders.Where(o => o.CustomerId == "C#1").ToListAsync(CancellationToken);
@@ -81,7 +106,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnTablePk_LsiCandidates_AutoSelects_WhenOrderingMatches()
+    public async Task On_WhereOnTablePk_LsiCandidates_AutoSelects_WhenOrderingMatches()
     {
         List<OrderItem>? results = null;
         try
@@ -114,7 +139,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_WhereOnTablePk_AmbiguousLsi_FallsBackToBaseTable()
+    public async Task On_WhereOnTablePk_AmbiguousLsi_FallsBackToBaseTable()
     {
         var results =
             await Db.Orders.Where(o => o.CustomerId == "C#1").ToListAsync(CancellationToken);
@@ -136,7 +161,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_ContainsOnGsiPk_AutoSelects_ByStatusIndex()
+    public async Task On_ContainsOnGsiPk_AutoSelects_ByStatusIndex()
     {
         var statusList = new List<string> { "PENDING", "SHIPPED" };
 
@@ -165,7 +190,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_UnsafeOrPredicate_BlocksAutoSelection_EmitsRejectionDiagnostics()
+    public async Task On_UnsafeOrPredicate_BlocksAutoSelection_EmitsRejectionDiagnostics()
     {
         _ = await Db
             .Orders
@@ -196,8 +221,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task
-        Conservative_WhereOnNonIndexPkAttribute_AllCandidatesRejected_EmitsIdxDiagnostics()
+    public async Task On_WhereOnNonIndexPkAttribute_AllCandidatesRejected_EmitsIdxDiagnostics()
     {
         _ = await Db.Orders.Where(o => o.Priority == 1).ToListAsync(CancellationToken);
 
@@ -230,7 +254,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
         _ = await Db
             .Orders
             .WithIndex("ByStatus")
-            .Where(o => o.Status == "PENDING")
+            .Where(o => o.Status == "PENDING" && o.CreatedAt == "2024-01-10")
             .ToListAsync(CancellationToken);
 
         LoggerFactory
@@ -251,12 +275,12 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
             """
             SELECT "customerId", "orderId", "createdAt", "priority", "region", "status"
             FROM "SecondaryIndexOrders"."ByStatus"
-            WHERE "status" = 'PENDING'
+            WHERE "status" = 'PENDING' AND "createdAt" = '2024-01-10'
             """);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_GsiPkWithOrderBySk_AutoSelects_ScoringWinner()
+    public async Task On_GsiPkWithOrderBySk_AutoSelects_ScoringWinner()
     {
         try
         {
@@ -286,7 +310,7 @@ public class SecondaryIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_NoPredicate_EmitsNoCompatibleIndex_StaysOnBaseTable()
+    public async Task On_NoPredicate_EmitsNoCompatibleIndex_StaysOnBaseTable()
     {
         _ = await Db.Orders.ToListAsync(CancellationToken);
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexFirstTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexFirstTests.cs
@@ -8,7 +8,7 @@ public class SecondaryIndexFirstTests(DynamoContainerFixture fixture)
     : SecondaryIndexTableTestFixture(fixture)
 {
     protected override DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task FirstAsync_AutoSelects_ByStatusGsi_PkEquality_SetsLimit1_ReturnsOneItem()

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexSuggestOnlyAutoSelectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexSuggestOnlyAutoSelectionTests.cs
@@ -24,7 +24,7 @@ public class SecondaryIndexSuggestOnlyAutoSelectionTests(DynamoContainerFixture 
                 => e.EventId.Id == DynamoEventId.SecondaryIndexSelected.Id
                 && e.LogLevel == LogLevel.Information
                 && e.Message.Contains(
-                    "Index 'ByStatus' on table 'SecondaryIndexOrders' would be selected in Conservative mode."));
+                    "Index 'ByStatus' on table 'SecondaryIndexOrders' would be auto-selected if automatic index selection were On."));
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexWithoutIndexTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SecondaryIndexTable/SecondaryIndexWithoutIndexTests.cs
@@ -10,10 +10,10 @@ public class SecondaryIndexWithoutIndexTests(DynamoContainerFixture fixture)
     : SecondaryIndexTableTestFixture(fixture)
 {
     protected override DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task WithoutIndex_ConservativeMode_UsesBaseTable_AndEmitsDiagnosticIDX006()
+    public async Task WithoutIndex_OnMode_UsesBaseTable_AndEmitsDiagnosticIDX006()
     {
         var results = await Db
             .Orders

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTableWithIndexes/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTableWithIndexes/Infra/TestFixture.cs
@@ -11,7 +11,7 @@ public abstract class SharedTableWithIndexesTestFixture : DynamoTestFixtureBase
             SharedTableWithIndexesItemTable.CreateTable);
 
     protected virtual DynamoAutomaticIndexSelectionMode AutomaticIndexSelectionMode
-        => DynamoAutomaticIndexSelectionMode.Conservative;
+        => DynamoAutomaticIndexSelectionMode.On;
 
     protected override bool UseSharedInternalServiceProvider => false;
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTableWithIndexes/SharedTableIndexAutoSelectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTableWithIndexes/SharedTableIndexAutoSelectionTests.cs
@@ -10,7 +10,7 @@ public class SharedTableIndexAutoSelectionTests(DynamoContainerFixture fixture)
     : SharedTableWithIndexesTestFixture(fixture)
 {
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_DerivedTypeQuery_AutoSelects_ByPriorityGsi()
+    public async Task On_DerivedTypeQuery_AutoSelects_ByPriorityGsi()
     {
         var results =
             await Db.PriorityWorkOrders.Where(o => o.Priority == 3).ToListAsync(CancellationToken);
@@ -44,7 +44,7 @@ public class SharedTableIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_BaseTypeQuery_OrDiscriminatorIsSafe_AutoSelects_ByStatusLsi()
+    public async Task On_BaseTypeQuery_OrDiscriminatorIsSafe_AutoSelects_ByStatusLsi()
     {
         var results = await Db
             .WorkOrders
@@ -78,7 +78,7 @@ public class SharedTableIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_BaseTypeQuery_NoIndexPkConstraint_FallsBackToBaseTable()
+    public async Task On_BaseTypeQuery_NoIndexPkConstraint_FallsBackToBaseTable()
     {
         _ = await Db.WorkOrders.Where(o => o.Status == "OPEN").ToListAsync(CancellationToken);
 
@@ -96,7 +96,7 @@ public class SharedTableIndexAutoSelectionTests(DynamoContainerFixture fixture)
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Conservative_ArchivedWorkOrderQuery_ByPriorityGsiIsNotACandidate()
+    public async Task On_ArchivedWorkOrderQuery_ByPriorityGsiIsNotACandidate()
     {
         _ = await Db
             .ArchivedWorkOrders
@@ -196,7 +196,7 @@ public class SharedTableIndexAutoSelectionTests(DynamoContainerFixture fixture)
             .ContainSingle(e
                 => e.EventId.Id == DynamoEventId.SecondaryIndexSelected.Id
                 && e.Message.Contains(
-                    "Index 'ByPriority' on table 'work-orders-indexed-table' would be selected in Conservative mode."));
+                    "Index 'ByPriority' on table 'work-orders-indexed-table' would be auto-selected if automatic index selection were On."));
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/DynamoAutoIndexSelectionAnalyzerTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/DynamoAutoIndexSelectionAnalyzerTests.cs
@@ -346,7 +346,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         decision.Diagnostics[0].Code.Should().Be("DYNAMO_IDX003");
         decision.Diagnostics[0].Level.Should().Be(DynamoQueryDiagnosticLevel.Information);
         decision.Diagnostics[0].Message.Should().Contain("ByStatus");
-        decision.Diagnostics[0].Message.Should().Contain("would be selected");
+        decision.Diagnostics[0].Message.Should().Contain("would be auto-selected");
     }
 
     /// <summary>Provides functionality for this member.</summary>
@@ -377,12 +377,12 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         decision.Diagnostics[1].Level.Should().Be(DynamoQueryDiagnosticLevel.Warning);
     }
 
-    // ── Conservative mode ────────────────────────────────────────────────────
+    // ── On mode ────────────────────────────────────────────────────
 
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_SingleMatch_NoBonuses_Returns_AutoSelected()
+    public void On_SingleMatch_NoBonuses_Returns_AutoSelected()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -391,7 +391,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -407,7 +407,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_NoCandidateSatisfied_EmitsIdx001Warning_NoSelection()
+    public void On_NoCandidateSatisfied_EmitsIdx001Warning_NoSelection()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -417,7 +417,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // CustomerId equality does not cover Status PK.
         var constraints = MakeConstraints(equalityPks: ["CustomerId"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -434,7 +434,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_AmbiguousTie_EmitsIdx002Warning_NoSelection()
+    public void On_AmbiguousTie_EmitsIdx002Warning_NoSelection()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -445,7 +445,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // Both GSI PKs are present and neither gets a sort-key bonus.
         var constraints = MakeConstraints(equalityPks: ["Status", "Region"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -462,7 +462,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_NoOrdering_DoesNotPreferSortKeyIndexOverPartitionOnlyIndex()
+    public void On_NoOrdering_DoesNotPreferSortKeyIndexOverPartitionOnlyIndex()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -472,7 +472,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -489,7 +489,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_SkBonusTiebreaks_ClearWinner_AutoSelected()
+    public void On_SkBonusTiebreaks_ClearWinner_AutoSelected()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -516,7 +516,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
             equalityPks: ["Status", "Region"],
             skConditions: ["CreatedAt"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidatesSkTiebreak,
             constraintsSkTiebreak);
 
@@ -529,7 +529,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_OrderingBonusTiebreaks_ClearWinner_AutoSelected()
+    public void On_OrderingBonusTiebreaks_ClearWinner_AutoSelected()
     {
         // Both candidates have PK covered and no SK condition, but ordering aligns with ByStatus.
         var candidates = new List<DynamoIndexDescriptor>
@@ -542,7 +542,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
             equalityPks: ["Status", "Region"],
             orderings: ["CreatedAt"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -557,7 +557,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_BothBonuses_BeatsSkOnly_AutoSelected()
+    public void On_BothBonuses_BeatsSkOnly_AutoSelected()
     {
         // ByStatus gets +2 (SK condition + ordering); ByRegion gets +1 (SK condition only).
         var candidates = new List<DynamoIndexDescriptor>
@@ -571,7 +571,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
             skConditions: ["CreatedAt", "Priority"],
             orderings: ["CreatedAt"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -584,7 +584,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_UnsafeOrBlocksAllCandidates_NoSelection()
+    public void On_UnsafeOrBlocksAllCandidates_NoSelection()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -593,7 +593,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"], hasUnsafeOr: true);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -609,7 +609,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_NonAllProjectionDescriptor_Excluded_NoSelection()
+    public void On_NonAllProjectionDescriptor_Excluded_NoSelection()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -622,7 +622,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -639,7 +639,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_InConstraint_SatisfiesPkGate_AutoSelected()
+    public void On_InConstraint_SatisfiesPkGate_AutoSelected()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -649,7 +649,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // IN constraint on Status PK satisfies Gate 1.
         var constraints = MakeConstraints(inPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -662,14 +662,14 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_NullQueryConstraints_Returns_NoSelection()
+    public void On_NullQueryConstraints_Returns_NoSelection()
     {
         var candidates = new List<DynamoIndexDescriptor>
         {
             MakeDescriptor("CustomerId", indexName: null),
             MakeDescriptor("Status", "CreatedAt", "ByStatus"),
         };
-        var ctx = BuildContext(DynamoAutomaticIndexSelectionMode.Conservative, candidates, null);
+        var ctx = BuildContext(DynamoAutomaticIndexSelectionMode.On, candidates, null);
 
         var decision = Analyzer.Analyze(ctx);
 
@@ -681,7 +681,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_BaseTableDescriptor_Skipped_OnlyIndexesEvaluated()
+    public void On_BaseTableDescriptor_Skipped_OnlyIndexesEvaluated()
     {
         // The base-table descriptor has the same PK attr as the query equality constraint.
         // It must be skipped — auto-selection should only consider secondary indexes.
@@ -692,7 +692,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -706,7 +706,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
-    public void Conservative_LsiCandidate_SatisfiedByTablePk_AutoSelected()
+    public void On_LsiCandidate_SatisfiedByTablePk_AutoSelected()
     {
         // LSI shares the base-table partition key (CustomerId). When the WHERE has CustomerId
         // equality, the LSI can be used as a key-condition query source.
@@ -723,7 +723,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["CustomerId"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -796,7 +796,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // Constraint is on CustomerId, not Status — Gate 1 fails for ByStatus.
         var constraints = MakeConstraints(equalityPks: ["CustomerId"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -825,7 +825,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // PK is covered but Gate 3 (projection) fails.
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -849,7 +849,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         // PK covered but Gate 2 (unsafe OR) fails.
         var constraints = MakeConstraints(equalityPks: ["Status"], hasUnsafeOr: true);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -873,7 +873,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["CustomerId"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -901,7 +901,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints);
 
@@ -921,7 +921,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
     /// <summary>Provides functionality for this member.</summary>
     public void WithoutIndex_DisablesAutoSelection_ReturnsNoSelection()
     {
-        // Even though ByStatus passes all gates in Conservative mode, IndexSelectionDisabled
+        // Even though ByStatus passes all gates in On mode, IndexSelectionDisabled
         // should short-circuit before evaluation and return the base table.
         var candidates = new List<DynamoIndexDescriptor>
         {
@@ -930,7 +930,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints,
             indexSelectionDisabled: true);
@@ -953,7 +953,7 @@ public class DynamoAutoIndexSelectionAnalyzerTests
         };
         var constraints = MakeConstraints(equalityPks: ["Status"]);
         var ctx = BuildContext(
-            DynamoAutomaticIndexSelectionMode.Conservative,
+            DynamoAutomaticIndexSelectionMode.On,
             candidates,
             constraints,
             indexSelectionDisabled: true,

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -14,7 +14,7 @@ public class PaginationConfigurationTests
     {
         var extension = new DynamoDbOptionsExtension();
 
-        extension.AutomaticIndexSelectionMode.Should().Be(DynamoAutomaticIndexSelectionMode.Off);
+        extension.AutomaticIndexSelectionMode.Should().Be(DynamoAutomaticIndexSelectionMode.On);
         extension.DynamoDbClient.Should().BeNull();
         extension.DynamoDbClientConfig.Should().BeNull();
         extension.DynamoDbClientConfigAction.Should().BeNull();
@@ -67,7 +67,7 @@ public class PaginationConfigurationTests
             .WithDynamoDbClient(client)
             .WithDynamoDbClientConfig(config)
             .WithDynamoDbClientConfigAction(callback)
-            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.Conservative)
+            .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.On)
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
             .WithMaxTransactionSize(42)
             .WithMaxBatchWriteSize(11);
@@ -109,15 +109,12 @@ public class PaginationConfigurationTests
         var optionsBuilder = new DbContextOptionsBuilder();
 
         optionsBuilder.UseDynamo(options
-            => options.UseAutomaticIndexSelection(DynamoAutomaticIndexSelectionMode.Conservative));
+            => options.UseAutomaticIndexSelection(DynamoAutomaticIndexSelectionMode.On));
 
         var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
 
         extension.Should().NotBeNull();
-        extension!
-            .AutomaticIndexSelectionMode
-            .Should()
-            .Be(DynamoAutomaticIndexSelectionMode.Conservative);
+        extension!.AutomaticIndexSelectionMode.Should().Be(DynamoAutomaticIndexSelectionMode.On);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -192,7 +189,7 @@ public class PaginationConfigurationTests
                 DynamoAutomaticIndexSelectionMode.Off);
         var extension2 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
-                DynamoAutomaticIndexSelectionMode.Conservative);
+                DynamoAutomaticIndexSelectionMode.On);
 
         extension1
             .Info
@@ -225,10 +222,10 @@ public class PaginationConfigurationTests
     {
         var extension1 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
-                DynamoAutomaticIndexSelectionMode.Conservative);
+                DynamoAutomaticIndexSelectionMode.On);
         var extension2 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
-                DynamoAutomaticIndexSelectionMode.Conservative);
+                DynamoAutomaticIndexSelectionMode.On);
 
         extension1.Info.ShouldUseSameServiceProvider(extension2.Info).Should().BeTrue();
     }


### PR DESCRIPTION
## Summary

Rename automatic index selection's public conservative mode to `On` and make it the provider default. The selection algorithm remains conservative: it still only auto-selects one safe, unambiguous compatible secondary index.

Fixes #182

## Changes

### Provider behavior
- Replace `DynamoAutomaticIndexSelectionMode.Conservative` with `DynamoAutomaticIndexSelectionMode.On` while preserving enum values: `Off = 0`, `SuggestOnly = 1`, `On = 2`.
- Default `DynamoDbOptionsExtension.AutomaticIndexSelectionMode` to `On`.
- Use `On` as the translation fallback when no provider extension is available.
- Update suggest-only diagnostic copy to say an index would be auto-selected if automatic index selection were `On`.

### Tests
- Rename analyzer and integration coverage from conservative mode to `On`.
- Update default option assertions and provider-default fixtures.
- Add a default-options integration path that auto-selects an index without calling `UseAutomaticIndexSelection(...)`.
- Keep explicit `Off` and `SuggestOnly` behavior covered.

### Docs
- Document `On` as the default automatic index selection mode.
- Remove obsolete opt-in/default-off wording.
- Update configuration, index-selection, diagnostics, limitations, and DynamoDB concept docs for the new mode names.

## Validation

- MCP: `run_all_tests_for_project` for `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` passed: 409 tests.
- MCP: `run_all_tests_for_project` for `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj` passed: 369 passed, 1 skipped.
- MCP: `run_all_tests` passed: 369 passed, 1 skipped.
- Docs: `uv run zensical build` passed.

## Breaking Changes

- `DynamoAutomaticIndexSelectionMode.Conservative` was removed.
- Use `DynamoAutomaticIndexSelectionMode.On` instead.