### PR TITLE
feat: add DynamoDB diagnostics and observability

### DIFF
--- a/.agents/skills/dynamodb-efcore-docs-update/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-docs-update/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dynamodb-efcore-docs-update
+description: Update documentation for behavior changes in the DynamoDB EF Core provider. Use when LINQ translation, PartiQL generation, pagination/projection semantics, diagnostics, configuration, or supported limitations change.
+---
+
+# DynamoDB EF Core Docs Update
+
+## Overview
+
+Use this skill whenever provider behavior changes so docs stay accurate in the same story. Follow
+this checklist to update canonical docs pages, keep examples aligned with supported translation, and
+verify docs build.
+
+## Trigger Conditions
+
+- New or changed LINQ operator translation
+- PartiQL generation behavior changes
+- Pagination/result limit/token semantics changes
+- Projection/materialization behavior changes
+- Provider option/configuration changes
+- New diagnostics, warnings, or logging changes
+- Newly supported or unsupported query shapes
+- Query pipeline architecture flow changes
+
+## Workflow
+
+1. Classify the behavior change
+  - Operator translation
+  - Pagination semantics
+  - Projection/materialization
+  - Configuration/options
+  - Diagnostics/warnings
+  - Limitations/support matrix
+  - Architecture/pipeline
+
+2. Update canonical docs first
+  - `docs/operators.md` for operator behavior and examples
+  - `docs/limitations.md` for unsupported or constrained shapes
+
+3. Update topical docs only where impacted
+  - `docs/pagination.md`
+  - `docs/projections.md`
+  - `docs/configuration.md`
+  - `docs/diagnostics.md`
+  - `docs/architecture.md`
+
+4. Check example correctness and scope
+  - Keep examples aligned with currently supported translation
+  - Avoid method calls in `Where` unless explicitly supported
+  - Keep content user-facing and concise
+  - Do not add internal test/code links in published docs
+
+5. Add DynamoDB/PartiQL semantic context when needed
+  - If behavior depends on AWS semantics, include a relevant AWS reference
+  - Typical references: ExecuteStatement API, PartiQL SELECT/operators, AttributeValue
+
+6. Update docs site config only if necessary
+  - Edit `zensical.toml` only when navigation or docs config must change
+
+7. Verify docs build
+  - Preferred: `uv run zensical build`
+  - Alternative: `task docs:build`
+
+## Output Checklist
+
+- Changed behavior is documented in all relevant canonical/topical pages
+- Examples reflect currently supported LINQ translation
+- AWS semantic references are added where behavior depends on DynamoDB/PartiQL rules
+- No internal implementation/test links were introduced in docs
+- Docs build succeeds
+
+## Reference
+
+See `references/doc-pages.md` for a quick page-impact matrix and an operator entry template.

--- a/.agents/skills/dynamodb-efcore-docs-update/references/doc-pages.md
+++ b/.agents/skills/dynamodb-efcore-docs-update/references/doc-pages.md
@@ -1,0 +1,45 @@
+## Docs Page Impact Matrix
+
+Use this quick map to decide which docs to update for a behavior change.
+
+- Operator translation changed -> `docs/operators.md`, `docs/limitations.md` (if partially
+  supported)
+- Pagination/result limits/tokens changed -> `docs/pagination.md`, `docs/operators.md` (if
+  operator-specific)
+- Projection/materialization behavior changed -> `docs/projections.md`, `docs/operators.md` (if
+  query-shape specific)
+- Provider configuration/option changed -> `docs/configuration.md`
+- New warnings/logs/diagnostics changed -> `docs/diagnostics.md`
+- Support/limitations changed -> `docs/limitations.md`, `docs/operators.md`
+- End-to-end query pipeline changed -> `docs/architecture.md`
+- Navigation/site structure changed -> `zensical.toml`
+
+## Operator Entry Template
+
+Use this structure when adding or updating an operator in `docs/operators.md`.
+
+```
+### <Operator or LINQ shape>
+
+Supported: <Yes|No|Partial>
+
+LINQ example:
+<short snippet that is currently supported>
+
+PartiQL shape:
+<representative PartiQL pattern or statement>
+
+Notes:
+- <behavior caveat or translation boundary>
+- <client/server evaluation note, if relevant>
+
+AWS semantic reference (when needed):
+- <link to ExecuteStatement / PartiQL operators / AttributeValue docs>
+```
+
+## Quality Checks Before Build
+
+- Examples compile mentally against current supported translation surface
+- No internal code/test links in user-facing docs
+- Language is concise and behavior-focused
+- AWS semantic references included where behavior depends on DynamoDB/PartiQL rules

--- a/.agents/skills/dynamodb-efcore-integration-tests/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-integration-tests/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: dynamodb-efcore-integration-tests
+description: Write DynamoDB Local integration tests for this EF Core provider (fixtures, per-test resets, seed comparisons, PartiQL baselines).
+---
+
+# DynamoDB EF Core Integration Tests
+
+Write end-to-end integration tests that run EF Core queries against DynamoDB Local and assert both
+results and generated PartiQL.
+
+## When to use
+
+Use this skill when you:
+
+- add or change query translation/execution behavior and need end-to-end verification
+- add a new table suite under `tests/LayeredCraft.EntityFrameworkCore.DynamoDb.IntegrationTests/`
+- need to debug/lock down generated PartiQL via `AssertSql(...)`
+
+## Quick start
+
+1. Pick an existing suite under
+   `tests/LayeredCraft.EntityFrameworkCore.DynamoDb.IntegrationTests/` (or create a new one).
+2. In a test:
+
+- prefer `[Fact(Timeout = TestConfiguration.DefaultTimeout)]` over plain `[Fact]`
+- execute the query on `Db` using `CancellationToken`
+- compute `expected` from the suite seed data (null-safe)
+- assert results with FluentAssertions
+- assert the exact PartiQL with `AssertSql("""...""")`
+
+3. Run the integration test project.
+
+## Conventions to follow
+
+- Always compare against in-memory seed collections; avoid hardcoded keys.
+- Mirror EF null-propagation in expected queries (`?.`), and guard list indexing.
+- For single-item queries, use `query.AsAsyncEnumerable().SingleAsync(CancellationToken)`.
+- For xUnit tests, use `[Fact(Timeout = TestConfiguration.DefaultTimeout)]` unless there is a
+  documented reason not to.
+- Prefer `AsNoTracking()` unless the test is explicitly about tracking.
+- PartiQL baselines must be the full statement; parameterized values appear as `?`.
+
+## References
+
+- `.Codex/skills/dynamodb-efcore-integration-tests/references/integration-tests.md`

--- a/.agents/skills/dynamodb-efcore-integration-tests/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-integration-tests/SKILL.md
@@ -13,13 +13,13 @@ results and generated PartiQL.
 Use this skill when you:
 
 - add or change query translation/execution behavior and need end-to-end verification
-- add a new table suite under `tests/LayeredCraft.EntityFrameworkCore.DynamoDb.IntegrationTests/`
+- add a new table suite under `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/`
 - need to debug/lock down generated PartiQL via `AssertSql(...)`
 
 ## Quick start
 
 1. Pick an existing suite under
-   `tests/LayeredCraft.EntityFrameworkCore.DynamoDb.IntegrationTests/` (or create a new one).
+   `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/` (or create a new one).
 2. In a test:
 
 - prefer `[Fact(Timeout = TestConfiguration.DefaultTimeout)]` over plain `[Fact]`

--- a/.agents/skills/dynamodb-efcore-integration-tests/references/integration-tests.md
+++ b/.agents/skills/dynamodb-efcore-integration-tests/references/integration-tests.md
@@ -1,0 +1,118 @@
+# DynamoDB EF Core Provider Integration Tests (Repo Conventions)
+
+Integration tests live in `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/` and run against
+DynamoDB Local (Testcontainers).
+
+## Project layout
+
+- Test project:
+  `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj`
+- Suites (examples):
+  - `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SimpleTable/`
+  - `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/OwnedTypesTable/`
+- Shared helpers:
+  -
+  `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/TestUtilities/DynamoDbPerTestResetTestBase.cs`
+  - `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/TestUtilities/DynamoDbSchemaManager.cs`
+
+## Base classes (how tests get Db, seeding, and AssertSql)
+
+- `DynamoDbTestBase<TFixture, TContext>`
+  - builds `DbContextOptions` via `UseDynamo(...)` with the fixture's `IAmazonDynamoDB`
+  - exposes `CancellationToken` via `TestContext.Current.CancellationToken`
+- `DynamoDbPerTestResetTestBase<TFixture, TContext>`
+  - per test: deletes all tables, (re)creates tables, seeds, creates `Db` + logger
+  - provides `AssertSql(params string[] expected)` to baseline captured PartiQL
+
+## Canonical test structure
+
+```csharp
+[Fact]
+public async Task Where_SomeCondition_ReturnsMatchingItems()
+{
+    var results = await Db.Items
+        .AsNoTracking()
+        .Where(x => x.SomeProperty == "value")
+        .ToListAsync(CancellationToken);
+
+    var expected = SeedDataClass.Items
+        .Where(x => x.SomeProperty == "value") // keep expected null-safe when applicable
+        .ToList();
+
+    results.Should().BeEquivalentTo(expected);
+
+    AssertSql(
+        """
+        SELECT ...
+        FROM "TableName"
+        WHERE "SomeProperty" = ?
+        """);
+}
+```
+
+Notes:
+
+- PartiQL uses `?` placeholders for parameterized values in baselines.
+- Always baseline the full statement (including SELECT list, FROM, WHERE, ORDER BY, LIMIT, etc.).
+
+## Rules of thumb (keep these consistent across suites)
+
+- Expected results:
+  - Always derive from the in-memory seed data for that suite (e.g. `OwnedTypesItems.Items`).
+  - Avoid hardcoding `Pk`/`Sk` values or building ad-hoc expected objects unless the test itself
+    inserts the data.
+- Null semantics:
+  - Mirror EF Core null-propagation (`?.`) in your expected LINQ.
+  - Guard list indexing (e.g. `x.Tags.Count > 0 && x.Tags[0] == ...`).
+- Single item queries:
+  - Prefer `await query.AsAsyncEnumerable().SingleAsync(CancellationToken)`.
+- Tracking:
+  - Prefer `AsNoTracking()` unless the test asserts tracking behavior.
+
+## Creating a new suite (minimal checklist)
+
+1. Add a suite folder under `tests/EntityFrameworkCore.DynamoDb.IntegrationTests/`.
+2. Create a fixture that starts DynamoDB Local:
+
+```csharp
+public sealed class MySuiteDynamoFixture : DynamoFixture
+{
+    public const string TableName = "MySuiteItems";
+}
+```
+
+3. Create a suite base that derives from `DynamoDbPerTestResetTestBase<..., ...>`:
+
+```csharp
+public abstract class MySuiteTestBase
+    : DynamoDbPerTestResetTestBase<MySuiteDynamoFixture, MySuiteDbContext>
+{
+    protected MySuiteTestBase(MySuiteDynamoFixture fixture) : base(fixture)
+    {
+    }
+
+    protected override async Task CreateTablesAsync(CancellationToken cancellationToken)
+    {
+        // CreateTableAsync(...) then wait for ACTIVE.
+        // Use DynamoDbSchemaManager.WaitForTableActiveAsync(...) where applicable.
+    }
+
+    protected override async Task SeedAsync(CancellationToken cancellationToken)
+    {
+        // Insert seed items (BatchWriteItem is typically chunked in batches of 25;
+        // retry UnprocessedItems until cleared).
+    }
+}
+```
+
+4. Add seed data for the suite (both typed objects and AttributeValue maps as needed).
+5. Add tests that follow the canonical structure and assert PartiQL via `AssertSql`.
+
+## Running integration tests
+
+- Use the `dotnet-test-mcp` runner when available.
+- Or run directly:
+
+```bash
+dotnet test tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj
+```

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,18 +1,5 @@
 [features]
 codex_hooks = true
 
-[mcp_servers.caveman-shrink]
-args = [
-  "-y",
-  "caveman-shrink",
-]
-command = "npx"
-
-[mcp_servers.context7]
-url = "https://mcp.context7.com/mcp"
-
-[mcp_servers.context7.http_headers]
-CONTEXT7_API_KEY = "YOUR_API_KEY"
-
 [mcp_servers.dotnet-test-mcp]
 command = "dotnet-test-mcp"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,18 @@
 [features]
 codex_hooks = true
+
+[mcp_servers.caveman-shrink]
+args = [
+  "-y",
+  "caveman-shrink",
+]
+command = "npx"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.context7.http_headers]
+CONTEXT7_API_KEY = "YOUR_API_KEY"
+
+[mcp_servers.dotnet-test-mcp]
+command = "dotnet-test-mcp"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+At session start, load `AGENTS.local.md` if it exists.
+
 This repo is an EF Core provider for AWS DynamoDB: LINQ -> translation -> PartiQL -> AWS SDK
 execution.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -158,7 +158,7 @@ issue another request.
 
 ### `ExecuteStatementFailed` — 30112
 
-Fires when an `ExecuteStatement` request fails or is canceled:
+Fires when an `ExecuteStatement` request fails with a non-cancellation exception:
 
 ```
 fail: Microsoft.EntityFrameworkCore.Database.Command[30112]
@@ -168,6 +168,8 @@ fail: Microsoft.EntityFrameworkCore.Database.Command[30112]
 The payload includes the thrown `exception`, `elapsed`, `commandId`, AWS `requestId` when
 available, `limit`, `nextTokenPresent`, and `seedNextTokenPresent`. Failed page requests propagate
 the original exception to query enumeration; the provider does not convert them to empty pages.
+Canceled query requests surface through EF Core's `QueryCanceled` diagnostic event instead of
+`ExecuteStatementFailed`.
 
 ## Query Events
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -76,6 +76,7 @@ emitted as log events.
 | `ExecutingPartiQlQuery`                    | 30100    | `Database.Command` | Information | —               |
 | `ExecutingExecuteStatement`                | 30101    | `Database.Command` | Information | —               |
 | `ExecutedExecuteStatement`                 | 30102    | `Database.Command` | Information | —               |
+| `ExecuteStatementFailed`                   | 30112    | `Database.Command` | Error       | —               |
 | `ExecutingPartiQlWrite`                    | 30110    | `Database.Command` | Information | —               |
 | `ExecutingPartiQlWriteRequest`             | 30113    | `Database.Command` | Information | —               |
 | `ExecutedPartiQlWriteRequest`              | 30114    | `Database.Command` | Information | —               |
@@ -131,6 +132,7 @@ Fields:
 | `limit`                | The page size sent on this request. `null` means no limit was set — DynamoDB will return up to its internal 1 MB cap per page. |
 | `nextTokenPresent`     | `True` when this is a continuation call — the provider is fetching the next page using a token from the previous response.     |
 | `seedNextTokenPresent` | `True` when the *first* request used a user-supplied pagination token (e.g. from a manual pagination call).                    |
+| `commandId`            | Provider-generated id that correlates start, completion, and failure diagnostics for the same AWS request.                     |
 
 The `limit` value is set by a query-level `Limit(n)` call or by `ToPageAsync(limit, token)`. If it
 is `null` and your query can return many items, you will typically see multiple round-trips as the
@@ -145,6 +147,28 @@ info: Microsoft.EntityFrameworkCore.Database.Command[30102]
       Executed DynamoDB ExecuteStatement request (itemsCount: 25, nextTokenPresent: True)
 ```
 
+Diagnostic payload fields include `itemsCount`, `nextTokenPresent`, `elapsed`, `commandId`,
+`requestId`, `limit`, `seedNextTokenPresent`, and `consumedCapacity`. The log message keeps the
+older concise shape for compatibility; use `DiagnosticListener` or structured diagnostics when you
+need request id, elapsed time, or consumed capacity.
+
+If `itemsCount` is less than `limit` and `nextTokenPresent` is still `True`, DynamoDB reached its
+internal 1 MB page cap before filling your requested page size. The provider will automatically
+issue another request.
+
+### `ExecuteStatementFailed` — 30112
+
+Fires when an `ExecuteStatement` request fails or is canceled:
+
+```
+fail: Microsoft.EntityFrameworkCore.Database.Command[30112]
+      Failed executing DynamoDB ExecuteStatement request (requestId: ..., elapsed: 12.34ms)
+```
+
+The payload includes the thrown `exception`, `elapsed`, `commandId`, AWS `requestId` when
+available, `limit`, `nextTokenPresent`, and `seedNextTokenPresent`. Failed page requests propagate
+the original exception to query enumeration; the provider does not convert them to empty pages.
+
 ## Query Events
 
 ### `ScanLikeQueryDetected` — 30111
@@ -158,16 +182,7 @@ warn: Microsoft.EntityFrameworkCore.Query[30111]
 
 By default, the same message is thrown as an `InvalidOperationException` before PartiQL generation or `ExecuteStatement`. The provider registers this event as an explicit throwing warning, so `ConfigureWarnings(w => w.Default(...))` does not override it. Use `ConfigureWarnings` with `DynamoEventId.ScanLikeQueryDetected` to `Log`, `Ignore`, or `Throw` this event explicitly.
 
