### PR TITLE
feat(query): integrate index warnings with ConfigureWarnings

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -258,6 +258,13 @@ constraint on an index partition key if you want automatic selection to pick up 
 whether a GSI would allow the provider to target a narrower key space, and confirm that running
 against the base table is acceptable for this query's access pattern.
 
+Use EF Core warning configuration to escalate or suppress this warning:
+
+```csharp
+options.ConfigureWarnings(w =>
+    w.Throw(DynamoEventId.NoCompatibleSecondaryIndexFound));
+```
+
 ______________________________________________________________________
 
 ### `DYNAMO_IDX002` — `MultipleCompatibleSecondaryIndexesFound` (Warning)
@@ -268,6 +275,13 @@ names. The query falls back to the base table.
 Use an explicit [`.WithIndex("IndexName")`](querying/index-selection.md) hint to resolve the
 ambiguity. The tied index names appear in the message, so you can pick the one that best fits the
 access pattern.
+
+Use EF Core warning configuration to suppress this warning when the fallback is intentional:
+
+```csharp
+options.ConfigureWarnings(w =>
+    w.Ignore(DynamoEventId.MultipleCompatibleSecondaryIndexesFound));
+```
 
 ______________________________________________________________________
 

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -9,6 +9,8 @@ namespace EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 /// <summary>Provides DynamoDB provider logging extensions.</summary>
 public static class DynamoLoggerExtensions
 {
+    private const string IndexSelectionDiagnosticMessage = "{message}";
+
     private static readonly Func<LogLevel, Action<ILogger, string, string, string, Exception?>>
         LogExecutingPartiQlQuery = level => LoggerMessage.Define<string, string, string>(
             level,
@@ -412,6 +414,70 @@ public static class DynamoLoggerExtensions
         if (eventId.Id == 0)
             return;
         QueryDiagnostic(diagnostics, diagnostic.Message, eventId, level, get, set);
+    }
+
+    private static void NoCompatibleSecondaryIndexFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+        string message)
+    {
+        var definition = LogNoCompatibleSecondaryIndexFound(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, message);
+    }
+
+    private static EventDefinition<string> LogNoCompatibleSecondaryIndexFound(
+        IDiagnosticsLogger logger)
+    {
+        var definitions = (DynamoLoggingDefinition)logger.Definitions;
+        var definition = definitions.LogNoCompatibleSecondaryIndexFound;
+        if (definition is null)
+        {
+            definition = new EventDefinition<string>(
+                logger.Options,
+                DynamoEventId.NoCompatibleSecondaryIndexFound,
+                LogLevel.Warning,
+                $"DynamoEventId.{nameof(DynamoEventId.NoCompatibleSecondaryIndexFound)}",
+                level => LoggerMessage.Define<string>(
+                    level,
+                    DynamoEventId.NoCompatibleSecondaryIndexFound,
+                    IndexSelectionDiagnosticMessage));
+            definitions.LogNoCompatibleSecondaryIndexFound = definition;
+        }
+
+        return (EventDefinition<string>)definition;
+    }
+
+    private static void MultipleCompatibleSecondaryIndexesFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+        string message)
+    {
+        var definition = LogMultipleCompatibleSecondaryIndexesFound(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(diagnostics, message);
+    }
+
+    private static EventDefinition<string> LogMultipleCompatibleSecondaryIndexesFound(
+        IDiagnosticsLogger logger)
+    {
+        var definitions = (DynamoLoggingDefinition)logger.Definitions;
+        var definition = definitions.LogMultipleCompatibleSecondaryIndexesFound;
+        if (definition is null)
+        {
+            definition = new EventDefinition<string>(
+                logger.Options,
+                DynamoEventId.MultipleCompatibleSecondaryIndexesFound,
+                LogLevel.Warning,
+                $"DynamoEventId.{nameof(DynamoEventId.MultipleCompatibleSecondaryIndexesFound)}",
+                level => LoggerMessage.Define<string>(
+                    level,
+                    DynamoEventId.MultipleCompatibleSecondaryIndexesFound,
+                    IndexSelectionDiagnosticMessage));
+            definitions.LogMultipleCompatibleSecondaryIndexesFound = definition;
+        }
+
+        return (EventDefinition<string>)definition;
     }
 
     /// <summary>Logs that a scan-like read query was detected and allowed to continue.</summary>

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -424,6 +424,22 @@ public static class DynamoLoggerExtensions
 
         if (diagnostics.ShouldLog(definition))
             definition.Log(diagnostics, message);
+
+        if (diagnostics.NeedsEventData(
+            definition,
+            out var diagnosticSourceEnabled,
+            out var simpleLogEnabled))
+        {
+            var eventData = new EventData(
+                definition,
+                (d, _) => ((EventDefinition<string>)d).GenerateMessage(message));
+
+            diagnostics.DispatchEventData(
+                definition,
+                eventData,
+                diagnosticSourceEnabled,
+                simpleLogEnabled);
+        }
     }
 
     private static EventDefinition<string> LogNoCompatibleSecondaryIndexFound(
@@ -456,6 +472,22 @@ public static class DynamoLoggerExtensions
 
         if (diagnostics.ShouldLog(definition))
             definition.Log(diagnostics, message);
+
+        if (diagnostics.NeedsEventData(
+            definition,
+            out var diagnosticSourceEnabled,
+            out var simpleLogEnabled))
+        {
+            var eventData = new EventData(
+                definition,
+                (d, _) => ((EventDefinition<string>)d).GenerateMessage(message));
+
+            diagnostics.DispatchEventData(
+                definition,
+                eventData,
+                diagnosticSourceEnabled,
+                simpleLogEnabled);
+        }
     }
 
     private static EventDefinition<string> LogMultipleCompatibleSecondaryIndexesFound(

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
@@ -4,6 +4,7 @@ using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Query.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace EntityFrameworkCore.DynamoDb.Tests.Query;
@@ -92,6 +93,27 @@ public class IndexQueryExtensionsTests
                         .Ignore(DynamoEventId.ScanLikeQueryDetected))
                 .Options);
 
