### PR TITLE
fix(storage): distinguish missing items from concurrency conflicts

### DIFF
--- a/docs/saving/concurrency.md
+++ b/docs/saving/concurrency.md
@@ -81,8 +81,16 @@ Conflict detection depends on the execution path:
 - **Transactional saves** (`ExecuteTransaction`): DynamoDB returns `TransactionCanceledException`
     with a `ConditionalCheckFailed` cancellation reason for the conflicting item.
 
-The provider maps both to `DbUpdateConcurrencyException`. The `Entries` property on the
-exception identifies which entities were in conflict.
+The provider requests DynamoDB's `ALL_OLD` value on condition-check failures and uses the
+returned item to distinguish key misses from token conflicts:
+
+- If DynamoDB returns the existing item, the key matched and the concurrency token predicate
+    failed; the provider throws `DbUpdateConcurrencyException`.
+- If DynamoDB does not return an item, the target key did not match any item. The item may have
+    been deleted, or the tracked key values may not match the stored item; the provider throws
+    `DbUpdateException`.
+
+The `Entries` property on the exception identifies which entities were involved.
 
 ## Handling DbUpdateConcurrencyException
 
@@ -153,9 +161,10 @@ the same.
 If concurrency tokens are configured, the token value is included in the WHERE predicate. This
 creates an important asymmetry:
 
-- **Item missing entirely** → silent success (provider accepts the delete as done).
-- **Item present with a different token value** → `ConditionalCheckFailedException` →
-    `DbUpdateConcurrencyException`.
+- **Item missing entirely** → silent success for singleton deletes (provider accepts the delete
+    as done) or `DbUpdateException` if DynamoDB reports a failed condition on that write path.
+- **Item present with a different token value** → `ConditionalCheckFailedException` with old item
+    attributes → `DbUpdateConcurrencyException`.
 
 The second case matters when two writers race to delete the same item: the first delete
 succeeds and the item is gone; the second delete finds the item missing and also succeeds. But

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -68,6 +68,8 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                 {
                     Statement = state.statement,
                     Parameters = state.parameters?.Count > 0 ? state.parameters : null,
+                    ReturnValuesOnConditionCheckFailure =
+                        ReturnValuesOnConditionCheckFailure.ALL_OLD,
                 };
 
                 await Client.ExecuteStatementAsync(request, ct).ConfigureAwait(false);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExceptionMapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExceptionMapper.cs
@@ -27,31 +27,38 @@ internal sealed class DynamoWriteExceptionMapper
                 ex,
                 entries);
 
-        if (ex is ConditionalCheckFailedException || IsConditionalCheckFailedException(ex))
-            return new DbUpdateConcurrencyException(
-                $"The '{firstEntry.EntityType.DisplayName()}' entity could not be "
-                + (entityState == EntityState.Modified ? "updated" : "deleted")
-                + " because one or more concurrency token values have changed since it was last read. "
-                + "Another writer may have modified this item.",
-                ex,
-                entries);
+        if (ex is ConditionalCheckFailedException ccf)
+            return HasReturnedItem(ccf.Item)
+                ? CreateConcurrencyException(ex, entityState, entries)
+                : CreateMissingItemException(ex, entityState, entries);
+
+        if (IsConditionalCheckFailedException(ex))
+            return EntityTypeHasConcurrencyTokens(firstEntry)
+                ? CreateConcurrencyException(ex, entityState, entries)
+                : CreateMissingItemException(ex, entityState, entries);
 
         if (ex is TransactionCanceledException tce)
         {
-            var hasConcurrency = tce.CancellationReasons?.Any(static r
-                    => string.Equals(r.Code, "ConditionalCheckFailed", StringComparison.Ordinal))
-                ?? false;
+            var conditionFailureReasons =
+                tce
+                    .CancellationReasons
+                    ?.Where(static r
+                        => string.Equals(
+                            r.Code,
+                            "ConditionalCheckFailed",
+                            StringComparison.Ordinal))
+                    .ToList();
 
-            return hasConcurrency
-                ? new DbUpdateConcurrencyException(
-                    $"Transaction cancelled due to a concurrency token conflict on "
-                    + $"'{firstEntry.EntityType.DisplayName()}'.",
-                    tce,
-                    entries)
-                : new DbUpdateException(
-                    $"Transaction cancelled while saving '{firstEntry.EntityType.DisplayName()}'.",
-                    tce,
-                    entries);
+            var hasConditionFailure = conditionFailureReasons?.Count > 0;
+            if (hasConditionFailure)
+                return conditionFailureReasons!.Any(static r => HasReturnedItem(r.Item))
+                    ? CreateConcurrencyException(tce, entityState, entries)
+                    : CreateMissingItemException(tce, entityState, entries);
+
+            return new DbUpdateException(
+                $"Transaction cancelled while saving '{firstEntry.EntityType.DisplayName()}'.",
+                tce,
+                entries);
         }
 
         return new DbUpdateException(
@@ -71,4 +78,45 @@ internal sealed class DynamoWriteExceptionMapper
                     ade.ErrorCode,
                     "ConditionalCheckFailedException",
                     StringComparison.Ordinal));