-Fields:
-
-| Field              | Meaning                                                                      |
-| ------------------ | ---------------------------------------------------------------------------- |
-| `itemsCount`       | Number of items in this page.                                                |
-| `nextTokenPresent` | `True` when DynamoDB returned a continuation token — more data is available. |
-
-If `itemsCount` is less than `limit` and `nextTokenPresent` is still `True`, DynamoDB reached its
-internal 1 MB page cap before filling your requested page size. The provider will automatically
-issue another request.
+The payload contains `message`, matching the rendered warning text.
 
 ### `ExecutingPartiQlWrite` — 30110
 
@@ -202,9 +217,17 @@ Request payloads include operation kind (`ExecuteStatement`, `ExecuteTransaction
 `BatchExecuteStatement`), statement count, provider command id, elapsed time, AWS request id when
 available, and consumed capacity when DynamoDB returns it.
 
+| Event                                      | Diagnostic payload fields                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `ExecutingPartiQlWriteRequest`             | `operation`, `statementCount`, `commandId`                                             |
+| `ExecutedPartiQlWriteRequest`              | `operation`, `statementCount`, `elapsed`, `commandId`, `requestId`, `consumedCapacity` |
+| `PartiQlWriteRequestFailed`                | `operation`, `statementCount`, `exception`, `elapsed`, `commandId`, `requestId`        |
+| `BatchPartiQlWriteReturnedStatementErrors` | `statementCount`, `errorCount`, `commandId`, `requestId`                               |
+
 For `BatchExecuteStatement`, per-statement `Error` values are not logged as command failures: the
 AWS command succeeded, then the provider reports returned statement errors as a warning and keeps
-normal `SaveChanges` exception/concurrency behavior.
+normal `SaveChanges` exception/concurrency behavior. DynamoDB can return HTTP success while some
+batch statements failed; treat this warning as a per-item failure signal, not a transport failure.
 
 ## Index Selection Events
 
@@ -383,17 +406,19 @@ results from multiple round-trips.
 
 ### `ConsumedCapacity`
 
-`ConsumedCapacity` is `null` unless `ReturnConsumedCapacity` was configured on the underlying
-`ExecuteStatementRequest`. To set this today, access the low-level client directly:
+`ConsumedCapacity` is `null` unless provider options request it and DynamoDB returns it. Configure
+this once on the provider options:
 
 ```csharp
-var client = context.Database.GetDynamoClient();
-// Use client.ExecuteStatementAsync(...) with ReturnConsumedCapacity configured
+optionsBuilder.UseDynamo(options => options
+    .DynamoDbClient(client)
+    .ReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL));
 ```
 
-!!! note "Planned"
-
-    Provider-level configuration for `ReturnConsumedCapacity` is tracked for a future release.
+`ReturnConsumedCapacity.TOTAL` reports table-level capacity. `ReturnConsumedCapacity.INDEXES` asks
+DynamoDB for table and index capacity details where the API supports them. Read diagnostics expose
+a single `ConsumedCapacity`; write request diagnostics expose a list because transaction and batch
+APIs can return multiple capacity entries.
 
 ## Model Validation Errors
 
@@ -428,21 +453,45 @@ during development, not in production steady-state.
 See [Supported Operators](querying/operators.md) and [Limitations](limitations.md) for the full
 list of supported and unsupported LINQ shapes.
 
+## DiagnosticListener Payloads
+
+EF Core also publishes these events through `DiagnosticListener` using provider-specific
+`EventData` payload types:
+
+| Payload type                                 | Events                                             |
+| -------------------------------------------- | -------------------------------------------------- |
+| `DynamoPartiQlCommandEventData`              | `ExecutingPartiQlQuery`, `ExecutingPartiQlWrite`   |
+| `DynamoExecuteStatementEventData`            | `ExecutingExecuteStatement`                        |
+| `DynamoExecuteStatementExecutedEventData`    | `ExecutedExecuteStatement`                         |
+| `DynamoExecuteStatementFailedEventData`      | `ExecuteStatementFailed`                           |
+| `DynamoPartiQlWriteRequestEventData`         | `ExecutingPartiQlWriteRequest`                     |
+| `DynamoPartiQlWriteRequestExecutedEventData` | `ExecutedPartiQlWriteRequest`                      |
+| `DynamoPartiQlWriteRequestFailedEventData`   | `PartiQlWriteRequestFailed`                        |
+| `DynamoBatchStatementErrorsEventData`        | `BatchPartiQlWriteReturnedStatementErrors`         |
+| `DynamoQueryDiagnosticEventData`             | Index-selection events and `ScanLikeQueryDetected` |
+
+Use `commandId` to join request start/completion/failure events in traces. Use AWS `requestId` for
+AWS Support cases and to correlate with SDK/service logs.
+
+## Inspecting Generated PartiQL
+
+Use EF Core's `ToQueryString()` to inspect generated PartiQL without sending a request:
+
+```csharp
+var partiQl = context.Orders
+    .Where(o => o.CustomerId == customerId)
+    .ToQueryString();
+```
+
+The output includes parameter comments with formatted DynamoDB `AttributeValue` values followed by
+the PartiQL text. `ToQueryString()` is for debugging: it does not execute scan-warning behavior,
+log command events, or call DynamoDB.
+
 ## Not Yet Available
-
-The following diagnostic features are tracked for future releases:
-
-**`ConfigureWarnings` integration** — Some warning events (`DYNAMO_IDX001`, `DYNAMO_IDX002`) cannot
-yet be escalated to exceptions or suppressed via `optionsBuilder.ConfigureWarnings(w => w.Throw(...))`.
-`ScanLikeQueryDetected` does support standard EF Core warning configuration.
 
 **Sensitive data logging** — `EnableSensitiveDataLogging()` has no effect on DynamoDB provider
 logs. Parameter values in PartiQL statements are always omitted from log output regardless of
 this setting.
-
-**Row-limiting query warning** — A warning for queries that can return many rows but have no
-explicit `Limit(n)` is planned but not yet emitted. Use the `ExecutedExecuteStatement` events to
-monitor round-trip counts and item counts in the meantime.
 
 ## See Also
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -71,19 +71,23 @@ emitted as log events.
 
 ## Event Reference
 
-| Event Name                                | Event ID | Category           | Level       | Code            |
-| ----------------------------------------- | -------- | ------------------ | ----------- | --------------- |
-| `ExecutingPartiQlQuery`                   | 30100    | `Database.Command` | Information | —               |
-| `ExecutingExecuteStatement`               | 30101    | `Database.Command` | Information | —               |
-| `ExecutedExecuteStatement`                | 30102    | `Database.Command` | Information | —               |
-| `ExecutingPartiQlWrite`                   | 30110    | `Database.Command` | Information | —               |
-| `NoCompatibleSecondaryIndexFound`         | 30104    | `Query`            | Warning     | `DYNAMO_IDX001` |
-| `MultipleCompatibleSecondaryIndexesFound` | 30105    | `Query`            | Warning     | `DYNAMO_IDX002` |
-| `SecondaryIndexSelected`                  | 30106    | `Query`            | Information | `DYNAMO_IDX003` |
-| `ExplicitIndexSelected`                   | 30107    | `Query`            | Information | `DYNAMO_IDX004` |
-| `SecondaryIndexCandidateRejected`         | 30108    | `Query`            | Information | `DYNAMO_IDX005` |
-| `ExplicitIndexSelectionDisabled`          | 30109    | `Query`            | Information | `DYNAMO_IDX006` |
-| `ScanLikeQueryDetected`                   | 30111    | `Query`            | Warning     | —               |
+| Event Name                                 | Event ID | Category           | Level       | Code            |
+| ------------------------------------------ | -------- | ------------------ | ----------- | --------------- |
+| `ExecutingPartiQlQuery`                    | 30100    | `Database.Command` | Information | —               |
+| `ExecutingExecuteStatement`                | 30101    | `Database.Command` | Information | —               |
+| `ExecutedExecuteStatement`                 | 30102    | `Database.Command` | Information | —               |
+| `ExecutingPartiQlWrite`                    | 30110    | `Database.Command` | Information | —               |
+| `ExecutingPartiQlWriteRequest`             | 30113    | `Database.Command` | Information | —               |
+| `ExecutedPartiQlWriteRequest`              | 30114    | `Database.Command` | Information | —               |
+| `PartiQlWriteRequestFailed`                | 30115    | `Database.Command` | Error       | —               |
+| `BatchPartiQlWriteReturnedStatementErrors` | 30116    | `Database.Command` | Warning     | —               |
+| `NoCompatibleSecondaryIndexFound`          | 30104    | `Query`            | Warning     | `DYNAMO_IDX001` |
+| `MultipleCompatibleSecondaryIndexesFound`  | 30105    | `Query`            | Warning     | `DYNAMO_IDX002` |
+| `SecondaryIndexSelected`                   | 30106    | `Query`            | Information | `DYNAMO_IDX003` |
+| `ExplicitIndexSelected`                    | 30107    | `Query`            | Information | `DYNAMO_IDX004` |
+| `SecondaryIndexCandidateRejected`          | 30108    | `Query`            | Information | `DYNAMO_IDX005` |
+| `ExplicitIndexSelectionDisabled`           | 30109    | `Query`            | Information | `DYNAMO_IDX006` |
+| `ScanLikeQueryDetected`                    | 30111    | `Query`            | Warning     | —               |
 
 Event IDs are stable across releases. You can use them to filter log output programmatically or
 in structured logging sinks.
@@ -181,6 +185,26 @@ write operations — whether transactional or non-transactional — each one gen
 
 Use this event to verify that complex properties, primitive collections, and discriminator values are
 being serialized into the expected PartiQL parameter positions.
+
+### Write request lifecycle — 30113, 30114, 30115, 30116
+
+The provider also logs request-level write diagnostics around actual AWS SDK calls. These events
+are separate from `ExecutingPartiQlWrite`, which remains statement-level for compatibility.
+
+| Event                                      | Meaning                                                                             |
+| ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `ExecutingPartiQlWriteRequest`             | A write SDK request is about to be sent.                                            |
+| `ExecutedPartiQlWriteRequest`              | The SDK request completed successfully.                                             |
+| `PartiQlWriteRequestFailed`                | The SDK request failed with an exception.                                           |
+| `BatchPartiQlWriteReturnedStatementErrors` | `BatchExecuteStatement` returned HTTP success but one or more per-statement errors. |
+
+Request payloads include operation kind (`ExecuteStatement`, `ExecuteTransaction`, or
+`BatchExecuteStatement`), statement count, provider command id, elapsed time, AWS request id when
+available, and consumed capacity when DynamoDB returns it.
+
+For `BatchExecuteStatement`, per-statement `Error` values are not logged as command failures: the
+AWS command succeeded, then the provider reports returned statement errors as a warning and keeps
+normal `SaveChanges` exception/concurrency behavior.
 
 ## Index Selection Events
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -61,8 +61,8 @@ DynamoDB counts *evaluated* items against `Limit` (not matched items), this is o
 `WHERE` clause guarantees at most one evaluation pass before a match:
 
 1. No user-specified `Limit(n)` on the query.
-1. The `WHERE` clause includes a partition-key equality condition.
-1. Any sort-key predicate is a valid DynamoDB key condition (`=`, `<`, `<=`, `>`, `>=`,
+2. The `WHERE` clause includes a partition-key equality condition.
+3. Any sort-key predicate is a valid DynamoDB key condition (`=`, `<`, `<=`, `>`, `>=`,
     `BETWEEN`, `begins_with`).
 
 Queries that do not meet all three conditions throw `InvalidOperationException` at translation
@@ -152,7 +152,7 @@ DynamoDB `ExecuteTransaction` enforces two hard limits:
     max 100), the provider throws `InvalidOperationException` unless
     `TransactionOverflowBehavior.UseChunking` is configured.
 
-1. **No duplicate items within a single transaction.** Writing the same DynamoDB item more than
+2. **No duplicate items within a single transaction.** Writing the same DynamoDB item more than
     once in a single transaction throws `InvalidOperationException` — the provider validates this
     client-side before sending the request to DynamoDB.
 
@@ -280,11 +280,11 @@ Synchronous query execution throws `InvalidOperationException`. This applies to 
 enumeration, not just `SaveChanges`. Methods like `ToList()`, `First()`, and `Count()` on a
 `DbSet` will throw. Use `ToListAsync()`, `FirstAsync()`, `AsAsyncEnumerable()`, etc.
 
-### `ToQueryString()` Not Implemented
+### `ToQueryString()` Is Debug-Only
 
-`IQueryable<T>.ToQueryString()` throws `NotImplementedException`. To inspect generated PartiQL,
-enable command logging at `Information` level and read the `ExecutingPartiQlQuery` event. See
-[Diagnostics and Logging](diagnostics.md).
+`IQueryable<T>.ToQueryString()` returns generated PartiQL and formatted parameter comments without
+sending a request to DynamoDB. It does not execute scan warnings, log command events, or validate
+that DynamoDB accepts the statement at runtime. See [Diagnostics and Logging](diagnostics.md).
 
 ### Parameterized Null Inconsistency
 

--- a/docs/querying/how-queries-execute.md
+++ b/docs/querying/how-queries-execute.md
@@ -12,8 +12,8 @@ _The provider compiles LINQ expressions into PartiQL `SELECT` statements and exe
 When you execute a LINQ query, the provider runs it through a multi-stage compilation pipeline before any network call is made:
 
 1. **`DynamoQueryableMethodTranslatingExpressionVisitor`** walks the LINQ expression tree and builds a `SelectExpression` — an internal query model representing the projected columns, `WHERE` predicate, `ORDER BY` orderings, and evaluation limit.
-1. **`DynamoQueryTranslationPostprocessor`** finalizes the `SelectExpression`: it injects discriminator predicates for shared-table entity types and runs index selection analysis to determine whether a GSI or LSI should be used.
-1. **`DynamoQuerySqlGenerator`** converts the `SelectExpression` into a PartiQL `SELECT` statement with positional `?` placeholders and a matching `AttributeValue` parameter list.
+2. **`DynamoQueryTranslationPostprocessor`** finalizes the `SelectExpression`: it injects discriminator predicates for shared-table entity types and runs index selection analysis to determine whether a GSI or LSI should be used.
+3. **`DynamoQuerySqlGenerator`** converts the `SelectExpression` into a PartiQL `SELECT` statement with positional `?` placeholders and a matching `AttributeValue` parameter list.
 
 ```csharp
 var orders = await db.Orders
@@ -63,6 +63,26 @@ Some projection shaping also runs client-side. Computed expressions in `Select` 
 arithmetic, constructor calls) and nested complex-property materialization are applied by the
 shaper lambda after the server returns the raw `AttributeValue` rows. This is expected behavior
 and is documented per operator on the [Projection](projection.md) page.