+    private static GsiDbContext CreateGsiContextWithWarningAnalyzer<TAnalyzer>(
+        IAmazonDynamoDB client,
+        Action<WarningsConfigurationBuilder> configureWarnings,
+        ILoggerFactory? loggerFactory = null) where TAnalyzer : class, IDynamoIndexSelectionAnalyzer
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<GsiDbContext>()
+            .ReplaceService<IDynamoIndexSelectionAnalyzer, TAnalyzer>()
+            .UseDynamo(o => o.DynamoDbClient(client))
+            .ConfigureWarnings(w =>
+            {
+                w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
+                w.Ignore(DynamoEventId.ScanLikeQueryDetected);
+                configureWarnings(w);
+            });
+
+        if (loggerFactory is not null)
+            optionsBuilder.UseLoggerFactory(loggerFactory);
+
+        return new GsiDbContext(optionsBuilder.Options);
+    }
+
     /// <summary>
     ///     Analyzer used by tests to simulate index auto-selection without an explicit WithIndex
     ///     hint.
@@ -134,6 +156,92 @@ public class IndexQueryExtensionsTests
                         DynamoIndexSelectionReason.AutoSelected,
                         []);
     }
+
+    private sealed class NoCompatibleIndexWarningAnalyzer : IDynamoIndexSelectionAnalyzer
+    {
+        /// <summary>Emits the no-compatible-index warning diagnostic.</summary>
+        /// <returns>The selected index decision.</returns>
+        public DynamoIndexSelectionDecision Analyze(DynamoIndexAnalysisContext context)
+            => new(
+                null,
+                DynamoIndexSelectionReason.NoSelection,
+                [
+                    new DynamoQueryDiagnostic(
+                        DynamoQueryDiagnosticLevel.Warning,
+                        "DYNAMO_IDX001",
+                        "No compatible secondary index was found for test query."),
+                ]);
+    }
+
+    private sealed class MultipleCompatibleIndexesWarningAnalyzer : IDynamoIndexSelectionAnalyzer
+    {
+        /// <summary>Emits the multiple-compatible-indexes warning diagnostic.</summary>
+        /// <returns>The selected index decision.</returns>
+        public DynamoIndexSelectionDecision Analyze(DynamoIndexAnalysisContext context)
+            => new(
+                null,
+                DynamoIndexSelectionReason.NoSelection,
+                [
+                    new DynamoQueryDiagnostic(
+                        DynamoQueryDiagnosticLevel.Warning,
+                        "DYNAMO_IDX002",
+                        "Multiple compatible secondary indexes were found for test query."),
+                ]);
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private readonly CapturingLogger _logger = new();
+
+        /// <summary>The captured log entries.</summary>
+        public IReadOnlyList<CapturedLogEntry> Entries => _logger.Entries;
+
+        /// <summary>Creates a logger.</summary>
+        /// <returns>The capturing logger.</returns>
+        public ILogger CreateLogger(string categoryName) => _logger;
+
+        /// <summary>Adds a logger provider.</summary>
+        public void AddProvider(ILoggerProvider provider) { }
+
+        /// <summary>Disposes the logger factory.</summary>
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly List<CapturedLogEntry> _entries = [];
+
+        /// <summary>The captured log entries.</summary>
+        public IReadOnlyList<CapturedLogEntry> Entries => _entries;
+
+        /// <summary>Begins a logging scope.</summary>
+        /// <returns>A disposable logging scope.</returns>
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+            => NullScope.Instance;
+
+        /// <summary>Returns whether logging is enabled.</summary>
+        /// <returns><see langword="true"/>.</returns>
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        /// <summary>Captures the log entry.</summary>
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => _entries.Add(new CapturedLogEntry(logLevel, eventId, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        internal static readonly NullScope Instance = new();
+
+        /// <summary>Disposes the scope.</summary>
+        public void Dispose() { }
+    }
+
+    private sealed record CapturedLogEntry(LogLevel LogLevel, EventId EventId, string Message);
 
     /// <summary>
     ///     Shared-table context: <c>SharedOrder</c> and <c>SharedInvoice</c> both map
@@ -367,6 +475,62 @@ public class IndexQueryExtensionsTests
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*'.WithIndex()'*'.WithoutIndex()'*");
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ConfigureWarnings_Throw_NoCompatibleSecondaryIndexFound_Throws()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        await using var context =
+            CreateGsiContextWithWarningAnalyzer<NoCompatibleIndexWarningAnalyzer>(
+                client,
+                w => w.Throw(DynamoEventId.NoCompatibleSecondaryIndexFound));
+
+        var act = async () => await context
+            .Orders
+            .Where(o => o.CustomerId == "C1")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*NoCompatibleSecondaryIndexFound*No compatible secondary index*");
+
+        await client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!);
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        ConfigureWarnings_Ignore_MultipleCompatibleSecondaryIndexesFound_SuppressesLog()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        var loggerFactory = new CapturingLoggerFactory();
+        await using var context =
+            CreateGsiContextWithWarningAnalyzer<MultipleCompatibleIndexesWarningAnalyzer>(
+                client,
+                w => w.Ignore(DynamoEventId.MultipleCompatibleSecondaryIndexesFound),
+                loggerFactory);
+
+        _ = await context
+            .Orders
+            .Where(o => o.CustomerId == "C1")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        loggerFactory
+            .Entries
+            .Should()
+            .NotContain(e
+                => e.EventId.Id == DynamoEventId.MultipleCompatibleSecondaryIndexesFound.Id);
+        await client
+            .Received()
+            .ExecuteStatementAsync(
+                Arg.Any<ExecuteStatementRequest>(),
+                Arg.Any<CancellationToken>());
     }
 
     // ── WithIndex extension tests ─────────────────────────────────────────────

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
@@ -96,7 +96,8 @@ public class IndexQueryExtensionsTests
     private static GsiDbContext CreateGsiContextWithWarningAnalyzer<TAnalyzer>(
         IAmazonDynamoDB client,
         Action<WarningsConfigurationBuilder> configureWarnings,
-        ILoggerFactory? loggerFactory = null) where TAnalyzer : class, IDynamoIndexSelectionAnalyzer
+        ILoggerFactory? loggerFactory = null,
+        Action<EventData>? logTo = null) where TAnalyzer : class, IDynamoIndexSelectionAnalyzer
     {
         var optionsBuilder = new DbContextOptionsBuilder<GsiDbContext>()
             .ReplaceService<IDynamoIndexSelectionAnalyzer, TAnalyzer>()
@@ -110,6 +111,13 @@ public class IndexQueryExtensionsTests
 
         if (loggerFactory is not null)
             optionsBuilder.UseLoggerFactory(loggerFactory);
+
+        if (logTo is not null)
+            optionsBuilder.LogTo(
+                (eventId, _)
+                    => eventId.Id == DynamoEventId.NoCompatibleSecondaryIndexFound.Id
+                    || eventId.Id == DynamoEventId.MultipleCompatibleSecondaryIndexesFound.Id,
+                logTo);
 
         return new GsiDbContext(optionsBuilder.Options);
     }