+
+    private static DbUpdateConcurrencyException CreateConcurrencyException(
+        Exception ex,
+        EntityState entityState,
+        IReadOnlyList<IUpdateEntry> entries)
+    {
+        var firstEntry = entries[0];
+
+        return new DbUpdateConcurrencyException(
+            $"The '{firstEntry.EntityType.DisplayName()}' entity could not be "
+            + (entityState == EntityState.Modified ? "updated" : "deleted")
+            + " because one or more concurrency token values have changed since it was last read. "
+            + "Another writer may have modified this item.",
+            ex,
+            entries);
+    }
+
+    private static DbUpdateException CreateMissingItemException(
+        Exception ex,
+        EntityState entityState,
+        IReadOnlyList<IUpdateEntry> entries)
+    {
+        var firstEntry = entries[0];
+
+        return new DbUpdateException(
+            $"The '{firstEntry.EntityType.DisplayName()}' entity could not be "
+            + (entityState == EntityState.Modified ? "updated" : "deleted")
+            + " because the DynamoDB item was not found for its key. It may have been "
+            + "deleted, or its key values may not match the stored item.",
+            ex,
+            entries);
+    }
+
+    private static bool EntityTypeHasConcurrencyTokens(IUpdateEntry entry)
+        => entry
+            .EntityType
+            .GetProperties()
+            .Any(static p => p.IsConcurrencyToken && !p.IsPrimaryKey());
+
+    private static bool HasReturnedItem(IReadOnlyDictionary<string, AttributeValue>? item)
+        => item is { Count: > 0 };
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExceptionMapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExceptionMapper.cs
@@ -32,11 +32,6 @@ internal sealed class DynamoWriteExceptionMapper
                 ? CreateConcurrencyException(ex, entityState, entries)
                 : CreateMissingItemException(ex, entityState, entries);
 
-        if (IsConditionalCheckFailedException(ex))
-            return EntityTypeHasConcurrencyTokens(firstEntry)
-                ? CreateConcurrencyException(ex, entityState, entries)
-                : CreateMissingItemException(ex, entityState, entries);
-
         if (ex is TransactionCanceledException tce)
         {
             var conditionFailureReasons =
@@ -71,14 +66,6 @@ internal sealed class DynamoWriteExceptionMapper
         => ex is AmazonDynamoDBException ade
             && string.Equals(ade.ErrorCode, "DuplicateItem", StringComparison.Ordinal);
 
-    private static bool IsConditionalCheckFailedException(Exception ex)
-        => ex is AmazonDynamoDBException ade
-            && (string.Equals(ade.ErrorCode, "ConditionalCheckFailed", StringComparison.Ordinal)
-                || string.Equals(
-                    ade.ErrorCode,
-                    "ConditionalCheckFailedException",
-                    StringComparison.Ordinal));
-
     private static DbUpdateConcurrencyException CreateConcurrencyException(
         Exception ex,
         EntityState entityState,
@@ -110,12 +97,6 @@ internal sealed class DynamoWriteExceptionMapper
             ex,
             entries);
     }
-
-    private static bool EntityTypeHasConcurrencyTokens(IUpdateEntry entry)
-        => entry
-            .EntityType
-            .GetProperties()
-            .Any(static p => p.IsConcurrencyToken && !p.IsPrimaryKey());
 
     private static bool HasReturnedItem(IReadOnlyDictionary<string, AttributeValue>? item)
         => item is { Count: > 0 };

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExecutor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteExecutor.cs
@@ -180,7 +180,10 @@ internal sealed class DynamoWriteExecutor(
             statements.Add(
                 new ParameterizedStatement
                 {
-                    Statement = operation.Statement, Parameters = operation.Parameters,
+                    Statement = operation.Statement,
+                    Parameters = operation.Parameters,
+                    ReturnValuesOnConditionCheckFailure =
+                        ReturnValuesOnConditionCheckFailure.ALL_OLD,
                 });
         }
 
@@ -237,7 +240,10 @@ internal sealed class DynamoWriteExecutor(
                 statements.Add(
                     new BatchStatementRequest
                     {
-                        Statement = operation.Statement, Parameters = operation.Parameters,
+                        Statement = operation.Statement,
+                        Parameters = operation.Parameters,
+                        ReturnValuesOnConditionCheckFailure =
+                            ReturnValuesOnConditionCheckFailure.ALL_OLD,
                     });
             }
 