+
+## Debugging Generated PartiQL
+
+Use EF Core's `ToQueryString()` to inspect generated PartiQL without sending a request to DynamoDB.
+Parameterized queries include comment lines with positional parameter names (`p0`, `p1`, ...) and
+formatted DynamoDB `AttributeValue` values before the PartiQL text.
+
+```csharp
+var partiQl = db.Orders
+    .Where(o => o.CustomerId == customerId)
+    .ToQueryString();
+
+// -- p0='CUSTOMER#123'
+// SELECT "pk", "sk", "total"
+// FROM "Orders"
+// WHERE "CustomerId" = ?
+```
+
+`ToQueryString()` is for debugging only: it does not run scan warnings, log query execution events,
+or execute `ExecuteStatement`.
 
 ## Async Execution
 

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2.Model;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EntityFrameworkCore.DynamoDb.Diagnostics;
@@ -22,7 +23,8 @@ public class DynamoExecuteStatementEventData(
     Func<EventDefinitionBase, EventData, string> messageGenerator,
     int? limit,
     bool nextTokenPresent,
-    bool seedNextTokenPresent) : EventData(eventDefinition, messageGenerator)
+    bool seedNextTokenPresent,
+    Guid commandId = default) : EventData(eventDefinition, messageGenerator)
 {
     /// <summary>Gets request limit.</summary>
     public virtual int? Limit { get; } = limit;
@@ -32,6 +34,9 @@ public class DynamoExecuteStatementEventData(
 
     /// <summary>Gets whether seed continuation token is present.</summary>
     public virtual bool SeedNextTokenPresent { get; } = seedNextTokenPresent;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
 }
 
 /// <summary>DiagnosticSource payload for completed DynamoDB ExecuteStatement request events.</summary>
@@ -39,13 +44,71 @@ public class DynamoExecuteStatementExecutedEventData(
     EventDefinitionBase eventDefinition,
     Func<EventDefinitionBase, EventData, string> messageGenerator,
     int itemsCount,
-    bool nextTokenPresent) : EventData(eventDefinition, messageGenerator)
+    bool nextTokenPresent,
+    TimeSpan elapsed = default,
+    Guid commandId = default,
+    string? requestId = null,
+    int? limit = null,
+    bool seedNextTokenPresent = false,
+    ConsumedCapacity? consumedCapacity = null) : EventData(eventDefinition, messageGenerator)
 {
     /// <summary>Gets returned item count.</summary>
     public virtual int ItemsCount { get; } = itemsCount;
 
     /// <summary>Gets whether continuation token is present.</summary>
     public virtual bool NextTokenPresent { get; } = nextTokenPresent;
+
+    /// <summary>Gets request duration.</summary>
+    public virtual TimeSpan Elapsed { get; } = elapsed;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets AWS request id when available.</summary>
+    public virtual string? RequestId { get; } = requestId;
+
+    /// <summary>Gets request limit.</summary>
+    public virtual int? Limit { get; } = limit;
+
+    /// <summary>Gets whether seed continuation token was present.</summary>
+    public virtual bool SeedNextTokenPresent { get; } = seedNextTokenPresent;
+
+    /// <summary>Gets consumed capacity returned by DynamoDB, when requested.</summary>
+    public virtual ConsumedCapacity? ConsumedCapacity { get; } = consumedCapacity;
+}
+
+/// <summary>DiagnosticSource payload for failed DynamoDB ExecuteStatement request events.</summary>
+public class DynamoExecuteStatementFailedEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    Exception exception,
+    TimeSpan elapsed,
+    Guid commandId,
+    string? requestId,
+    int? limit,
+    bool nextTokenPresent,
+    bool seedNextTokenPresent) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets exception that caused request failure.</summary>
+    public virtual Exception Exception { get; } = exception;
+
+    /// <summary>Gets request duration.</summary>
+    public virtual TimeSpan Elapsed { get; } = elapsed;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets AWS request id when available.</summary>
+    public virtual string? RequestId { get; } = requestId;
+
+    /// <summary>Gets request limit.</summary>
+    public virtual int? Limit { get; } = limit;
+
+    /// <summary>Gets whether continuation token was present.</summary>
+    public virtual bool NextTokenPresent { get; } = nextTokenPresent;
+
+    /// <summary>Gets whether seed continuation token was present.</summary>
+    public virtual bool SeedNextTokenPresent { get; } = seedNextTokenPresent;
 }
 
 /// <summary>DiagnosticSource payload for DynamoDB query diagnostics.</summary>

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EntityFrameworkCore.DynamoDb.Diagnostics;
+
+/// <summary>DiagnosticSource payload for DynamoDB PartiQL command text events.</summary>
+public class DynamoPartiQlCommandEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    string tableName,
+    string commandText) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets target DynamoDB table name.</summary>
+    public virtual string TableName { get; } = tableName;
+
+    /// <summary>Gets PartiQL command text.</summary>
+    public virtual string CommandText { get; } = commandText;
+}
+
+/// <summary>DiagnosticSource payload for DynamoDB ExecuteStatement request events.</summary>
+public class DynamoExecuteStatementEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    int? limit,
+    bool nextTokenPresent,
+    bool seedNextTokenPresent) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets request limit.</summary>
+    public virtual int? Limit { get; } = limit;
+
+    /// <summary>Gets whether continuation token is present.</summary>
+    public virtual bool NextTokenPresent { get; } = nextTokenPresent;
+
+    /// <summary>Gets whether seed continuation token is present.</summary>
+    public virtual bool SeedNextTokenPresent { get; } = seedNextTokenPresent;
+}
+
+/// <summary>DiagnosticSource payload for completed DynamoDB ExecuteStatement request events.</summary>
+public class DynamoExecuteStatementExecutedEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    int itemsCount,
+    bool nextTokenPresent) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets returned item count.</summary>
+    public virtual int ItemsCount { get; } = itemsCount;
+
+    /// <summary>Gets whether continuation token is present.</summary>
+    public virtual bool NextTokenPresent { get; } = nextTokenPresent;
+}
+
+/// <summary>DiagnosticSource payload for DynamoDB query diagnostics.</summary>
+public class DynamoQueryDiagnosticEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    string message) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets diagnostic message.</summary>
+    public virtual string Message { get; } = message;
+}

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
@@ -111,6 +111,121 @@ public class DynamoExecuteStatementFailedEventData(
     public virtual bool SeedNextTokenPresent { get; } = seedNextTokenPresent;
 }
 
+/// <summary>Identifies DynamoDB PartiQL write request operation kind.</summary>
+public enum DynamoPartiQlWriteOperation
+{
+    /// <summary>Single ExecuteStatement write request.</summary>
+    ExecuteStatement,
+
+    /// <summary>ExecuteTransaction write request.</summary>
+    ExecuteTransaction,
+
+    /// <summary>BatchExecuteStatement write request.</summary>
+    BatchExecuteStatement
+}
+
+/// <summary>DiagnosticSource payload for DynamoDB PartiQL write request start events.</summary>
+public class DynamoPartiQlWriteRequestEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    DynamoPartiQlWriteOperation operation,
+    int statementCount,
+    Guid commandId) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets DynamoDB operation kind.</summary>
+    public virtual DynamoPartiQlWriteOperation Operation { get; } = operation;
+
+    /// <summary>Gets submitted statement count.</summary>
+    public virtual int StatementCount { get; } = statementCount;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+}
+
+/// <summary>DiagnosticSource payload for completed DynamoDB PartiQL write request events.</summary>
+public class DynamoPartiQlWriteRequestExecutedEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    DynamoPartiQlWriteOperation operation,
+    int statementCount,
+    TimeSpan elapsed,
+    Guid commandId,
+    string? requestId,
+    IReadOnlyList<ConsumedCapacity>? consumedCapacity) : EventData(
+    eventDefinition,
+    messageGenerator)
+{
+    /// <summary>Gets DynamoDB operation kind.</summary>
+    public virtual DynamoPartiQlWriteOperation Operation { get; } = operation;
+
+    /// <summary>Gets submitted statement count.</summary>
+    public virtual int StatementCount { get; } = statementCount;
+
+    /// <summary>Gets request duration.</summary>
+    public virtual TimeSpan Elapsed { get; } = elapsed;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets AWS request id when available.</summary>
+    public virtual string? RequestId { get; } = requestId;
+
+    /// <summary>Gets consumed capacity returned by DynamoDB, when requested.</summary>
+    public virtual IReadOnlyList<ConsumedCapacity>? ConsumedCapacity { get; } = consumedCapacity;
+}
+
+/// <summary>DiagnosticSource payload for failed DynamoDB PartiQL write request events.</summary>
+public class DynamoPartiQlWriteRequestFailedEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    DynamoPartiQlWriteOperation operation,
+    int statementCount,
+    Exception exception,
+    TimeSpan elapsed,
+    Guid commandId,
+    string? requestId) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets DynamoDB operation kind.</summary>
+    public virtual DynamoPartiQlWriteOperation Operation { get; } = operation;
+
+    /// <summary>Gets submitted statement count.</summary>
+    public virtual int StatementCount { get; } = statementCount;
+
+    /// <summary>Gets exception that caused request failure.</summary>
+    public virtual Exception Exception { get; } = exception;
+
+    /// <summary>Gets request duration.</summary>
+    public virtual TimeSpan Elapsed { get; } = elapsed;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets AWS request id when available.</summary>
+    public virtual string? RequestId { get; } = requestId;
+}
+
+/// <summary>DiagnosticSource payload for successful batch write requests with per-statement errors.</summary>
+public class DynamoBatchStatementErrorsEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    int statementCount,
+    int errorCount,
+    Guid commandId,
+    string? requestId) : EventData(eventDefinition, messageGenerator)
+{
+    /// <summary>Gets submitted statement count.</summary>
+    public virtual int StatementCount { get; } = statementCount;
+
+    /// <summary>Gets response statement error count.</summary>
+    public virtual int ErrorCount { get; } = errorCount;
+
+    /// <summary>Gets provider command id for correlating request diagnostics.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets AWS request id when available.</summary>
+    public virtual string? RequestId { get; } = requestId;
+}
+
 /// <summary>DiagnosticSource payload for DynamoDB query diagnostics.</summary>
 public class DynamoQueryDiagnosticEventData(
     EventDefinitionBase eventDefinition,

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
@@ -35,7 +35,7 @@ public static class DynamoEventId
     /// A PartiQL query is going to be executed.
     /// </summary>
     /// <remarks>
-    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category.
+    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoPartiQlCommandEventData" /> payloads.
     /// </remarks>
     public static readonly EventId ExecutingPartiQlQuery = new(
         (int)Id.ExecutingPartiQlQuery,
@@ -45,7 +45,7 @@ public static class DynamoEventId
     /// An ExecuteStatement request is going to be sent.
     /// </summary>
     /// <remarks>
-    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category.
+    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoExecuteStatementEventData" /> payloads.
     /// </remarks>
     public static readonly EventId ExecutingExecuteStatement = new(
         (int)Id.ExecutingExecuteStatement,
@@ -55,7 +55,7 @@ public static class DynamoEventId
     /// An ExecuteStatement request has completed.
     /// </summary>
     /// <remarks>
-    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category.
+    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoExecuteStatementExecutedEventData" /> payloads.
     /// </remarks>
     public static readonly EventId ExecutedExecuteStatement = new(
         (int)Id.ExecutedExecuteStatement,
@@ -65,50 +65,50 @@ public static class DynamoEventId
     /// A PartiQL write statement (INSERT, UPDATE, or DELETE) is going to be executed.
     /// </summary>
     /// <remarks>
-    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category.
+    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoPartiQlCommandEventData" /> payloads.
     /// </remarks>
     public static readonly EventId ExecutingPartiQlWrite = new(
         (int)Id.ExecutingPartiQlWrite,
         CommandPrefix + Id.ExecutingPartiQlWrite);
 
     /// <summary>No compatible secondary index was found for automatic selection.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId NoCompatibleSecondaryIndexFound = new(
         (int)Id.NoCompatibleSecondaryIndexFound,
         QueryPrefix + Id.NoCompatibleSecondaryIndexFound);
 
     /// <summary>Multiple compatible secondary indexes tied during automatic selection.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId MultipleCompatibleSecondaryIndexesFound = new(
         (int)Id.MultipleCompatibleSecondaryIndexesFound,
         QueryPrefix + Id.MultipleCompatibleSecondaryIndexesFound);
 
     /// <summary>A secondary index was selected, or would be selected, for the query.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId SecondaryIndexSelected = new(
         (int)Id.SecondaryIndexSelected,
         QueryPrefix + Id.SecondaryIndexSelected);
 
     /// <summary>A secondary index was explicitly selected via <c>.WithIndex()</c>.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId ExplicitIndexSelected = new(
         (int)Id.ExplicitIndexSelected,
         QueryPrefix + Id.ExplicitIndexSelected);
 
     /// <summary>A secondary index candidate was rejected during automatic index selection.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId SecondaryIndexCandidateRejected = new(
         (int)Id.SecondaryIndexCandidateRejected,
         QueryPrefix + Id.SecondaryIndexCandidateRejected);
 
     /// <summary>Index selection was suppressed by <c>.WithoutIndex()</c>.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId ExplicitIndexSelectionDisabled = new(
         (int)Id.ExplicitIndexSelectionDisabled,
         QueryPrefix + Id.ExplicitIndexSelectionDisabled);
 
     /// <summary>A read query was classified as scan-like.</summary>
-    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category.</remarks>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>
     public static readonly EventId ScanLikeQueryDetected = new(
         (int)Id.ScanLikeQueryDetected,
         QueryPrefix + Id.ScanLikeQueryDetected);

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
@@ -18,6 +18,10 @@ public static class DynamoEventId
         ExecutedExecuteStatement = CoreEventId.ProviderBaseId + 102,
         ExecuteStatementFailed = CoreEventId.ProviderBaseId + 112,
         ExecutingPartiQlWrite = CoreEventId.ProviderBaseId + 110,
+        ExecutingPartiQlWriteRequest = CoreEventId.ProviderBaseId + 113,
+        ExecutedPartiQlWriteRequest = CoreEventId.ProviderBaseId + 114,
+        PartiQlWriteRequestFailed = CoreEventId.ProviderBaseId + 115,
+        BatchPartiQlWriteReturnedStatementErrors = CoreEventId.ProviderBaseId + 116,
 
         // Query events
         NoCompatibleSecondaryIndexFound = CoreEventId.ProviderBaseId + 104,
@@ -81,6 +85,30 @@ public static class DynamoEventId
     public static readonly EventId ExecutingPartiQlWrite = new(
         (int)Id.ExecutingPartiQlWrite,
         CommandPrefix + Id.ExecutingPartiQlWrite);
+
+    /// <summary>A DynamoDB PartiQL write request is going to be sent.</summary>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoPartiQlWriteRequestEventData" /> payloads.</remarks>
+    public static readonly EventId ExecutingPartiQlWriteRequest = new(
+        (int)Id.ExecutingPartiQlWriteRequest,
+        CommandPrefix + Id.ExecutingPartiQlWriteRequest);
+
+    /// <summary>A DynamoDB PartiQL write request completed.</summary>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoPartiQlWriteRequestExecutedEventData" /> payloads.</remarks>
+    public static readonly EventId ExecutedPartiQlWriteRequest = new(
+        (int)Id.ExecutedPartiQlWriteRequest,
+        CommandPrefix + Id.ExecutedPartiQlWriteRequest);
+
+    /// <summary>A DynamoDB PartiQL write request failed.</summary>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoPartiQlWriteRequestFailedEventData" /> payloads.</remarks>
+    public static readonly EventId PartiQlWriteRequestFailed = new(
+        (int)Id.PartiQlWriteRequestFailed,
+        CommandPrefix + Id.PartiQlWriteRequestFailed);
+
+    /// <summary>A successful BatchExecuteStatement write request returned per-statement errors.</summary>
+    /// <remarks>This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoBatchStatementErrorsEventData" /> payloads.</remarks>
+    public static readonly EventId BatchPartiQlWriteReturnedStatementErrors = new(
+        (int)Id.BatchPartiQlWriteReturnedStatementErrors,
+        CommandPrefix + Id.BatchPartiQlWriteReturnedStatementErrors);
 
     /// <summary>No compatible secondary index was found for automatic selection.</summary>
     /// <remarks>This event is in the <c>DbLoggerCategory.Query</c> category and uses <see cref="DynamoQueryDiagnosticEventData" /> payloads.</remarks>

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
@@ -16,6 +16,7 @@ public static class DynamoEventId
         ExecutingPartiQlQuery = CoreEventId.ProviderBaseId + 100,
         ExecutingExecuteStatement = CoreEventId.ProviderBaseId + 101,
         ExecutedExecuteStatement = CoreEventId.ProviderBaseId + 102,
+        ExecuteStatementFailed = CoreEventId.ProviderBaseId + 112,
         ExecutingPartiQlWrite = CoreEventId.ProviderBaseId + 110,
 
         // Query events
@@ -60,6 +61,16 @@ public static class DynamoEventId
     public static readonly EventId ExecutedExecuteStatement = new(
         (int)Id.ExecutedExecuteStatement,
         CommandPrefix + Id.ExecutedExecuteStatement);
+
+    /// <summary>
+    /// An ExecuteStatement request failed.
+    /// </summary>
+    /// <remarks>
+    /// This event is in the <c>DbLoggerCategory.Database.Command</c> category and uses <see cref="DynamoExecuteStatementFailedEventData" /> payloads.
+    /// </remarks>
+    public static readonly EventId ExecuteStatementFailed = new(
+        (int)Id.ExecuteStatementFailed,
+        CommandPrefix + Id.ExecuteStatementFailed);
 
     /// <summary>
     /// A PartiQL write statement (INSERT, UPDATE, or DELETE) is going to be executed.

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -5,142 +5,148 @@ using Microsoft.Extensions.Logging;
 
 namespace EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 