@@ -531,6 +539,33 @@ public class IndexQueryExtensionsTests
             .ExecuteStatementAsync(
                 Arg.Any<ExecuteStatementRequest>(),
                 Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task LogTo_NoCompatibleSecondaryIndexFound_ReceivesEventDataWithoutLoggerFactory()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+        List<EventData> eventData = [];
+        await using var context =
+            CreateGsiContextWithWarningAnalyzer<NoCompatibleIndexWarningAnalyzer>(
+                client,
+                w => w.Log(DynamoEventId.NoCompatibleSecondaryIndexFound),
+                logTo: eventData.Add);
+
+        _ = await context
+            .Orders
+            .Where(o => o.CustomerId == "C1")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        eventData
+            .Should()
+            .ContainSingle(e
+                => e.EventId.Id == DynamoEventId.NoCompatibleSecondaryIndexFound.Id
+                && e.ToString().Contains("No compatible secondary index was found"));
     }
 
     // ── WithIndex extension tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Routes DynamoDB index-selection warning events through EF Core's warnings pipeline so `ConfigureWarnings` can control provider diagnostics. `DYNAMO_IDX001` and `DYNAMO_IDX002` now support `Ignore`, `Log`, and `Throw` behavior while `ScanLikeQueryDetected` keeps its existing provider-default throw behavior.

## Changes

- Replaced direct `ILogger` warning emission for `NoCompatibleSecondaryIndexFound` and `MultipleCompatibleSecondaryIndexesFound` with EF Core `EventDefinition<string>` logging.
- Added cached Dynamo logging definitions for the two configurable index-selection warnings.
- Added deterministic query-pipeline tests for throwing and suppressing index-selection warnings.
- Updated diagnostics docs with `ConfigureWarnings` examples and removed the old limitation note.

## Validation

- `run_all_tests_for_project`: `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj` passed, 425/425.
- `task docs:build` passed.

## Related Issues

Fixes #178

## Release Notes

DynamoDB index-selection warnings `DYNAMO_IDX001` and `DYNAMO_IDX002` can now be configured with EF Core `ConfigureWarnings`.