@@ -301,10 +307,20 @@ internal sealed class DynamoWriteExecutor(
     }
 
     private static AmazonDynamoDBException CreateBatchStatementException(BatchStatementError error)
-        => new(error.Message ?? "DynamoDB BatchExecuteStatement reported a statement failure.")
+    {
+        if (string.Equals(error.Code, "ConditionalCheckFailed", StringComparison.Ordinal))
+            return new ConditionalCheckFailedException(
+                error.Message ?? "DynamoDB BatchExecuteStatement reported a condition failure.")
+            {
+                ErrorCode = error.Code, Item = error.Item,
+            };
+
+        return new AmazonDynamoDBException(
+            error.Message ?? "DynamoDB BatchExecuteStatement reported a statement failure.")
         {
             ErrorCode = error.Code,
         };
+    }
 
     private static IReadOnlyDictionary<InternalEntityEntry, IReadOnlyList<InternalEntityEntry>>
         BuildRootAggregateEntries(

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
@@ -234,6 +234,109 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
+    //  BATCH — stale version and missing item
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    ///     In a non-transactional batch write, a stale concurrency token on one item causes
+    ///     <see cref="DbUpdateConcurrencyException" />. DynamoDB returns <c>ALL_OLD</c> item attributes on
+    ///     condition failure so the provider can classify the error correctly.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task BatchUpdate_StaleVersion_ThrowsDbUpdateConcurrencyException()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        var first = new CustomerItem
+        {
+            Pk = "TENANT#CONC-BATCH",
+            Sk = "CUSTOMER#BATCH-STALE-1",
+            Version = 1,
+            Email = "batch-first@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var second = new CustomerItem
+        {
+            Pk = "TENANT#CONC-BATCH",
+            Sk = "CUSTOMER#BATCH-STALE-2",
+            Version = 1,
+            Email = "batch-second@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        await BumpVersionAsync(second.Pk, second.Sk, CancellationToken);
+
+        first.Version = 2;
+        first.Email = "batch-first-updated@example.com";
+        second.Version = 2;
+        second.Email = "batch-second-updated@example.com";
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    /// <summary>
+    ///     In a non-transactional batch write, a condition failure on a key that no longer exists is
+    ///     reported as <see cref="DbUpdateException" /> (not concurrency), because DynamoDB returns no
+    ///     <c>ALL_OLD</c> item when the key is absent.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task BatchUpdate_ItemDeletedExternally_ThrowsDbUpdateExceptionNotConcurrency()
+    {
+        Db.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
+
+        var first = new CustomerItem
+        {
+            Pk = "TENANT#CONC-BATCH",
+            Sk = "CUSTOMER#BATCH-MISSING-1",
+            Version = 1,
+            Email = "batch-missing-first@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        var second = new CustomerItem
+        {
+            Pk = "TENANT#CONC-BATCH",
+            Sk = "CUSTOMER#BATCH-MISSING-2",
+            Version = 1,
+            Email = "batch-missing-second@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Add(first);
+        Db.Customers.Add(second);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        await Client.DeleteItemAsync(
+            new DeleteItemRequest
+            {
+                TableName = SaveChangesItemTable.TableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["pk"] = new() { S = second.Pk }, ["sk"] = new() { S = second.Sk },
+                },
+            },
+            CancellationToken);
+
+        first.Version = 2;
+        first.Email = "batch-missing-first-updated@example.com";
+        second.Version = 2;
+        second.Email = "batch-missing-second-updated@example.com";
+
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        var assertion = await act.Should().ThrowAsync<DbUpdateException>();
+        assertion.And.Should().NotBeOfType<DbUpdateConcurrencyException>();
+        assertion.WithMessage("*not found for its key*");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
     //  DELETE — stale version
     // ──────────────────────────────────────────────────────────────────────────────
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
@@ -99,6 +99,140 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             """);
     }
 
+    /// <summary>
+    ///     If the key no longer matches any DynamoDB item, the failed UPDATE is reported as a missing
+    ///     item instead of a stale-token concurrency conflict.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task UpdateAsync_ItemDeletedExternally_ThrowsDbUpdateExceptionNotConcurrency()
+    {
+        var customer = new CustomerItem
+        {
+            Pk = "TENANT#CONC",
+            Sk = "CUSTOMER#MISSING-UPD",
+            Version = 1,
+            Email = "before-delete@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Add(customer);
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+
+        await Client.DeleteItemAsync(
+            new DeleteItemRequest
+            {
+                TableName = SaveChangesItemTable.TableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["pk"] = new() { S = customer.Pk }, ["sk"] = new() { S = customer.Sk },
+                },
+            },
+            CancellationToken);
+
+        customer.Version = 2;
+        customer.Email = "missing@example.com";
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        var assertion = await act.Should().ThrowAsync<DbUpdateException>();
+        assertion.And.Should().NotBeOfType<DbUpdateConcurrencyException>();
+        assertion.WithMessage("*not found for its key*");
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "email" = ?, "version" = ?
+            WHERE "pk" = ? AND "sk" = ? AND "version" = ?
+            """);
+    }
+
+    /// <summary>
+    ///     If the partition key matches an existing item but the sort key does not, DynamoDB does not
+    ///     return an old item on condition failure. The provider reports this as a missing key target
+    ///     instead of a stale-token concurrency conflict.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        UpdateAsync_RightPartitionKeyWrongSortKey_ThrowsDbUpdateExceptionNotConcurrency()
+    {
+        await PutItemAsync(
+            new Dictionary<string, AttributeValue>
+            {
+                ["pk"] = new() { S = "TENANT#CONC-WRONG-SK" },
+                ["sk"] = new() { S = "CUSTOMER#REAL" },
+                ["$type"] = new() { S = "CustomerItem" },
+                ["email"] = new() { S = "real@example.com" },
+                ["version"] = new() { N = "1" },
+                ["isPreferred"] = new() { BOOL = false },
+                ["createdAt"] = new() { S = "2026-04-01 00:00:00+00:00" },
+            },
+            CancellationToken);
+
+        var customer = new CustomerItem
+        {
+            Pk = "TENANT#CONC-WRONG-SK",
+            Sk = "CUSTOMER#WRONG",
+            Version = 1,
+            Email = "wrong-before@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Attach(customer);
+        LoggerFactory.Clear();
+
+        customer.Version = 2;
+        customer.Email = "wrong-after@example.com";
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        var assertion = await act.Should().ThrowAsync<DbUpdateException>();
+        assertion.And.Should().NotBeOfType<DbUpdateConcurrencyException>();
+        assertion.WithMessage("*not found for its key*");
+
+        var realItem =
+            await GetItemAsync("TENANT#CONC-WRONG-SK", "CUSTOMER#REAL", CancellationToken);
+        realItem.Should().NotBeNull();
+        realItem!["version"].N.Should().Be("1");
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "email" = ?, "version" = ?
+            WHERE "pk" = ? AND "sk" = ? AND "version" = ?
+            """);
+    }
+
+    /// <summary>
+    ///     If neither key component matches any item, the failed UPDATE is reported as a missing key
+    ///     target instead of a stale-token concurrency conflict.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task UpdateAsync_NonExistentKey_ThrowsDbUpdateExceptionNotConcurrency()
+    {
+        var customer = new CustomerItem
+        {
+            Pk = "TENANT#CONC-GHOST",
+            Sk = "CUSTOMER#GHOST-UPD",
+            Version = 1,
+            Email = "ghost-before@example.com",
+            IsPreferred = false,
+            CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+        Db.Customers.Attach(customer);
+        LoggerFactory.Clear();
+
+        customer.Version = 2;
+        customer.Email = "ghost-after@example.com";
+        var act = async () => await Db.SaveChangesAsync(CancellationToken);
+        var assertion = await act.Should().ThrowAsync<DbUpdateException>();
+        assertion.And.Should().NotBeOfType<DbUpdateConcurrencyException>();
+        assertion.WithMessage("*not found for its key*");
+
+        AssertSql(
+            """
+            UPDATE "AppItems"
+            SET "email" = ?, "version" = ?
+            WHERE "pk" = ? AND "sk" = ? AND "version" = ?
+            """);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────────
     //  DELETE — stale version
     // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This updates DynamoDB write failure handling so conditional failures can distinguish missing key targets from actual optimistic concurrency conflicts. The provider now requests DynamoDB `ALL_OLD` data on condition-check failures and uses returned old item presence to classify exceptions more accurately.

## Changes

- Set `ReturnValuesOnConditionCheckFailure = ALL_OLD` for single, transactional, and batch PartiQL writes.
- Map conditional failures with returned old item data to `DbUpdateConcurrencyException`.
- Map conditional failures without returned old item data to `DbUpdateException` with a key-not-found message.
- Preserve batch `BatchStatementError.Item` data when converting batch statement failures.
- Add integration coverage for missing item, wrong sort key, and stale version cases.
- Update concurrency docs to explain key-miss vs token-conflict behavior.

## Validation

- `dotnet build`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj --no-build`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj --no-build -- --filter-class EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable.SaveChangesConcurrencyTests`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj --no-build -- --filter-method '*DeleteAsync_NonExistentKey_IsNoOp'`
- `task docs:build`

## Related Issues

Fixes #170