-/// <summary>Represents the DynamoLoggerExtensions type.</summary>
+/// <summary>Provides DynamoDB provider logging extensions.</summary>
 public static class DynamoLoggerExtensions
 {
-    private static readonly Action<ILogger, string, string, string, Exception?>
-        LogExecutingPartiQlQuery = LoggerMessage.Define<string, string, string>(
-            LogLevel.Information,
+    private static readonly Func<LogLevel, Action<ILogger, string, string, string, Exception?>>
+        LogExecutingPartiQlQuery = level => LoggerMessage.Define<string, string, string>(
+            level,
             DynamoEventId.ExecutingPartiQlQuery,
             "Executing DynamoDB PartiQL query for table '{tableName}'{newLine}{commandText}");
 
-    private static readonly Action<ILogger, int?, bool, bool, Exception?>
-        LogExecutingExecuteStatement = LoggerMessage.Define<int?, bool, bool>(
-            LogLevel.Information,
+    private static readonly Func<LogLevel, Action<ILogger, int?, bool, bool, Exception?>>
+        LogExecutingExecuteStatement = level => LoggerMessage.Define<int?, bool, bool>(
+            level,
             DynamoEventId.ExecutingExecuteStatement,
             "Executing DynamoDB ExecuteStatement request (limit: {limit}, nextTokenPresent: {nextTokenPresent}, seedNextTokenPresent: {seedNextTokenPresent})");
 
-    private static readonly Action<ILogger, int, bool, Exception?> LogExecutedExecuteStatement =
-        LoggerMessage.Define<int, bool>(
-            LogLevel.Information,
+    private static readonly Func<LogLevel, Action<ILogger, int, bool, Exception?>>
+        LogExecutedExecuteStatement = level => LoggerMessage.Define<int, bool>(
+            level,
             DynamoEventId.ExecutedExecuteStatement,
             "Executed DynamoDB ExecuteStatement request (itemsCount: {itemsCount}, nextTokenPresent: {nextTokenPresent})");
 
-    private static readonly Action<ILogger, string, Exception?> LogNoCompatibleSecondaryIndexFound =
-        LoggerMessage.Define<string>(
-            LogLevel.Warning,
-            DynamoEventId.NoCompatibleSecondaryIndexFound,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?>
-        LogMultipleCompatibleSecondaryIndexesFound = LoggerMessage.Define<string>(
-            LogLevel.Warning,
-            DynamoEventId.MultipleCompatibleSecondaryIndexesFound,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?> LogSecondaryIndexSelected =
-        LoggerMessage.Define<string>(
-            LogLevel.Information,
-            DynamoEventId.SecondaryIndexSelected,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?> LogExplicitIndexSelected =
-        LoggerMessage.Define<string>(
-            LogLevel.Information,
-            DynamoEventId.ExplicitIndexSelected,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?> LogSecondaryIndexCandidateRejected =
-        LoggerMessage.Define<string>(
-            LogLevel.Information,
-            DynamoEventId.SecondaryIndexCandidateRejected,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?> LogExplicitIndexSelectionDisabled =
-        LoggerMessage.Define<string>(
-            LogLevel.Information,
-            DynamoEventId.ExplicitIndexSelectionDisabled,
-            "{message}");
-
-    private static readonly Action<ILogger, string, Exception?> LogScanLikeQueryDetected =
-        LoggerMessage.Define<string>(
-            LogLevel.Warning,
-            DynamoEventId.ScanLikeQueryDetected,
-            "{message}");
-
-    private static readonly Action<ILogger, string, string, string, Exception?>
-        LogExecutingPartiQlWrite = LoggerMessage.Define<string, string, string>(
-            LogLevel.Information,
+    private static readonly Func<LogLevel, Action<ILogger, string, string, string, Exception?>>
+        LogExecutingPartiQlWrite = level => LoggerMessage.Define<string, string, string>(
+            level,
             DynamoEventId.ExecutingPartiQlWrite,
             "Executing DynamoDB PartiQL write for table '{tableName}'{newLine}{commandText}");
 
-    /// <summary>Provides functionality for this member.</summary>
+    private static readonly Func<LogLevel, Action<ILogger, string, Exception?>> LogMessage = level
+        => LoggerMessage.Define<string>(level, default, "{message}");
+
+    /// <summary>Logs that a PartiQL query is about to be executed.</summary>
     public static void ExecutingPartiQlQuery(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         string tableName,
         string commandText)
     {
-        if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-            return;
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutingPartiQlQuery,
+            (d, v) => d.LogExecutingPartiQlQuery = v,
+            DynamoEventId.ExecutingPartiQlQuery,
+            LogLevel.Information,
+            LogExecutingPartiQlQuery);
 
-        LogExecutingPartiQlQuery(
-            diagnostics.Logger,
-            tableName,
-            Environment.NewLine,
-            commandText,
-            null);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, tableName, Environment.NewLine, commandText);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoPartiQlCommandEventData(
+                    definition,
+                    PartiQlMessage,
+                    tableName,
+                    commandText),
+                ds,
+                sl);
     }
 
-    /// <summary>Provides functionality for this member.</summary>
+    /// <summary>Logs that an ExecuteStatement request is about to be sent.</summary>
     public static void ExecutingExecuteStatement(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         int? limit,
         bool nextTokenPresent,
         bool seedNextTokenPresent = false)
     {
-        if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-            return;
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutingExecuteStatement,
+            (d, v) => d.LogExecutingExecuteStatement = v,
+            DynamoEventId.ExecutingExecuteStatement,
+            LogLevel.Information,
+            LogExecutingExecuteStatement);
 
-        LogExecutingExecuteStatement(
-            diagnostics.Logger,
-            limit,
-            nextTokenPresent,
-            seedNextTokenPresent,
-            null);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, limit, nextTokenPresent, seedNextTokenPresent);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoExecuteStatementEventData(
+                    definition,
+                    ExecutingExecuteStatementMessage,
+                    limit,
+                    nextTokenPresent,
+                    seedNextTokenPresent),
+                ds,
+                sl);
     }
 
-    /// <summary>Provides functionality for this member.</summary>
+    /// <summary>Logs that an ExecuteStatement request completed.</summary>
     public static void ExecutedExecuteStatement(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         int itemsCount,
         bool nextTokenPresent)
     {
-        if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-            return;
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutedExecuteStatement,
+            (d, v) => d.LogExecutedExecuteStatement = v,
+            DynamoEventId.ExecutedExecuteStatement,
+            LogLevel.Information,
+            LogExecutedExecuteStatement);
 
-        LogExecutedExecuteStatement(diagnostics.Logger, itemsCount, nextTokenPresent, null);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, itemsCount, nextTokenPresent);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoExecuteStatementExecutedEventData(
+                    definition,
+                    ExecutedExecuteStatementMessage,
+                    itemsCount,
+                    nextTokenPresent),
+                ds,
+                sl);
     }
 
-    /// <summary>
-    ///     Logs that a PartiQL write statement (INSERT, UPDATE, or DELETE) is about to be executed.
-    /// </summary>
-    /// <param name="diagnostics">The command diagnostics logger.</param>
-    /// <param name="tableName">The target DynamoDB table name.</param>
-    /// <param name="commandText">The PartiQL statement text.</param>
+    /// <summary>Logs that a PartiQL write statement is about to be executed.</summary>
     public static void ExecutingPartiQlWrite(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         string tableName,
         string commandText)
     {
-        if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-            return;
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutingPartiQlWrite,
+            (d, v) => d.LogExecutingPartiQlWrite = v,
+            DynamoEventId.ExecutingPartiQlWrite,
+            LogLevel.Information,
+            LogExecutingPartiQlWrite);
 
-        LogExecutingPartiQlWrite(
-            diagnostics.Logger,
-            tableName,
-            Environment.NewLine,
-            commandText,
-            null);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, tableName, Environment.NewLine, commandText);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoPartiQlCommandEventData(
+                    definition,
+                    PartiQlMessage,
+                    tableName,
+                    commandText),
+                ds,
+                sl);
     }
 
     /// <summary>Logs a structured query-compilation diagnostic from automatic index selection.</summary>
@@ -148,63 +154,169 @@ public static class DynamoLoggerExtensions
         this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
         DynamoQueryDiagnostic diagnostic)
     {
-        switch (diagnostic.Code)
+        var (eventId, level, get, set) = diagnostic.Code switch
         {
-            case "DYNAMO_IDX001":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Warning))
-                    return;
-
-                LogNoCompatibleSecondaryIndexFound(diagnostics.Logger, diagnostic.Message, null);
-                return;
-
-            case "DYNAMO_IDX002":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Warning))
-                    return;
-
-                LogMultipleCompatibleSecondaryIndexesFound(
-                    diagnostics.Logger,
-                    diagnostic.Message,
-                    null);
-                return;
-
-            case "DYNAMO_IDX003":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-                    return;
-
-                LogSecondaryIndexSelected(diagnostics.Logger, diagnostic.Message, null);
-                return;
-
-            case "DYNAMO_IDX004":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-                    return;
-
-                LogExplicitIndexSelected(diagnostics.Logger, diagnostic.Message, null);
-                return;
-
-            case "DYNAMO_IDX005":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-                    return;
-
-                LogSecondaryIndexCandidateRejected(diagnostics.Logger, diagnostic.Message, null);
-                return;
-
-            case "DYNAMO_IDX006":
-                if (!diagnostics.Logger.IsEnabled(LogLevel.Information))
-                    return;
-
-                LogExplicitIndexSelectionDisabled(diagnostics.Logger, diagnostic.Message, null);
-                return;
-        }
+            "DYNAMO_IDX001" => (DynamoEventId.NoCompatibleSecondaryIndexFound, LogLevel.Warning,
+                (Func<DynamoLoggingDefinition, EventDefinition<string>?>)(d
+                    => d.LogNoCompatibleSecondaryIndexFound),
+                (Action<DynamoLoggingDefinition, EventDefinition<string>>)((d, v)
+                    => d.LogNoCompatibleSecondaryIndexFound = v)),
+            "DYNAMO_IDX002" => (DynamoEventId.MultipleCompatibleSecondaryIndexesFound,
+                LogLevel.Warning, d => d.LogMultipleCompatibleSecondaryIndexesFound,
+                (d, v) => d.LogMultipleCompatibleSecondaryIndexesFound = v),
+            "DYNAMO_IDX003" => (DynamoEventId.SecondaryIndexSelected, LogLevel.Information,
+                d => d.LogSecondaryIndexSelected, (d, v) => d.LogSecondaryIndexSelected = v),
+            "DYNAMO_IDX004" => (DynamoEventId.ExplicitIndexSelected, LogLevel.Information,
+                d => d.LogExplicitIndexSelected, (d, v) => d.LogExplicitIndexSelected = v),
+            "DYNAMO_IDX005" => (DynamoEventId.SecondaryIndexCandidateRejected, LogLevel.Information,
+                d => d.LogSecondaryIndexCandidateRejected,
+                (d, v) => d.LogSecondaryIndexCandidateRejected = v),
+            "DYNAMO_IDX006" => (DynamoEventId.ExplicitIndexSelectionDisabled, LogLevel.Information,
+                d => d.LogExplicitIndexSelectionDisabled,
+                (d, v) => d.LogExplicitIndexSelectionDisabled = v),
+            _ => default
+        };
+        if (eventId.Id == 0)
+            return;
+        QueryDiagnostic(diagnostics, diagnostic.Message, eventId, level, get, set);
     }
 
     /// <summary>Logs that a scan-like read query was detected and allowed to continue.</summary>
     internal static void ScanLikeQueryDetected(
         this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
         string message)
-    {
-        if (!diagnostics.Logger.IsEnabled(LogLevel.Warning))
-            return;
+        => QueryDiagnostic(
+            diagnostics,
+            message,
+            DynamoEventId.ScanLikeQueryDetected,
+            LogLevel.Warning,
+            d => d.LogScanLikeQueryDetected,
+            (d, v) => d.LogScanLikeQueryDetected = v);
 
-        LogScanLikeQueryDetected(diagnostics.Logger, message, null);
+    private static void QueryDiagnostic(
+        IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+        string message,
+        EventId eventId,
+        LogLevel level,
+        Func<DynamoLoggingDefinition, EventDefinition<string>?> get,
+        Action<DynamoLoggingDefinition, EventDefinition<string>> set)
+    {
+        var definition = Definition(
+            diagnostics,
+            get,
+            set,
+            eventId,
+            level,
+            l => LoggerMessage.Define<string>(l, eventId, "{message}"));
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, message);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoQueryDiagnosticEventData(definition, QueryDiagnosticMessage, message),
+                ds,
+                sl);
     }
+
+    private static EventDefinition<T1, T2, T3> Definition<TLoggerCategory, T1, T2, T3>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, EventDefinition<T1, T2, T3>?> get,
+        Action<DynamoLoggingDefinition, EventDefinition<T1, T2, T3>> set,
+        EventId eventId,
+        LogLevel level,
+        Func<LogLevel, Action<ILogger, T1, T2, T3, Exception?>> factory)
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+        => Get(
+            diagnostics,
+            get,
+            set,
+            _ => new EventDefinition<T1, T2, T3>(
+                diagnostics.Options,
+                eventId,
+                level,
+                eventId.Name!,
+                factory));
+
+    private static EventDefinition<T1, T2> Definition<TLoggerCategory, T1, T2>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, EventDefinition<T1, T2>?> get,
+        Action<DynamoLoggingDefinition, EventDefinition<T1, T2>> set,
+        EventId eventId,
+        LogLevel level,
+        Func<LogLevel, Action<ILogger, T1, T2, Exception?>> factory)
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+        => Get(
+            diagnostics,
+            get,
+            set,
+            _ => new EventDefinition<T1, T2>(
+                diagnostics.Options,
+                eventId,
+                level,
+                eventId.Name!,
+                factory));
+
+    private static EventDefinition<T> Definition<TLoggerCategory, T>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, EventDefinition<T>?> get,
+        Action<DynamoLoggingDefinition, EventDefinition<T>> set,
+        EventId eventId,
+        LogLevel level,
+        Func<LogLevel, Action<ILogger, T, Exception?>> factory)
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+        => Get(
+            diagnostics,
+            get,
+            set,
+            _ => new EventDefinition<T>(
+                diagnostics.Options,
+                eventId,
+                level,
+                eventId.Name!,
+                factory));
+
+    private static TDefinition Get<TLoggerCategory, TDefinition>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, TDefinition?> get,
+        Action<DynamoLoggingDefinition, TDefinition> set,
+        Func<DynamoLoggingDefinition, TDefinition> create)
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new() where TDefinition : class
+    {
+        var definitions = (DynamoLoggingDefinition)diagnostics.Definitions;
+        var definition = get(definitions);
+        if (definition is not null)
+            return definition;
+        definition = create(definitions);
+        set(definitions, definition);
+        return definition;
+    }
+
+    private static string PartiQlMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string, string>)definition;
+        var p = (DynamoPartiQlCommandEventData)payload;
+        return d.GenerateMessage(p.TableName, Environment.NewLine, p.CommandText);
+    }
+
+    private static string ExecutingExecuteStatementMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var d = (EventDefinition<int?, bool, bool>)definition;
+        var p = (DynamoExecuteStatementEventData)payload;
+        return d.GenerateMessage(p.Limit, p.NextTokenPresent, p.SeedNextTokenPresent);
+    }
+
+    private static string ExecutedExecuteStatementMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var d = (EventDefinition<int, bool>)definition;
+        var p = (DynamoExecuteStatementExecutedEventData)payload;
+        return d.GenerateMessage(p.ItemsCount, p.NextTokenPresent);
+    }
+
+    private static string QueryDiagnosticMessage(EventDefinitionBase definition, EventData payload)
+        => ((EventDefinition<string>)definition).GenerateMessage(
+            ((DynamoQueryDiagnosticEventData)payload).Message);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -27,11 +27,8 @@ public static class DynamoLoggerExtensions
             DynamoEventId.ExecutedExecuteStatement,
             "Executed DynamoDB ExecuteStatement request (itemsCount: {itemsCount}, nextTokenPresent: {nextTokenPresent})");
 
-    private static readonly Func<LogLevel, Action<ILogger, string?, double, Exception?>>
-        LogExecuteStatementFailed = level => LoggerMessage.Define<string?, double>(
-            level,
-            DynamoEventId.ExecuteStatementFailed,
-            "Failed executing DynamoDB ExecuteStatement request (requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
+    private const string ExecuteStatementFailedLogMessage =
+        "Failed executing DynamoDB ExecuteStatement request (requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)";
 
     private static readonly Func<LogLevel, Action<ILogger, string, string, string, Exception?>>
         LogExecutingPartiQlWrite = level => LoggerMessage.Define<string, string, string>(
@@ -53,12 +50,8 @@ public static class DynamoLoggerExtensions
                 DynamoEventId.ExecutedPartiQlWriteRequest,
                 "Executed DynamoDB {operation} write request ({statementCount} statements, requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
 
-    private static readonly
-        Func<LogLevel, Action<ILogger, string, int, string?, double, Exception?>>
-        LogPartiQlWriteRequestFailed = level => LoggerMessage.Define<string, int, string?, double>(
-            level,
-            DynamoEventId.PartiQlWriteRequestFailed,
-            "Failed executing DynamoDB {operation} write request ({statementCount} statements, requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
+    private const string PartiQlWriteRequestFailedLogMessage =
+        "Failed executing DynamoDB {operation} write request ({statementCount} statements, requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)";
 
     private static readonly Func<LogLevel, Action<ILogger, int, int, string?, Exception?>>
         LogBatchPartiQlWriteReturnedStatementErrors = level
@@ -187,10 +180,18 @@ public static class DynamoLoggerExtensions
             (d, v) => d.LogExecuteStatementFailed = v,
             DynamoEventId.ExecuteStatementFailed,
             LogLevel.Error,
-            LogExecuteStatementFailed);
+            ExecuteStatementFailedLogMessage);
 
         if (diagnostics.ShouldLog(definition))
-            definition.Log(diagnostics, requestId, elapsed.TotalMilliseconds);
+            definition.Log(
+                diagnostics,
+                logger => logger.Log(
+                    definition.Level,
+                    definition.EventId,
+                    exception,
+                    definition.MessageFormat,
+                    requestId,
+                    elapsed.TotalMilliseconds));
         if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
             diagnostics.DispatchEventData(
                 definition,
@@ -321,14 +322,19 @@ public static class DynamoLoggerExtensions
             (d, v) => d.LogPartiQlWriteRequestFailed = v,
             DynamoEventId.PartiQlWriteRequestFailed,
             LogLevel.Error,
-            LogPartiQlWriteRequestFailed);
+            PartiQlWriteRequestFailedLogMessage);
         if (diagnostics.ShouldLog(definition))
             definition.Log(
                 diagnostics,
-                operation.ToString(),
-                statementCount,
-                requestId,
-                elapsed.TotalMilliseconds);
+                logger => logger.Log(
+                    definition.Level,
+                    definition.EventId,
+                    exception,
+                    definition.MessageFormat,
+                    operation.ToString(),
+                    statementCount,
+                    requestId,
+                    elapsed.TotalMilliseconds));
         if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
             diagnostics.DispatchEventData(
                 definition,
@@ -464,6 +470,24 @@ public static class DynamoLoggerExtensions
                 eventId.Name!,
                 factory));
 
+    private static FallbackEventDefinition Definition<TLoggerCategory>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, FallbackEventDefinition?> get,
+        Action<DynamoLoggingDefinition, FallbackEventDefinition> set,
+        EventId eventId,
+        LogLevel level,
+        string messageFormat) where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+        => Get(
+            diagnostics,
+            get,
+            set,
+            _ => new FallbackEventDefinition(
+                diagnostics.Options,
+                eventId,
+                level,
+                eventId.Name!,
+                messageFormat));
+
     private static EventDefinition<T1, T2, T3> Definition<TLoggerCategory, T1, T2, T3>(
         IDiagnosticsLogger<TLoggerCategory> diagnostics,
         Func<DynamoLoggingDefinition, EventDefinition<T1, T2, T3>?> get,
@@ -569,9 +593,15 @@ public static class DynamoLoggerExtensions
         EventDefinitionBase definition,
         EventData payload)
     {
-        var d = (EventDefinition<string?, double>)definition;
+        var d = (FallbackEventDefinition)definition;
         var p = (DynamoExecuteStatementFailedEventData)payload;
-        return d.GenerateMessage(p.RequestId, p.Elapsed.TotalMilliseconds);
+        return d.GenerateMessage(logger => logger.Log(
+            d.Level,
+            d.EventId,
+            p.Exception,
+            d.MessageFormat,
+            p.RequestId,
+            p.Elapsed.TotalMilliseconds));
     }
 
     private static string WriteRequestExecutingMessage(
@@ -601,11 +631,16 @@ public static class DynamoLoggerExtensions
         EventData payload)
     {
         var p = (DynamoPartiQlWriteRequestFailedEventData)payload;
-        return ((EventDefinition<string, int, string?, double>)definition).GenerateMessage(
+        var d = (FallbackEventDefinition)definition;
+        return d.GenerateMessage(logger => logger.Log(
+            d.Level,
+            d.EventId,
+            p.Exception,
+            d.MessageFormat,
             p.Operation.ToString(),
             p.StatementCount,
             p.RequestId,
-            p.Elapsed.TotalMilliseconds);
+            p.Elapsed.TotalMilliseconds));
     }
 
     private static string BatchStatementErrorsMessage(

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -528,10 +528,13 @@ public static class DynamoLoggerExtensions
         Func<DynamoLoggingDefinition, TDefinition> create)
         where TLoggerCategory : LoggerCategory<TLoggerCategory>, new() where TDefinition : class
     {
-        var definitions = (DynamoLoggingDefinition)diagnostics.Definitions;
+        if (diagnostics.Definitions is not DynamoLoggingDefinition definitions)
+            return create(new DynamoLoggingDefinition());
+
         var definition = get(definitions);
         if (definition is not null)
             return definition;
+
         definition = create(definitions);
         set(definitions, definition);
         return definition;

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Query.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -25,6 +26,12 @@ public static class DynamoLoggerExtensions
             level,
             DynamoEventId.ExecutedExecuteStatement,
             "Executed DynamoDB ExecuteStatement request (itemsCount: {itemsCount}, nextTokenPresent: {nextTokenPresent})");
+
+    private static readonly Func<LogLevel, Action<ILogger, string?, double, Exception?>>
+        LogExecuteStatementFailed = level => LoggerMessage.Define<string?, double>(
+            level,
+            DynamoEventId.ExecuteStatementFailed,
+            "Failed executing DynamoDB ExecuteStatement request (requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
 
     private static readonly Func<LogLevel, Action<ILogger, string, string, string, Exception?>>
         LogExecutingPartiQlWrite = level => LoggerMessage.Define<string, string, string>(
@@ -68,7 +75,8 @@ public static class DynamoLoggerExtensions
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         int? limit,
         bool nextTokenPresent,
-        bool seedNextTokenPresent = false)
+        bool seedNextTokenPresent = false,
+        Guid commandId = default)
     {
         var definition = Definition(
             diagnostics,
@@ -88,7 +96,8 @@ public static class DynamoLoggerExtensions
                     ExecutingExecuteStatementMessage,
                     limit,
                     nextTokenPresent,
-                    seedNextTokenPresent),
+                    seedNextTokenPresent,
+                    commandId),
                 ds,
                 sl);
     }
@@ -97,7 +106,13 @@ public static class DynamoLoggerExtensions
     public static void ExecutedExecuteStatement(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         int itemsCount,
-        bool nextTokenPresent)
+        bool nextTokenPresent,
+        TimeSpan elapsed = default,
+        Guid commandId = default,
+        string? requestId = null,
+        int? limit = null,
+        bool seedNextTokenPresent = false,
+        ConsumedCapacity? consumedCapacity = null)
     {
         var definition = Definition(
             diagnostics,
@@ -116,7 +131,51 @@ public static class DynamoLoggerExtensions
                     definition,
                     ExecutedExecuteStatementMessage,
                     itemsCount,
-                    nextTokenPresent),
+                    nextTokenPresent,
+                    elapsed,
+                    commandId,
+                    requestId,
+                    limit,
+                    seedNextTokenPresent,
+                    consumedCapacity),
+                ds,
+                sl);
+    }
+
+    /// <summary>Logs that an ExecuteStatement request failed.</summary>
+    public static void ExecuteStatementFailed(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        Exception exception,
+        TimeSpan elapsed,
+        Guid commandId,
+        string? requestId,
+        int? limit,
+        bool nextTokenPresent,
+        bool seedNextTokenPresent)
+    {
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecuteStatementFailed,
+            (d, v) => d.LogExecuteStatementFailed = v,
+            DynamoEventId.ExecuteStatementFailed,
+            LogLevel.Error,
+            LogExecuteStatementFailed);
+
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, requestId, elapsed.TotalMilliseconds);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoExecuteStatementFailedEventData(
+                    definition,
+                    ExecuteStatementFailedMessage,
+                    exception,
+                    elapsed,
+                    commandId,
+                    requestId,
+                    limit,
+                    nextTokenPresent,
+                    seedNextTokenPresent),
                 ds,
                 sl);
     }
@@ -314,6 +373,15 @@ public static class DynamoLoggerExtensions
         var d = (EventDefinition<int, bool>)definition;
         var p = (DynamoExecuteStatementExecutedEventData)payload;
         return d.GenerateMessage(p.ItemsCount, p.NextTokenPresent);
+    }
+
+    private static string ExecuteStatementFailedMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var d = (EventDefinition<string?, double>)definition;
+        var p = (DynamoExecuteStatementFailedEventData)payload;
+        return d.GenerateMessage(p.RequestId, p.Elapsed.TotalMilliseconds);
     }
 
     private static string QueryDiagnosticMessage(EventDefinitionBase definition, EventData payload)

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -39,6 +39,34 @@ public static class DynamoLoggerExtensions
             DynamoEventId.ExecutingPartiQlWrite,
             "Executing DynamoDB PartiQL write for table '{tableName}'{newLine}{commandText}");
 
+    private static readonly Func<LogLevel, Action<ILogger, string, int, Exception?>>
+        LogExecutingPartiQlWriteRequest = level => LoggerMessage.Define<string, int>(
+            level,
+            DynamoEventId.ExecutingPartiQlWriteRequest,
+            "Executing DynamoDB {operation} write request ({statementCount} statements)");
+
+    private static readonly
+        Func<LogLevel, Action<ILogger, string, int, string?, double, Exception?>>
+        LogExecutedPartiQlWriteRequest = level
+            => LoggerMessage.Define<string, int, string?, double>(
+                level,
+                DynamoEventId.ExecutedPartiQlWriteRequest,
+                "Executed DynamoDB {operation} write request ({statementCount} statements, requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
+
+    private static readonly
+        Func<LogLevel, Action<ILogger, string, int, string?, double, Exception?>>
+        LogPartiQlWriteRequestFailed = level => LoggerMessage.Define<string, int, string?, double>(
+            level,
+            DynamoEventId.PartiQlWriteRequestFailed,
+            "Failed executing DynamoDB {operation} write request ({statementCount} statements, requestId: {requestId}, elapsed: {elapsedMilliseconds}ms)");
+
+    private static readonly Func<LogLevel, Action<ILogger, int, int, string?, Exception?>>
+        LogBatchPartiQlWriteReturnedStatementErrors = level
+            => LoggerMessage.Define<int, int, string?>(
+                level,
+                DynamoEventId.BatchPartiQlWriteReturnedStatementErrors,
+                "DynamoDB BatchExecuteStatement write request returned {errorCount} statement errors for {statementCount} statements (requestId: {requestId})");
+
     private static readonly Func<LogLevel, Action<ILogger, string, Exception?>> LogMessage = level
         => LoggerMessage.Define<string>(level, default, "{message}");
 
@@ -208,6 +236,146 @@ public static class DynamoLoggerExtensions
                 sl);
     }
 
+    /// <summary>Logs that a PartiQL write request is about to be sent.</summary>
+    public static void ExecutingPartiQlWriteRequest(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        DynamoPartiQlWriteOperation operation,
+        int statementCount,
+        Guid commandId)
+    {
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutingPartiQlWriteRequest,
+            (d, v) => d.LogExecutingPartiQlWriteRequest = v,
+            DynamoEventId.ExecutingPartiQlWriteRequest,
+            LogLevel.Information,
+            LogExecutingPartiQlWriteRequest);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, operation.ToString(), statementCount);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoPartiQlWriteRequestEventData(
+                    definition,
+                    WriteRequestExecutingMessage,
+                    operation,
+                    statementCount,
+                    commandId),
+                ds,
+                sl);
+    }
+
+    /// <summary>Logs that a PartiQL write request completed.</summary>
+    public static void ExecutedPartiQlWriteRequest(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        DynamoPartiQlWriteOperation operation,
+        int statementCount,
+        TimeSpan elapsed,
+        Guid commandId,
+        string? requestId,
+        IReadOnlyList<ConsumedCapacity>? consumedCapacity)
+    {
+        var definition = Definition(
+            diagnostics,
+            d => d.LogExecutedPartiQlWriteRequest,
+            (d, v) => d.LogExecutedPartiQlWriteRequest = v,
+            DynamoEventId.ExecutedPartiQlWriteRequest,
+            LogLevel.Information,
+            LogExecutedPartiQlWriteRequest);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(
+                diagnostics,
+                operation.ToString(),
+                statementCount,
+                requestId,
+                elapsed.TotalMilliseconds);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoPartiQlWriteRequestExecutedEventData(
+                    definition,
+                    WriteRequestExecutedMessage,
+                    operation,
+                    statementCount,
+                    elapsed,
+                    commandId,
+                    requestId,
+                    consumedCapacity),
+                ds,
+                sl);
+    }
+
+    /// <summary>Logs that a PartiQL write request failed.</summary>
+    public static void PartiQlWriteRequestFailed(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        DynamoPartiQlWriteOperation operation,
+        int statementCount,
+        Exception exception,
+        TimeSpan elapsed,
+        Guid commandId,
+        string? requestId)
+    {
+        var definition = Definition(
+            diagnostics,
+            d => d.LogPartiQlWriteRequestFailed,
+            (d, v) => d.LogPartiQlWriteRequestFailed = v,
+            DynamoEventId.PartiQlWriteRequestFailed,
+            LogLevel.Error,
+            LogPartiQlWriteRequestFailed);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(
+                diagnostics,
+                operation.ToString(),
+                statementCount,
+                requestId,
+                elapsed.TotalMilliseconds);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoPartiQlWriteRequestFailedEventData(
+                    definition,
+                    WriteRequestFailedMessage,
+                    operation,
+                    statementCount,
+                    exception,
+                    elapsed,
+                    commandId,
+                    requestId),
+                ds,
+                sl);
+    }
+
+    /// <summary>Logs that a successful batch write request returned per-statement errors.</summary>
+    public static void BatchPartiQlWriteReturnedStatementErrors(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        int statementCount,
+        int errorCount,
+        Guid commandId,
+        string? requestId)
+    {
+        var definition = Definition(
+            diagnostics,
+            d => d.LogBatchPartiQlWriteReturnedStatementErrors,
+            (d, v) => d.LogBatchPartiQlWriteReturnedStatementErrors = v,
+            DynamoEventId.BatchPartiQlWriteReturnedStatementErrors,
+            LogLevel.Warning,
+            LogBatchPartiQlWriteReturnedStatementErrors);
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, errorCount, statementCount, requestId);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoBatchStatementErrorsEventData(
+                    definition,
+                    BatchStatementErrorsMessage,
+                    statementCount,
+                    errorCount,
+                    commandId,
+                    requestId),
+                ds,
+                sl);
+    }
+
     /// <summary>Logs a structured query-compilation diagnostic from automatic index selection.</summary>
     internal static void IndexSelectionDiagnostic(
         this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
@@ -276,6 +444,25 @@ public static class DynamoLoggerExtensions
                 ds,
                 sl);
     }
+
+    private static EventDefinition<T1, T2, T3, T4> Definition<TLoggerCategory, T1, T2, T3, T4>(
+        IDiagnosticsLogger<TLoggerCategory> diagnostics,
+        Func<DynamoLoggingDefinition, EventDefinition<T1, T2, T3, T4>?> get,
+        Action<DynamoLoggingDefinition, EventDefinition<T1, T2, T3, T4>> set,
+        EventId eventId,
+        LogLevel level,
+        Func<LogLevel, Action<ILogger, T1, T2, T3, T4, Exception?>> factory)
+        where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
+        => Get(
+            diagnostics,
+            get,
+            set,
+            _ => new EventDefinition<T1, T2, T3, T4>(
+                diagnostics.Options,
+                eventId,
+                level,
+                eventId.Name!,
+                factory));
 
     private static EventDefinition<T1, T2, T3> Definition<TLoggerCategory, T1, T2, T3>(
         IDiagnosticsLogger<TLoggerCategory> diagnostics,
@@ -382,6 +569,51 @@ public static class DynamoLoggerExtensions
         var d = (EventDefinition<string?, double>)definition;
         var p = (DynamoExecuteStatementFailedEventData)payload;
         return d.GenerateMessage(p.RequestId, p.Elapsed.TotalMilliseconds);
+    }
+
+    private static string WriteRequestExecutingMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var p = (DynamoPartiQlWriteRequestEventData)payload;
+        return ((EventDefinition<string, int>)definition).GenerateMessage(
+            p.Operation.ToString(),
+            p.StatementCount);
+    }
+
+    private static string WriteRequestExecutedMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var p = (DynamoPartiQlWriteRequestExecutedEventData)payload;
+        return ((EventDefinition<string, int, string?, double>)definition).GenerateMessage(
+            p.Operation.ToString(),
+            p.StatementCount,
+            p.RequestId,
+            p.Elapsed.TotalMilliseconds);
+    }
+
+    private static string WriteRequestFailedMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var p = (DynamoPartiQlWriteRequestFailedEventData)payload;
+        return ((EventDefinition<string, int, string?, double>)definition).GenerateMessage(
+            p.Operation.ToString(),
+            p.StatementCount,
+            p.RequestId,
+            p.Elapsed.TotalMilliseconds);
+    }
+
+    private static string BatchStatementErrorsMessage(
+        EventDefinitionBase definition,
+        EventData payload)
+    {
+        var p = (DynamoBatchStatementErrorsEventData)payload;
+        return ((EventDefinition<int, int, string?>)definition).GenerateMessage(
+            p.ErrorCount,
+            p.StatementCount,
+            p.RequestId);
     }
 
     private static string QueryDiagnosticMessage(EventDefinitionBase definition, EventData payload)

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
@@ -14,6 +14,9 @@ public class DynamoLoggingDefinition : LoggingDefinitions
     /// <summary>Cached event definition for executed ExecuteStatement logs.</summary>
     public EventDefinition<int, bool>? LogExecutedExecuteStatement;
 
+    /// <summary>Cached event definition for failed ExecuteStatement logs.</summary>
+    public EventDefinition<string?, double>? LogExecuteStatementFailed;
+
     /// <summary>Cached event definition for executing PartiQL write logs.</summary>
     public EventDefinition<string, string, string>? LogExecutingPartiQlWrite;
 

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
@@ -15,7 +15,7 @@ public class DynamoLoggingDefinition : LoggingDefinitions
     public EventDefinition<int, bool>? LogExecutedExecuteStatement;
 
     /// <summary>Cached event definition for failed ExecuteStatement logs.</summary>
-    public EventDefinition<string?, double>? LogExecuteStatementFailed;
+    public FallbackEventDefinition? LogExecuteStatementFailed;
 
     /// <summary>Cached event definition for executing PartiQL write logs.</summary>
     public EventDefinition<string, string, string>? LogExecutingPartiQlWrite;
@@ -27,7 +27,7 @@ public class DynamoLoggingDefinition : LoggingDefinitions
     public EventDefinition<string, int, string?, double>? LogExecutedPartiQlWriteRequest;
 
     /// <summary>Cached event definition for write request failed logs.</summary>
-    public EventDefinition<string, int, string?, double>? LogPartiQlWriteRequestFailed;
+    public FallbackEventDefinition? LogPartiQlWriteRequestFailed;
 
     /// <summary>Cached event definition for batch per-statement error logs.</summary>
     public EventDefinition<int, int, string?>? LogBatchPartiQlWriteReturnedStatementErrors;

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
@@ -2,5 +2,39 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 
-/// <summary>Represents the DynamoLoggingDefinition type.</summary>
-public class DynamoLoggingDefinition : LoggingDefinitions { }
+/// <summary>Defines cached DynamoDB provider logging metadata.</summary>
+public class DynamoLoggingDefinition : LoggingDefinitions
+{
+    /// <summary>Cached event definition for executing PartiQL query logs.</summary>
+    public EventDefinition<string, string, string>? LogExecutingPartiQlQuery;
+
+    /// <summary>Cached event definition for executing ExecuteStatement logs.</summary>
+    public EventDefinition<int?, bool, bool>? LogExecutingExecuteStatement;
+
+    /// <summary>Cached event definition for executed ExecuteStatement logs.</summary>
+    public EventDefinition<int, bool>? LogExecutedExecuteStatement;
+
+    /// <summary>Cached event definition for executing PartiQL write logs.</summary>
+    public EventDefinition<string, string, string>? LogExecutingPartiQlWrite;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogNoCompatibleSecondaryIndexFound;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogMultipleCompatibleSecondaryIndexesFound;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogSecondaryIndexSelected;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogExplicitIndexSelected;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogSecondaryIndexCandidateRejected;
+
+    /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
+    public EventDefinition<string>? LogExplicitIndexSelectionDisabled;
+
+    /// <summary>Cached event definition for scan-like query diagnostic logs.</summary>
+    public EventDefinition<string>? LogScanLikeQueryDetected;
+}

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
@@ -20,6 +20,18 @@ public class DynamoLoggingDefinition : LoggingDefinitions
     /// <summary>Cached event definition for executing PartiQL write logs.</summary>
     public EventDefinition<string, string, string>? LogExecutingPartiQlWrite;
 
+    /// <summary>Cached event definition for write request start logs.</summary>
+    public EventDefinition<string, int>? LogExecutingPartiQlWriteRequest;
+
+    /// <summary>Cached event definition for write request completed logs.</summary>
+    public EventDefinition<string, int, string?, double>? LogExecutedPartiQlWriteRequest;
+
+    /// <summary>Cached event definition for write request failed logs.</summary>
+    public EventDefinition<string, int, string?, double>? LogPartiQlWriteRequestFailed;
+
+    /// <summary>Cached event definition for batch per-statement error logs.</summary>
+    public EventDefinition<int, int, string?>? LogBatchPartiQlWriteReturnedStatementErrors;
+
     /// <summary>Cached event definition for index/scan diagnostic logs.</summary>
     public EventDefinition<string>? LogNoCompatibleSecondaryIndexFound;
 

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/DynamoDbContextOptionsBuilder.cs
@@ -76,6 +76,13 @@ public class DynamoDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilde
     public virtual DynamoDbContextOptionsBuilder MaxBatchWriteSize(int maxBatchWriteSize)
         => WithOption(e => e.WithMaxBatchWriteSize(maxBatchWriteSize));
 
+    /// <summary>Configures whether DynamoDB should return consumed capacity in responses.</summary>
+    /// <param name="returnConsumedCapacity">Consumed capacity detail requested from DynamoDB.</param>
+    /// <returns>The builder for chaining.</returns>
+    public virtual DynamoDbContextOptionsBuilder ReturnConsumedCapacity(
+        ReturnConsumedCapacity? returnConsumedCapacity)
+        => WithOption(e => e.WithReturnConsumedCapacity(returnConsumedCapacity));
+
     /// <summary>Updates the provider options extension with the supplied mutation action.</summary>
     protected virtual DynamoDbContextOptionsBuilder WithOption(
         Func<DynamoDbOptionsExtension, DynamoDbOptionsExtension> setAction)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -193,7 +193,6 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 hashCode.Add(Extension.TransactionOverflowBehavior);
                 hashCode.Add(Extension.MaxTransactionSize);
                 hashCode.Add(Extension.MaxBatchWriteSize);
-                hashCode.Add(Extension.ReturnConsumedCapacity);
 
                 _serviceProviderHash = hashCode.ToHashCode();
             }
@@ -216,8 +215,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 && Extension.TransactionOverflowBehavior
                 == otherInfo.Extension.TransactionOverflowBehavior
                 && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize
-                && Extension.MaxBatchWriteSize == otherInfo.Extension.MaxBatchWriteSize
-                && Extension.ReturnConsumedCapacity == otherInfo.Extension.ReturnConsumedCapacity;
+                && Extension.MaxBatchWriteSize == otherInfo.Extension.MaxBatchWriteSize;
 
         /// <summary>Provides functionality for this member.</summary>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -37,6 +37,9 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     /// <summary>Maximum number of write operations sent in a single non-atomic PartiQL batch.</summary>
     public int MaxBatchWriteSize { get; private set; } = DynamoPartiQlBatchLimit;
 
+    /// <summary>Controls whether DynamoDB should return consumed capacity in responses.</summary>
+    public ReturnConsumedCapacity? ReturnConsumedCapacity { get; private set; }
+
     /// <summary>Registers provider services in the EF Core internal service container.</summary>
     public virtual void ApplyServices(IServiceCollection services)
         => services.AddEntityFrameworkDynamo();
@@ -143,6 +146,17 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
         return clone;
     }
 
+    /// <summary>Sets whether DynamoDB should return consumed capacity in responses.</summary>
+    public virtual DynamoDbOptionsExtension WithReturnConsumedCapacity(
+        ReturnConsumedCapacity? returnConsumedCapacity)
+    {
+        var clone = Clone();
+
+        clone.ReturnConsumedCapacity = returnConsumedCapacity;
+
+        return clone;
+    }
+
     /// <summary>Creates a copy of this extension with the current option values.</summary>
     protected virtual DynamoDbOptionsExtension Clone()
         => new()
@@ -154,6 +168,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
             TransactionOverflowBehavior = TransactionOverflowBehavior,
             MaxTransactionSize = MaxTransactionSize,
             MaxBatchWriteSize = MaxBatchWriteSize,
+            ReturnConsumedCapacity = ReturnConsumedCapacity,
         };
 
     /// <summary>Represents the DynamoOptionsExtensionInfo type.</summary>
@@ -178,6 +193,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 hashCode.Add(Extension.TransactionOverflowBehavior);
                 hashCode.Add(Extension.MaxTransactionSize);
                 hashCode.Add(Extension.MaxBatchWriteSize);
+                hashCode.Add(Extension.ReturnConsumedCapacity);
 
                 _serviceProviderHash = hashCode.ToHashCode();
             }
@@ -200,7 +216,8 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                 && Extension.TransactionOverflowBehavior
                 == otherInfo.Extension.TransactionOverflowBehavior
                 && Extension.MaxTransactionSize == otherInfo.Extension.MaxTransactionSize
-                && Extension.MaxBatchWriteSize == otherInfo.Extension.MaxBatchWriteSize;
+                && Extension.MaxBatchWriteSize == otherInfo.Extension.MaxBatchWriteSize
+                && Extension.ReturnConsumedCapacity == otherInfo.Extension.ReturnConsumedCapacity;
 
         /// <summary>Provides functionality for this member.</summary>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }
@@ -217,6 +234,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
                     + $"TransactionOverflowBehavior={Extension.TransactionOverflowBehavior},"
                     + $"MaxTransactionSize={Extension.MaxTransactionSize},"
                     + $"MaxBatchWriteSize={Extension.MaxBatchWriteSize},"
+                    + $"ReturnConsumedCapacity={Extension.ReturnConsumedCapacity},"
                     + $"DynamoDbClient={Extension.DynamoDbClient is not null},"
                     + $"DynamoDbClientConfig={Extension.DynamoDbClientConfig is not null},"
                     + $"DynamoDbClientConfigAction={Extension.DynamoDbClientConfigAction is not null}";

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -1,5 +1,7 @@
 using System.Collections;
+using System.Globalization;
 using System.Linq.Expressions;
+using System.Text;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Diagnostics;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
@@ -54,7 +56,7 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>Provides functionality for this member.</summary>
-        public string ToQueryString() => throw new NotImplementedException();
+        public string ToQueryString() => FormatQueryString(GenerateQuery());
 
         /// <summary>Generates the PartiQL query at runtime with parameter values.</summary>
         private DynamoPartiQlQuery GenerateQuery()
@@ -254,7 +256,7 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public string ToQueryString() => throw new NotImplementedException();
+        public string ToQueryString() => FormatQueryString(GenerateQuery());
 
         private DynamoPartiQlQuery GenerateQuery()
             => _sqlGeneratorFactory.Create().Generate(_selectExpression, _queryContext.Parameters);
@@ -374,6 +376,63 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
         }
     }
 #pragma warning restore EF9102
+
+    /// <summary>Formats generated PartiQL with debug parameter comments.</summary>
+    private static string FormatQueryString(DynamoPartiQlQuery query)
+    {
+        if (query.Parameters.Count == 0)
+            return query.Sql;
+
+        var builder = new StringBuilder();
+        for (var i = 0; i < query.Parameters.Count; i++)
+            builder
+                .Append("-- p")
+                .Append(i)
+                .Append('=')
+                .Append(FormatAttributeValue(query.Parameters[i]))
+                .AppendLine();
+
+        builder.Append(query.Sql);
+        return builder.ToString();
+    }
+
+    /// <summary>Formats a DynamoDB attribute value for query debug output.</summary>
+    private static string FormatAttributeValue(AttributeValue value)
+    {
+        if (value.NULL == true)
+            return "NULL";
+
+        if (value.S is not null)
+            return $"'{value.S.Replace("'", "''")}'";
+
+        if (value.N is not null)
+            return value.N;
+
+        if (value.BOOL is bool boolean)
+            return boolean ? "TRUE" : "FALSE";
+
+        if (value.B is not null)
+            return $"<binary:{value.B.Length.ToString(CultureInfo.InvariantCulture)} bytes>";
+
+        if (value.SS.Count > 0)
+            return $"<<{string.Join(", ", value.SS.Select(s => $"'{s.Replace("'", "''")}'"))}>>";
+
+        if (value.NS.Count > 0)
+            return $"<<{string.Join(", ", value.NS)}>>";
+
+        if (value.BS.Count > 0)
+            return
+                $"<<{string.Join(", ", value.BS.Select(b => $"<binary:{b.Length.ToString(CultureInfo.InvariantCulture)} bytes>"))}>>";
+
+        if (value.L.Count > 0)
+            return $"[{string.Join(", ", value.L.Select(FormatAttributeValue))}]";
+
+        if (value.M.Count > 0)
+            return
+                $"{{{string.Join(", ", value.M.Select(kvp => $"{kvp.Key}: {FormatAttributeValue(kvp.Value)}"))}}}";
+
+        return "<empty>";
+    }
 
     /// <summary>
     ///     Resolves an integer expression to its runtime value. Handles constant literals and compiled-query

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -414,20 +414,20 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
         if (value.B is not null)
             return $"<binary:{value.B.Length.ToString(CultureInfo.InvariantCulture)} bytes>";
 
-        if (value.SS.Count > 0)
+        if (value.SS?.Count > 0)
             return $"<<{string.Join(", ", value.SS.Select(s => $"'{s.Replace("'", "''")}'"))}>>";
 
-        if (value.NS.Count > 0)
+        if (value.NS?.Count > 0)
             return $"<<{string.Join(", ", value.NS)}>>";
 
-        if (value.BS.Count > 0)
+        if (value.BS?.Count > 0)
             return
                 $"<<{string.Join(", ", value.BS.Select(b => $"<binary:{b.Length.ToString(CultureInfo.InvariantCulture)} bytes>"))}>>";
 
-        if (value.L.Count > 0)
+        if (value.L?.Count > 0)
             return $"[{string.Join(", ", value.L.Select(FormatAttributeValue))}]";
 
-        if (value.M.Count > 0)
+        if (value.M?.Count > 0)
             return
                 $"{{{string.Join(", ", value.M.Select(kvp => $"{kvp.Key}: {FormatAttributeValue(kvp.Value)}"))}}}";
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -137,6 +137,26 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
             {
                 using var _ = _concurrencyDetector?.EnterCriticalSection();
 
+                try
+                {
+                    return await MoveNextCoreAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _queryingEnumerable._queryLogger.QueryCanceled(_queryContext.Context.GetType());
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    _queryingEnumerable._queryLogger.QueryIterationFailed(
+                        _queryContext.Context.GetType(),
+                        exception);
+                    throw;
+                }
+            }
+
+            private async ValueTask<bool> MoveNextCoreAsync()
+            {
                 if (_dataEnumerator == null)
                 {
                     EnforceScanQueryWarning(
@@ -287,6 +307,26 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor
             {
                 using var _ = _concurrencyDetector?.EnterCriticalSection();
 
+                try
+                {
+                    return await MoveNextCoreAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _queryingEnumerable._queryLogger.QueryCanceled(_queryContext.Context.GetType());
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    _queryingEnumerable._queryLogger.QueryIterationFailed(
+                        _queryContext.Context.GetType(),
+                        exception);
+                    throw;
+                }
+            }
+
+            private async ValueTask<bool> MoveNextCoreAsync()
+            {
                 if (_emitted)
                 {
                     Current = default!;

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.cs
@@ -77,10 +77,6 @@ public partial class DynamoShapedQueryCompilingExpressionVisitor(
         var standAloneStateManager = dynamoQueryCompilationContext.QueryTrackingBehavior
             == QueryTrackingBehavior.NoTrackingWithIdentityResolution;
 
-        if (!dynamoQueryCompilationContext.IsAsync)
-            throw new InvalidOperationException(
-                "Synchronous query execution is not supported for DynamoDB. Use async methods (e.g. ToListAsync). ");
-
         if (pagingExpression is not null)
             return CreatePagingEnumerableExpression(
                 shaperBody.Type,

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Amazon.DynamoDBv2;
 using Amazon.Runtime;
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Diagnostics;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 using EntityFrameworkCore.DynamoDb.Utilities;
@@ -74,7 +75,40 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                         ReturnValuesOnConditionCheckFailure.ALL_OLD,
                 };
 
-                await Client.ExecuteStatementAsync(request, ct).ConfigureAwait(false);
+                var commandId = Guid.NewGuid();
+                var stopwatch = Stopwatch.StartNew();
+                _commandLogger.ExecutingPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.ExecuteStatement,
+                    1,
+                    commandId);
+
+                ExecuteStatementResponse response;
+                try
+                {
+                    response =
+                        await Client.ExecuteStatementAsync(request, ct).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    stopwatch.Stop();
+                    _commandLogger.PartiQlWriteRequestFailed(
+                        DynamoPartiQlWriteOperation.ExecuteStatement,
+                        1,
+                        exception,
+                        stopwatch.Elapsed,
+                        commandId,
+                        (exception as AmazonServiceException)?.RequestId);
+                    throw;
+                }
+
+                stopwatch.Stop();
+                _commandLogger.ExecutedPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.ExecuteStatement,
+                    1,
+                    stopwatch.Elapsed,
+                    commandId,
+                    response.ResponseMetadata?.RequestId,
+                    response.ConsumedCapacity is null ? null : [response.ConsumedCapacity]);
 
                 return true;
             },
@@ -96,7 +130,41 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                     TransactStatements = [.. transactionStatements],
                 };
 
-                await Client.ExecuteTransactionAsync(request, ct).ConfigureAwait(false);
+                var commandId = Guid.NewGuid();
+                var stopwatch = Stopwatch.StartNew();
+                var statementCount = request.TransactStatements?.Count ?? 0;
+                _commandLogger.ExecutingPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.ExecuteTransaction,
+                    statementCount,
+                    commandId);
+
+                ExecuteTransactionResponse response;
+                try
+                {
+                    response =
+                        await Client.ExecuteTransactionAsync(request, ct).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    stopwatch.Stop();
+                    _commandLogger.PartiQlWriteRequestFailed(
+                        DynamoPartiQlWriteOperation.ExecuteTransaction,
+                        statementCount,
+                        exception,
+                        stopwatch.Elapsed,
+                        commandId,
+                        (exception as AmazonServiceException)?.RequestId);
+                    throw;
+                }
+
+                stopwatch.Stop();
+                _commandLogger.ExecutedPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.ExecuteTransaction,
+                    statementCount,
+                    stopwatch.Elapsed,
+                    commandId,
+                    response.ResponseMetadata?.RequestId,
+                    response.ConsumedCapacity);
 
                 return true;
             },
@@ -119,10 +187,52 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                     Statements = [.. batchStatements],
                 };
 
-                var response =
-                    await Client.BatchExecuteStatementAsync(request, ct).ConfigureAwait(false);
+                var commandId = Guid.NewGuid();
+                var stopwatch = Stopwatch.StartNew();
+                var statementCount = request.Statements?.Count ?? 0;
+                _commandLogger.ExecutingPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.BatchExecuteStatement,
+                    statementCount,
+                    commandId);
 
-                return (IReadOnlyList<BatchStatementResponse>)(response.Responses ?? []);
+                BatchExecuteStatementResponse response;
+                try
+                {
+                    response =
+                        await Client.BatchExecuteStatementAsync(request, ct).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    stopwatch.Stop();
+                    _commandLogger.PartiQlWriteRequestFailed(
+                        DynamoPartiQlWriteOperation.BatchExecuteStatement,
+                        statementCount,
+                        exception,
+                        stopwatch.Elapsed,
+                        commandId,
+                        (exception as AmazonServiceException)?.RequestId);
+                    throw;
+                }
+
+                stopwatch.Stop();
+                _commandLogger.ExecutedPartiQlWriteRequest(
+                    DynamoPartiQlWriteOperation.BatchExecuteStatement,
+                    statementCount,
+                    stopwatch.Elapsed,
+                    commandId,
+                    response.ResponseMetadata?.RequestId,
+                    response.ConsumedCapacity);
+
+                var responses = (IReadOnlyList<BatchStatementResponse>)(response.Responses ?? []);
+                var errorCount = responses.Count(r => r.Error is not null);
+                if (errorCount > 0)
+                    _commandLogger.BatchPartiQlWriteReturnedStatementErrors(
+                        statementCount,
+                        errorCount,
+                        commandId,
+                        response.ResponseMetadata?.RequestId);
+
+                return responses;
             },
             null,
             cancellationToken);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -17,6 +17,7 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 public class DynamoClientWrapper : IDynamoClientWrapper
 {
     private readonly AmazonDynamoDBConfig? _amazonDynamoDbConfig;
+    private readonly ReturnConsumedCapacity? _returnConsumedCapacity;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _commandLogger;
     private readonly IExecutionStrategy _executionStrategy;
 
@@ -34,6 +35,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper
         else
             _amazonDynamoDbConfig = BuildAmazonDynamoDbConfig(options);
 
+        _returnConsumedCapacity = options.ReturnConsumedCapacity;
         _executionStrategy = executionStrategy.NotNull();
         _commandLogger = commandLogger.NotNull();
     }
@@ -53,7 +55,11 @@ public class DynamoClientWrapper : IDynamoClientWrapper
         ExecuteStatementRequest statementRequest,
         bool singlePageOnly = false,
         Action<ExecuteStatementResponse>? onPageFetched = null)
-        => new DynamoAsyncEnumerable(this, statementRequest, singlePageOnly, onPageFetched);
+    {
+        statementRequest.ReturnConsumedCapacity ??= _returnConsumedCapacity;
+
+        return new DynamoAsyncEnumerable(this, statementRequest, singlePageOnly, onPageFetched);
+    }
 
     /// <summary>Executes a write PartiQL statement (INSERT, UPDATE, DELETE) and discards any result items.</summary>
     /// <param name="statement">The PartiQL write statement to execute.</param>
@@ -73,6 +79,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                     Parameters = state.parameters?.Count > 0 ? state.parameters : null,
                     ReturnValuesOnConditionCheckFailure =
                         ReturnValuesOnConditionCheckFailure.ALL_OLD,
+                    ReturnConsumedCapacity = _returnConsumedCapacity,
                 };
 
                 var commandId = Guid.NewGuid();
@@ -128,6 +135,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                 var request = new ExecuteTransactionRequest
                 {
                     TransactStatements = [.. transactionStatements],
+                    ReturnConsumedCapacity = _returnConsumedCapacity,
                 };
 
                 var commandId = Guid.NewGuid();
@@ -185,6 +193,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                 var request = new BatchExecuteStatementRequest
                 {
                     Statements = [.. batchStatements],
+                    ReturnConsumedCapacity = _returnConsumedCapacity,
                 };
 
                 var commandId = Guid.NewGuid();

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Amazon.DynamoDBv2;
+using Amazon.Runtime;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
@@ -263,21 +265,49 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                 var isFirstRequest = !_hasExecutedRequest;
                 var seedNextTokenPresent = isFirstRequest && _request.NextToken is not null;
 
+                var commandId = Guid.NewGuid();
+                var stopwatch = Stopwatch.StartNew();
+
                 dynamoEnumerable._dynamoClientWrapper._commandLogger.ExecutingExecuteStatement(
                     _request.Limit,
                     _request.NextToken is not null,
-                    seedNextTokenPresent);
+                    seedNextTokenPresent,
+                    commandId);
 
-                var response =
-                    await dynamoEnumerable
+                ExecuteStatementResponse response;
+                try
+                {
+                    response = await dynamoEnumerable
                         ._dynamoClientWrapper
                         .Client
                         .ExecuteStatementAsync(_request, ct)
                         .ConfigureAwait(false);
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    stopwatch.Stop();
+                    dynamoEnumerable._dynamoClientWrapper._commandLogger.ExecuteStatementFailed(
+                        exception,
+                        stopwatch.Elapsed,
+                        commandId,
+                        (exception as AmazonServiceException)?.RequestId,
+                        _request.Limit,
+                        _request.NextToken is not null,
+                        seedNextTokenPresent);
+                    throw;
+                }
+
+                stopwatch.Stop();
 
                 dynamoEnumerable._dynamoClientWrapper._commandLogger.ExecutedExecuteStatement(
                     response.Items?.Count ?? 0,
-                    response.NextToken is not null);
+                    response.NextToken is not null,
+                    stopwatch.Elapsed,
+                    commandId,
+                    response.ResponseMetadata?.RequestId,
+                    _request.Limit,
+                    seedNextTokenPresent,
+                    response.ConsumedCapacity);
 
                 // Notify before items are yielded so callers can capture per-page metadata.
                 dynamoEnumerable._onPageFetched?.Invoke(response);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -56,9 +56,10 @@ public class DynamoClientWrapper : IDynamoClientWrapper
         bool singlePageOnly = false,
         Action<ExecuteStatementResponse>? onPageFetched = null)
     {
-        statementRequest.ReturnConsumedCapacity ??= _returnConsumedCapacity;
+        var request = CloneExecuteStatementRequest(statementRequest, false);
+        request.ReturnConsumedCapacity ??= _returnConsumedCapacity;
 
-        return new DynamoAsyncEnumerable(this, statementRequest, singlePageOnly, onPageFetched);
+        return new DynamoAsyncEnumerable(this, request, singlePageOnly, onPageFetched);
     }
 
     /// <summary>Executes a write PartiQL statement (INSERT, UPDATE, DELETE) and discards any result items.</summary>
@@ -269,6 +270,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper
                     ? [..prototype.Parameters]
                     : prototype.Parameters,
             Limit = prototype.Limit,
+            NextToken = prototype.NextToken,
             ConsistentRead = prototype.ConsistentRead,
             ReturnConsumedCapacity = prototype.ReturnConsumedCapacity,
             ReturnValuesOnConditionCheckFailure = prototype.ReturnValuesOnConditionCheckFailure,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -251,7 +252,8 @@ public class DynamoClientWrapperTests
         await client
             .Received(1)
             .ExecuteStatementAsync(
-                Arg.Is<ExecuteStatementRequest>(r => r.Parameters != null && r.Parameters.Count == 1),
+                Arg.Is<ExecuteStatementRequest>(r
+                    => r.Parameters != null && r.Parameters.Count == 1),
                 Arg.Any<CancellationToken>());
     }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoFailureLoggingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoFailureLoggingTests.cs
@@ -1,0 +1,148 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Diagnostics;
+
+/// <summary>Tests exception capture for DynamoDB failure logs.</summary>
+public class DynamoFailureLoggingTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecuteStatementFailed_PassesExceptionToILogger()
+    {
+        var exception = new InvalidOperationException("read failed");
+        var capture = new CapturingLoggerFactory();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ExecuteStatementResponse>(exception));
+        await using var context = RequestContext.Create(client, capture);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        var act = async () =>
+        {
+            await foreach (var _ in wrapper.ExecutePartiQl(
+                new ExecuteStatementRequest { Statement = "SELECT * FROM T", Limit = 10, })) { }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("read failed");
+        var entry =
+            capture
+                .Entries
+                .Should()
+                .ContainSingle(e => e.EventId.Id == DynamoEventId.ExecuteStatementFailed.Id)
+                .Subject;
+        entry.LogLevel.Should().Be(LogLevel.Error);
+        entry.Exception.Should().BeSameAs(exception);
+        entry.State["requestId"].Should().BeNull();
+        entry.State["elapsedMilliseconds"].Should().BeOfType<double>();
+        entry.Message.Should().Contain("Failed executing DynamoDB ExecuteStatement request");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task PartiQlWriteRequestFailed_PassesExceptionToILogger()
+    {
+        var exception = new InvalidOperationException("write failed");
+        var capture = new CapturingLoggerFactory();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ExecuteStatementResponse>(exception));
+        await using var context = RequestContext.Create(client, capture);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        var act = () => wrapper.ExecuteWriteAsync("DELETE FROM T", []);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("write failed");
+        var entry =
+            capture
+                .Entries
+                .Should()
+                .ContainSingle(e => e.EventId.Id == DynamoEventId.PartiQlWriteRequestFailed.Id)
+                .Subject;
+        entry.LogLevel.Should().Be(LogLevel.Error);
+        entry.Exception.Should().BeSameAs(exception);
+        entry.State["operation"].Should().Be("ExecuteStatement");
+        entry.State["statementCount"].Should().Be(1);
+        entry.State["requestId"].Should().BeNull();
+        entry.State["elapsedMilliseconds"].Should().BeOfType<double>();
+        entry.Message.Should().Contain("Failed executing DynamoDB ExecuteStatement write request");
+    }
+
+    private sealed class RequestContext(DbContextOptions<RequestContext> options) : DbContext(
+        options)
+    {
+        public static RequestContext Create(IAmazonDynamoDB client, ILoggerFactory loggerFactory)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<RequestContext>();
+            optionsBuilder
+                .UseDynamo(options => options.DynamoDbClient(client))
+                .UseLoggerFactory(loggerFactory)
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+            return new RequestContext(optionsBuilder.Options);
+        }
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private readonly List<LogEntry> _entries = [];
+
+        public IReadOnlyList<LogEntry> Entries => _entries;
+
+        public ILogger CreateLogger(string categoryName)
+            => categoryName.StartsWith(
+                DbLoggerCategory.Database.Command.Name,
+                StringComparison.Ordinal)
+                ? new CapturingLogger(this)
+                : NullLogger.Instance;
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+
+        private void Add(LogEntry entry) => _entries.Add(entry);
+
+        private sealed class CapturingLogger(CapturingLoggerFactory factory) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var structuredState = state is IReadOnlyList<KeyValuePair<string, object?>> values
+                    ? values
+                        .Where(pair => pair.Key != "{OriginalFormat}")
+                        .ToDictionary(pair => pair.Key, pair => pair.Value)
+                    : [];
+
+                factory.Add(
+                    new LogEntry(
+                        logLevel,
+                        eventId,
+                        exception,
+                        formatter(state, exception),
+                        structuredState));
+            }
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel LogLevel,
+        EventId EventId,
+        Exception? Exception,
+        string Message,
+        IReadOnlyDictionary<string, object?> State);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -224,14 +224,29 @@ public class PaginationConfigurationTests
         var extension2 = new DynamoDbOptionsExtension()
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
             .WithMaxTransactionSize(64)
-            .WithMaxBatchWriteSize(10)
-            .WithReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
+            .WithMaxBatchWriteSize(10);
 
         extension1
             .Info
             .GetServiceProviderHashCode()
             .Should()
             .NotBe(extension2.Info.GetServiceProviderHashCode());
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ServiceProviderHash_ExcludesReturnConsumedCapacity()
+    {
+        var extension1 =
+            new DynamoDbOptionsExtension().WithReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
+        var extension2 =
+            new DynamoDbOptionsExtension().WithReturnConsumedCapacity(
+                ReturnConsumedCapacity.INDEXES);
+
+        extension1
+            .Info
+            .GetServiceProviderHashCode()
+            .Should()
+            .Be(extension2.Info.GetServiceProviderHashCode());
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -243,6 +258,18 @@ public class PaginationConfigurationTests
         var extension2 =
             new DynamoDbOptionsExtension().WithAutomaticIndexSelectionMode(
                 DynamoAutomaticIndexSelectionMode.On);
+
+        extension1.Info.ShouldUseSameServiceProvider(extension2.Info).Should().BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ShouldUseSameServiceProvider_DifferentReturnConsumedCapacity_ReturnsTrue()
+    {
+        var extension1 =
+            new DynamoDbOptionsExtension().WithReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
+        var extension2 =
+            new DynamoDbOptionsExtension().WithReturnConsumedCapacity(
+                ReturnConsumedCapacity.INDEXES);
 
         extension1.Info.ShouldUseSameServiceProvider(extension2.Info).Should().BeTrue();
     }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/PaginationConfigurationTests.cs
@@ -20,6 +20,7 @@ public class PaginationConfigurationTests
         extension.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.Throw);
         extension.MaxTransactionSize.Should().Be(100);
         extension.MaxBatchWriteSize.Should().Be(25);
+        extension.ReturnConsumedCapacity.Should().BeNull();
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -69,7 +70,8 @@ public class PaginationConfigurationTests
             .WithAutomaticIndexSelectionMode(DynamoAutomaticIndexSelectionMode.On)
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
             .WithMaxTransactionSize(42)
-            .WithMaxBatchWriteSize(11);
+            .WithMaxBatchWriteSize(11)
+            .WithReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
 
         // Clone is protected; trigger via a With method.
         var cloned =
@@ -85,6 +87,7 @@ public class PaginationConfigurationTests
         cloned.TransactionOverflowBehavior.Should().Be(TransactionOverflowBehavior.UseChunking);
         cloned.MaxTransactionSize.Should().Be(42);
         cloned.MaxBatchWriteSize.Should().Be(11);
+        cloned.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.TOTAL);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -141,6 +144,20 @@ public class PaginationConfigurationTests
 
         extension.Should().NotBeNull();
         extension!.MaxTransactionSize.Should().Be(12);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void UseDynamo_ConfigureReturnConsumedCapacity_StoresValueOnOptionsExtension()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        optionsBuilder.UseDynamo(options
+            => options.ReturnConsumedCapacity(ReturnConsumedCapacity.INDEXES));
+
+        var extension = optionsBuilder.Options.FindExtension<DynamoDbOptionsExtension>();
+
+        extension.Should().NotBeNull();
+        extension!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.INDEXES);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -207,7 +224,8 @@ public class PaginationConfigurationTests
         var extension2 = new DynamoDbOptionsExtension()
             .WithTransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking)
             .WithMaxTransactionSize(64)
-            .WithMaxBatchWriteSize(10);
+            .WithMaxBatchWriteSize(10)
+            .WithReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
 
         extension1
             .Info

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ScanQueryGuardTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ScanQueryGuardTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.EntityFrameworkCore;
@@ -161,6 +162,31 @@ public class ScanQueryGuardTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DiagnosticListener_Receives_ScanLikeQueryDetected_EventData()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = CreateClient();
+        await using var context = ScanGuardDbContext.Create(
+            client,
+            w => w.Log(DynamoEventId.ScanLikeQueryDetected));
+
+        await context
+            .Items
+            .Where(x => x.Status == "OPEN")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        observer
+            .Events
+            .Any(e => e.Key == DynamoEventId.ScanLikeQueryDetected.Name
+                && e.Value is DynamoQueryDiagnosticEventData data
+                && data.Message.Contains(
+                    "Scan-like DynamoDB query detected",
+                    StringComparison.Ordinal))
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task ConfigureWarnings_Ignore_Executes()
     {
         var client = CreateClient();
@@ -227,6 +253,36 @@ public class ScanQueryGuardTests
             .Returns(new ExecuteStatementResponse { Items = [], NextToken = null });
 
         return client;
+    }
+
+    private sealed class DynamoDiagnosticObserver
+        : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>, IDisposable
+    {
+        private readonly IDisposable _subscription;
+        private IDisposable? _listenerSubscription;
+
+        public DynamoDiagnosticObserver()
+            => _subscription = DiagnosticListener.AllListeners.Subscribe(this);
+
+        public List<KeyValuePair<string, object?>> Events { get; } = [];
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name == DbLoggerCategory.Name)
+                _listenerSubscription = value.Subscribe(this);
+        }
+
+        public void OnNext(KeyValuePair<string, object?> value) => Events.Add(value);
+
+        public void OnError(Exception error) { }
+
+        public void OnCompleted() { }
+
+        public void Dispose()
+        {
+            _listenerSubscription?.Dispose();
+            _subscription.Dispose();
+        }
     }
 
     private sealed record ScanGuardItem

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ScanQueryGuardTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ScanQueryGuardTests.cs
@@ -162,6 +162,128 @@ public class ScanQueryGuardTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DiagnosticListener_Receives_Enriched_ExecuteStatement_EventData()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = CreateClient();
+        await using var context = ScanGuardDbContext.Create(client);
+
+        await context
+            .Items
+            .Where(x => x.Pk == "P#1")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        observer
+            .Events
+            .Any(e => e.Key == DynamoEventId.ExecutingExecuteStatement.Name
+                && e.Value is DynamoExecuteStatementEventData { CommandId: var commandId }
+                && commandId != Guid.Empty)
+            .Should()
+            .BeTrue();
+
+        observer
+            .Events
+            .Any(e => e.Key == DynamoEventId.ExecutedExecuteStatement.Name
+                && e.Value is DynamoExecuteStatementExecutedEventData
+                {
+                    CommandId: var commandId, Elapsed: var elapsed, RequestId: "request-1"
+                }
+                && commandId != Guid.Empty
+                && elapsed >= TimeSpan.Zero)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DiagnosticListener_Receives_Executed_Event_Per_Page()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = CreateClient(
+            new ExecuteStatementResponse
+            {
+                Items = [CreateItem("S#1")],
+                NextToken = "next",
+                ResponseMetadata =
+                    new Amazon.Runtime.ResponseMetadata { RequestId = "request-1" },
+            },
+            new ExecuteStatementResponse
+            {
+                Items = [CreateItem("S#2")],
+                ResponseMetadata =
+                    new Amazon.Runtime.ResponseMetadata { RequestId = "request-2" },
+            });
+        await using var context = ScanGuardDbContext.Create(client);
+
+        await context
+            .Items
+            .Where(x => x.Pk == "P#1")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        observer
+            .Events
+            .Count(e => e.Key == DynamoEventId.ExecutedExecuteStatement.Name
+                && e.Value is DynamoExecuteStatementExecutedEventData
+                {
+                    RequestId: "request-1" or "request-2"
+                })
+            .Should()
+            .Be(2);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DiagnosticListener_Receives_Failed_ExecuteStatement_EventData()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = CreateClient();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ExecuteStatementResponse>>(_
+                => throw new Amazon.DynamoDBv2.Model.InternalServerErrorException("boom")
+                {
+                    RequestId = "failed-request"
+                });
+        await using var context = ScanGuardDbContext.Create(client);
+
+        var act = async ()
+            => await context
+                .Items
+                .Where(x => x.Pk == "P#1")
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Amazon.DynamoDBv2.Model.InternalServerErrorException>();
+        observer
+            .Events
+            .Any(e => e.Key == DynamoEventId.ExecuteStatementFailed.Name
+                && e.Value is DynamoExecuteStatementFailedEventData
+                {
+                    RequestId: "failed-request",
+                    Exception: Amazon.DynamoDBv2.Model.InternalServerErrorException
+                })
+            .Should()
+            .BeTrue();
+        observer.Events.Any(e => e.Key == CoreEventId.QueryIterationFailed.Name).Should().BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task DiagnosticListener_Receives_QueryCanceled()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = CreateClient();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ExecuteStatementResponse>>(callInfo
+                => throw new OperationCanceledException(callInfo.Arg<CancellationToken>()));
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        await using var context = ScanGuardDbContext.Create(client);
+
+        var act = async () => await context.Items.Where(x => x.Pk == "P#1").ToListAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        observer.Events.Any(e => e.Key == CoreEventId.QueryCanceled.Name).Should().BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task DiagnosticListener_Receives_ScanLikeQueryDetected_EventData()
     {
         using var observer = new DynamoDiagnosticObserver();
@@ -244,16 +366,38 @@ public class ScanQueryGuardTests
         await client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!);
     }
 
-    private static IAmazonDynamoDB CreateClient()
+    private static IAmazonDynamoDB CreateClient(params ExecuteStatementResponse[] responses)
     {
         var client = Substitute.For<IAmazonDynamoDB>();
 
+        responses = responses.Length == 0
+            ?
+            [
+                new ExecuteStatementResponse
+                {
+                    Items = [],
+                    NextToken = null,
+                    ResponseMetadata =
+                        new Amazon.Runtime.ResponseMetadata { RequestId = "request-1" },
+                },
+            ]
+            : responses;
+
         client
             .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
-            .Returns(new ExecuteStatementResponse { Items = [], NextToken = null });
+            .Returns(responses[0], responses.Skip(1).ToArray());
 
         return client;
     }
+
+    private static Dictionary<string, AttributeValue> CreateItem(string sk)
+        => new()
+        {
+            ["pk"] = new AttributeValue("P#1"),
+            ["sk"] = new AttributeValue(sk),
+            ["status"] = new AttributeValue("OPEN"),
+            ["total"] = new AttributeValue { N = "1" },
+        };
 
     private sealed class DynamoDiagnosticObserver
         : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>, IDisposable

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
@@ -1,0 +1,75 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Query;
+
+/// <summary>Unit tests for DynamoDB query debug output.</summary>
+public class ToQueryStringTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ToQueryString_SimpleQuery_ReturnsPartiQlWithoutExecutingRequest()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = ToQueryStringDbContext.Create(client);
+
+        var queryString = context.Items.AllowScan().ToQueryString();
+
+        queryString
+            .Should()
+            .Be("SELECT \"pk\", \"name\"" + Environment.NewLine + "FROM \"ToQueryStringItems\"");
+        client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!, default);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ToQueryString_ParameterizedQuery_IncludesParameterCommentsAndPartiQl()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = ToQueryStringDbContext.Create(client);
+        var pk = "tenant'1";
+
+        var queryString = context.Items.Where(e => e.Pk == pk).ToQueryString();
+
+        queryString
+            .Should()
+            .Be(
+                "-- p0='tenant''1'"
+                + Environment.NewLine
+                + "SELECT \"pk\", \"name\""
+                + Environment.NewLine
+                + "FROM \"ToQueryStringItems\""
+                + Environment.NewLine
+                + "WHERE \"pk\" = ?");
+        client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!, default);
+    }
+
+    private sealed class ToQueryStringEntity
+    {
+        public string Pk { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class ToQueryStringDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ToQueryStringEntity> Items => Set<ToQueryStringEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<ToQueryStringEntity>(builder =>
+            {
+                builder.ToTable("ToQueryStringItems");
+                builder.HasPartitionKey(e => e.Pk);
+            });
+
+        public static ToQueryStringDbContext Create(IAmazonDynamoDB client)
+            => new(
+                new DbContextOptionsBuilder<ToQueryStringDbContext>()
+                    .UseDynamo(options => options.DynamoDbClient(client))
+                    .ConfigureWarnings(w
+                        => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .Options);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
@@ -1,6 +1,8 @@
+using System.Reflection;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Query.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using NSubstitute;
@@ -45,6 +47,41 @@ public class ToQueryStringTests
                 + "WHERE \"pk\" = ?");
         client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!, default);
     }
+
+    [Theory(Timeout = TestConfiguration.DefaultTimeout)]
+    [MemberData(nameof(AttributeValues))]
+    public void ToQueryString_AttributeValueFormatting_HandlesSdkV4NullCollections(
+        AttributeValue value,
+        string expected)
+        => FormatAttributeValue(value).Should().Be(expected);
+
+    public static TheoryData<AttributeValue, string> AttributeValues()
+        => new()
+        {
+            { new AttributeValue(), "<empty>" },
+            { new AttributeValue { SS = ["a", "b'c"] }, "<<'a', 'b''c'>>" },
+            { new AttributeValue { NS = ["1", "2"] }, "<<1, 2>>" },
+            {
+                new AttributeValue { BS = [new MemoryStream([1, 2, 3])] },
+                "<<<binary:3 bytes>>>"
+            },
+            { new AttributeValue { L = [new AttributeValue { S = "x" }] }, "['x']" },
+            {
+                new AttributeValue
+                {
+                    M = new Dictionary<string, AttributeValue>
+                    {
+                        ["k"] = new() { S = "v" },
+                    },
+                },
+                "{k: 'v'}"
+            },
+        };
+
+    private static string FormatAttributeValue(AttributeValue value)
+        => (string)typeof(DynamoShapedQueryCompilingExpressionVisitor).GetMethod(
+            "FormatAttributeValue",
+            BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, [value])!;
 
     private sealed class ToQueryStringEntity
     {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/ReturnConsumedCapacityRequestTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/ReturnConsumedCapacityRequestTests.cs
@@ -1,0 +1,109 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
+
+/// <summary>Tests provider-level consumed capacity request configuration.</summary>
+public class ReturnConsumedCapacityRequestTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecutePartiQl_AppliesConfiguredReturnConsumedCapacity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteStatementRequest? captured = null;
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.INDEXES);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        await foreach (var _ in wrapper.ExecutePartiQl(
+            new ExecuteStatementRequest { Statement = "SELECT * FROM T" })) { }
+
+        captured.Should().NotBeNull();
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.INDEXES);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecuteWriteAsync_AppliesConfiguredReturnConsumedCapacity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteStatementRequest? captured = null;
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse());
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.TOTAL);
+
+        await context.GetService<IDynamoClientWrapper>().ExecuteWriteAsync("DELETE FROM T", []);
+
+        captured.Should().NotBeNull();
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.TOTAL);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecuteBatchWriteAsync_AppliesConfiguredReturnConsumedCapacity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        BatchExecuteStatementRequest? captured = null;
+        client
+            .BatchExecuteStatementAsync(
+                Arg.Do<BatchExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new BatchExecuteStatementResponse { Responses = [] });
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.TOTAL);
+
+        await context
+            .GetService<IDynamoClientWrapper>()
+            .ExecuteBatchWriteAsync([new BatchStatementRequest { Statement = "DELETE FROM T" }]);
+
+        captured.Should().NotBeNull();
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.TOTAL);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecuteTransactionAsync_AppliesConfiguredReturnConsumedCapacity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteTransactionRequest? captured = null;
+        client
+            .ExecuteTransactionAsync(
+                Arg.Do<ExecuteTransactionRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteTransactionResponse());
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.TOTAL);
+
+        await context
+            .GetService<IDynamoClientWrapper>()
+            .ExecuteTransactionAsync([new ParameterizedStatement { Statement = "DELETE FROM T" }]);
+
+        captured.Should().NotBeNull();
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.TOTAL);
+    }
+
+    private sealed class RequestContext(DbContextOptions<RequestContext> options) : DbContext(
+        options)
+    {
+        public static RequestContext Create(
+            IAmazonDynamoDB client,
+            ReturnConsumedCapacity? returnConsumedCapacity = null)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<RequestContext>();
+            optionsBuilder
+                .UseDynamo(options => options
+                    .DynamoDbClient(client)
+                    .ReturnConsumedCapacity(returnConsumedCapacity))
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+            return new RequestContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/ReturnConsumedCapacityRequestTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/ReturnConsumedCapacityRequestTests.cs
@@ -32,6 +32,77 @@ public class ReturnConsumedCapacityRequestTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecutePartiQl_DoesNotMutateCallerRequest()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteStatementRequest? captured = null;
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.INDEXES);
+        var request = new ExecuteStatementRequest { Statement = "SELECT * FROM T" };
+
+        await foreach (var _ in
+            context.GetService<IDynamoClientWrapper>().ExecutePartiQl(request)) { }
+
+        request.ReturnConsumedCapacity.Should().BeNull();
+        captured.Should().NotBeNull();
+        captured.Should().NotBeSameAs(request);
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.INDEXES);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecutePartiQl_PreservesExplicitReturnConsumedCapacity()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteStatementRequest? captured = null;
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.INDEXES);
+
+        await foreach (var _ in context
+            .GetService<IDynamoClientWrapper>()
+            .ExecutePartiQl(
+                new ExecuteStatementRequest
+                {
+                    Statement = "SELECT * FROM T",
+                    ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL,
+                })) { }
+
+        captured.Should().NotBeNull();
+        captured!.ReturnConsumedCapacity.Should().Be(ReturnConsumedCapacity.TOTAL);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ExecutePartiQl_PreservesSeedNextToken()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        ExecuteStatementRequest? captured = null;
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r => captured = r),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        await using var context = RequestContext.Create(client, ReturnConsumedCapacity.INDEXES);
+
+        await foreach (var _ in context
+            .GetService<IDynamoClientWrapper>()
+            .ExecutePartiQl(
+                new ExecuteStatementRequest
+                {
+                    Statement = "SELECT * FROM T", NextToken = "seed-token",
+                })) { }
+
+        captured.Should().NotBeNull();
+        captured!.NextToken.Should().Be("seed-token");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task ExecuteWriteAsync_AppliesConfiguredReturnConsumedCapacity()
     {
         var client = Substitute.For<IAmazonDynamoDB>();


### PR DESCRIPTION
## Summary

Adds a full observability surface for DynamoDB query and write execution. The provider now emits structured EF Core diagnostics for PartiQL generation, per-request read/write lifecycle events, failures, batch statement errors, AWS request IDs, elapsed times, and optional consumed capacity. This makes query cost, pagination behavior, failures, and generated PartiQL easier to inspect without parsing log strings or attaching a debugger.

## Changes

### Diagnostics and logging

- Added provider-specific `EventData` payload types for `DiagnosticListener` consumers.
- Added new stable `DynamoEventId` values for failed read requests, write request lifecycle events, batch write per-statement errors, and scan/index-selection diagnostics.
- Added cached logging definitions for DynamoDB events.
- Added fallback handling when EF supplies non-provider logging definitions.

### Read request observability

- Enriched `ExecuteStatement` read diagnostics with provider `commandId`, AWS `requestId`, elapsed time, request `Limit`, continuation-token state, seed continuation-token state, and consumed capacity when returned.
- Emits success/failure diagnostics per DynamoDB page.
- Emits EF Core query cancellation and query iteration failure diagnostics during async enumeration.

### Write request observability

- Added request-level diagnostics around `ExecuteStatement`, `ExecuteTransaction`, and `BatchExecuteStatement` writes.
- Captures operation kind, statement count, elapsed time, AWS request ID, command correlation ID, and consumed capacity.
- Logs a warning when `BatchExecuteStatement` succeeds at HTTP level but returns per-statement errors.

### Consumed capacity configuration

- Added provider option:

  ```csharp
  optionsBuilder.UseDynamo(options => options
      .ReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL));
  ```

- Applies configured `ReturnConsumedCapacity` to read, single-write, transaction, and batch requests.

- Keeps default behavior unchanged when option is not configured.

### `ToQueryString()` support

- Implemented EF Core `ToQueryString()` for DynamoDB queries.

- Returns generated PartiQL without sending a DynamoDB request.

- Includes formatted parameter comments for positional `AttributeValue` parameters.

  ```sql
  -- p0='CUSTOMER#123'
  SELECT "pk", "sk", "total"
  FROM "Orders"
  WHERE "CustomerId" = ?
  ```

- Keeps synchronous result enumeration unsupported.

### Documentation

- Updated diagnostics docs with event IDs, categories, payloads, request metadata, consumed capacity, and `DiagnosticListener` usage.
- Documented `ToQueryString()` behavior in query execution docs and limitations.
- Added agent workflow docs for future provider documentation and integration-test updates.

## Validation

Added/updated tests covering:

- `DiagnosticListener` payloads for read start/success/failure events.
- Per-page executed read events.
- query cancellation and iteration failure diagnostics.
- scan-like query diagnostic payloads.
- `ToQueryString()` output and no-request behavior.
- `ReturnConsumedCapacity` option storage, cloning, service-provider hash behavior, and request application across read/write APIs.
- write/batch diagnostic behavior.

Not run in this session.

Recommended before merge:

```bash
dotnet test
task docs:build
```

## Release Notes

- Added structured DynamoDB diagnostics for reads, writes, failures, request correlation, and consumed capacity.
- Added `ReturnConsumedCapacity(...)` provider option.
- Added DynamoDB `ToQueryString()` support for inspecting generated PartiQL without executing requests.

## Notes for Reviewers

- Main review focus: diagnostic event names/IDs, payload shapes, and whether these should be considered public/stable API.
- `ToQueryString()` intentionally formats parameters for debugging only; command logs still omit parameter values.
- Consumed capacity remains opt-in to avoid changing default AWS response shape/cost metadata behavior.
- Batch writes can report per-statement errors despite successful HTTP response; this PR surfaces that as a warning diagnostic.
