### PR TITLE
feat(metadata): add key resolution and transaction handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ execution.
 ## Commands
 
 - Build: `dotnet build`
+- Manage NuGet packages with the `dotnet` CLI (`dotnet add package`, `dotnet package update`,
+  `dotnet remove package`, etc.); do not hand-edit package references unless the CLI cannot express
+  the needed change.
 - Run tests through the .NET test MCP server whenever available.
 - Unit test project:
   `tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj`

--- a/EntityFrameworkCore.DynamoDb.slnx
+++ b/EntityFrameworkCore.DynamoDb.slnx
@@ -1,5 +1,5 @@
 <Solution>
-  <Folder Name="/git/">
+  <Folder Name="/.github/">
     <File Path=".github/workflows/pr-build.yaml" />
     <File Path=".github/workflows/pr-title-check.yaml" />
     <File Path=".github/workflows/publish-preview.yaml" />

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoModelExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoModelExtensions.cs
@@ -52,6 +52,11 @@ internal static class DynamoModelExtensions
                     StringComparer.Ordinal)
                 .ThenBy(static index => index.DeclaringEntityType.Name, StringComparer.Ordinal);
 
+        /// <summary>Gets the effective table-group name used for shared-table DynamoDB metadata.</summary>
+        internal string GetTableGroupName()
+            => entityType.FindAnnotation(DynamoAnnotationNames.TableGroupName)?.Value as string
+                ?? entityType.ComputeTableGroupName();
+
         /// <summary>Computes the effective table-group name used for shared-table DynamoDB metadata.</summary>
         internal string ComputeTableGroupName()
         {
@@ -59,6 +64,43 @@ internal static class DynamoModelExtensions
 
             return mappedEntityType.FindAnnotation(DynamoAnnotationNames.TableName)?.Value as string
                 ?? mappedEntityType.ClrType.Name;
+        }
+
+        /// <summary>Resolves the entity type that defines table key metadata for this entity type.</summary>
+        internal IReadOnlyEntityType ResolveKeyMappedEntityType()
+        {
+            var tableMappedType = entityType.ResolveTableMappedEntityType();
+            if (tableMappedType.GetPartitionKeyProperty() is not null)
+                return tableMappedType;
+
+            foreach (var baseType in entityType.GetAllBaseTypes())
+                if (baseType.GetPartitionKeyProperty() is not null)
+                    return baseType;
+
+            return tableMappedType;
+        }
+    }
+
+    extension(IEntityType entityType)
+    {
+        /// <summary>Gets the effective table-group name used for shared-table DynamoDB metadata.</summary>
+        internal string GetTableGroupName()
+            => entityType.FindRuntimeAnnotation(DynamoAnnotationNames.TableGroupName)
+                    ?.Value as string
+                ?? ((IReadOnlyEntityType)entityType).GetTableGroupName();
+
+        /// <summary>Resolves the entity type that defines table key metadata for this entity type.</summary>
+        internal IEntityType ResolveKeyMappedEntityType()
+        {
+            var tableMappedType = (IEntityType)entityType.ResolveTableMappedEntityType();
+            if (tableMappedType.GetPartitionKeyProperty() is not null)
+                return tableMappedType;
+
+            foreach (var baseType in entityType.GetAllBaseTypes())
+                if (baseType.GetPartitionKeyProperty() is not null)
+                    return baseType;
+
+            return tableMappedType;
         }
     }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoModelExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoModelExtensions.cs
@@ -52,8 +52,8 @@ internal static class DynamoModelExtensions
                     StringComparer.Ordinal)
                 .ThenBy(static index => index.DeclaringEntityType.Name, StringComparer.Ordinal);
 
-        /// <summary>Gets the effective table-group name used for shared-table DynamoDB metadata.</summary>
-        internal string GetTableGroupName()
+        /// <summary>Computes the effective table-group name used for shared-table DynamoDB metadata.</summary>
+        internal string ComputeTableGroupName()
         {
             var mappedEntityType = entityType.ResolveTableMappedEntityType();
 

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,6 +26,7 @@ public static class DynamoServiceCollectionExtensions
                 .TryAdd<IDatabaseProvider, DatabaseProvider<DynamoDbOptionsExtension>>()
                 .TryAdd<IStructuralTypeMaterializerSource, DynamoStructuralTypeMaterializerSource>()
                 .TryAdd<IDatabase, DynamoDatabaseWrapper>()
+                .TryAdd<IDbContextTransactionManager, DynamoTransactionManager>()
                 .TryAdd<IQueryContextFactory, DynamoQueryContextFactory>()
                 .TryAdd<IProviderConventionSetBuilder, DynamoConventionSetBuilder>()
                 .TryAdd<IModelValidator, DynamoModelValidator>()

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class DynamoServiceCollectionExtensions
                 .TryAdd<IDatabaseProvider, DatabaseProvider<DynamoDbOptionsExtension>>()
                 .TryAdd<IStructuralTypeMaterializerSource, DynamoStructuralTypeMaterializerSource>()
                 .TryAdd<IDatabase, DynamoDatabaseWrapper>()
+                .TryAdd<IDatabaseCreator, DynamoDatabaseCreator>()
                 .TryAdd<IDbContextTransactionManager, DynamoTransactionManager>()
                 .TryAdd<IQueryContextFactory, DynamoQueryContextFactory>()
                 .TryAdd<IProviderConventionSetBuilder, DynamoConventionSetBuilder>()

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelRuntimeInitializer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelRuntimeInitializer.cs
@@ -50,9 +50,7 @@ public sealed class DynamoModelRuntimeInitializer(ModelRuntimeInitializerDepende
 
         foreach (var tableGroup in model
             .EnumerateRootEntityTypes()
-            .GroupBy(
-                static entityType => (string)entityType[DynamoAnnotationNames.TableGroupName]!,
-                StringComparer.Ordinal))
+            .GroupBy(static entityType => entityType.GetTableGroupName(), StringComparer.Ordinal))
         {
             var rootEntityTypes = tableGroup.ToList();
             var sourcesByRootEntityType =
@@ -91,7 +89,7 @@ public sealed class DynamoModelRuntimeInitializer(ModelRuntimeInitializerDepende
         IReadOnlyEntityType entityType,
         IEnumerable<IReadOnlyIndex> secondaryIndexes)
     {
-        var sourceEntityType = ResolveKeySourceEntityType(entityType);
+        var sourceEntityType = entityType.ResolveKeyMappedEntityType();
         var partitionKeyProperty = sourceEntityType.GetPartitionKeyProperty()
             ?? throw new InvalidOperationException(
                 $"Entity type '{entityType.DisplayName()}' does not have a configured DynamoDB partition key.");
@@ -284,20 +282,6 @@ public sealed class DynamoModelRuntimeInitializer(ModelRuntimeInitializerDepende
             == GetKeyTypeCategory(GetEffectiveProviderClrType(right.PartitionKeyProperty))
             && GetSortKeyTypeCategory(left.SortKeyProperty)
             == GetSortKeyTypeCategory(right.SortKeyProperty);
-
-    /// <summary>Resolves the entity type that defines table key metadata for the queried entity type.</summary>
-    private static IReadOnlyEntityType ResolveKeySourceEntityType(IReadOnlyEntityType entityType)
-    {
-        var tableMappedType = entityType.ResolveTableMappedEntityType();
-        if (tableMappedType.GetPartitionKeyProperty() is not null)
-            return tableMappedType;
-
-        foreach (var baseType in entityType.GetAllBaseTypes())
-            if (baseType.GetPartitionKeyProperty() is not null)
-                return baseType;
-
-        return tableMappedType;
-    }
 
     /// <summary>Returns the effective provider CLR type with nullable wrappers removed.</summary>
     private static Type GetEffectiveProviderClrType(IReadOnlyProperty property)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelRuntimeInitializer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelRuntimeInitializer.cs
@@ -26,10 +26,21 @@ public sealed class DynamoModelRuntimeInitializer(ModelRuntimeInitializerDepende
         if (prevalidation)
             return;
 
+        ApplyTableGroupNameAnnotations(model);
+
         model.GetOrAddRuntimeAnnotationValue(
             DynamoAnnotationNames.RuntimeTableModel,
             static currentModel => BuildRuntimeTableModel((IReadOnlyModel)currentModel!),
             model);
+    }
+
+    /// <summary>Stores effective table-group names on runtime entity metadata.</summary>
+    private static void ApplyTableGroupNameAnnotations(IModel model)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+            entityType.SetRuntimeAnnotation(
+                DynamoAnnotationNames.TableGroupName,
+                entityType.ComputeTableGroupName());
     }
 
     /// <summary>Builds runtime table descriptors grouped by effective physical table name.</summary>
@@ -39,7 +50,9 @@ public sealed class DynamoModelRuntimeInitializer(ModelRuntimeInitializerDepende
 
         foreach (var tableGroup in model
             .EnumerateRootEntityTypes()
-            .GroupBy(static entityType => entityType.GetTableGroupName(), StringComparer.Ordinal))
+            .GroupBy(
+                static entityType => (string)entityType[DynamoAnnotationNames.TableGroupName]!,
+                StringComparer.Ordinal))
         {
             var rootEntityTypes = tableGroup.ToList();
             var sourcesByRootEntityType =

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
@@ -121,7 +121,7 @@ public sealed class DynamoDiscriminatorConvention(
             .ToList();
 
         foreach (var tableGroup in rootEntityTypes.GroupBy(static entityType
-            => entityType.GetTableGroupName()))
+            => entityType.ComputeTableGroupName()))
         {
             var hasHierarchy =
                 tableGroup.Any(static entityType => entityType.GetDerivedTypes().Any());

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
@@ -8,6 +8,9 @@ public static class DynamoAnnotationNames
     /// <summary>Annotation key for the DynamoDB table name on an entity type.</summary>
     public const string TableName = Prefix + "TableName";
 
+    /// <summary>Annotation key for the effective DynamoDB table group name on an entity type.</summary>
+    public const string TableGroupName = Prefix + "TableGroupName";
+
     /// <summary>Annotation key for the DynamoDB attribute name on a property or complex property.</summary>
     public const string AttributeName = Prefix + "AttributeName";
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -413,7 +414,7 @@ public class DynamoQueryableMethodTranslatingExpressionVisitor
     protected override ShapedQueryExpression? CreateShapedQueryExpression(IEntityType entityType)
     {
         // Get the table name from entity metadata.
-        var tableName = entityType.GetTableGroupName();
+        var tableName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
 
         var queryExpression = new SelectExpression(tableName, entityType.Name);
 
@@ -502,14 +503,14 @@ public class DynamoQueryableMethodTranslatingExpressionVisitor
     /// </summary>
     private bool RequiresDiscriminatorPredicate(IEntityType entityType)
     {
-        var tableGroupName = entityType.GetTableGroupName();
+        var tableGroupName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
 
         HashSet<IReadOnlyEntityType> concreteTypes = [];
         foreach (var rootEntityType in QueryCompilationContext
             .Model
             .EnumerateRootEntityTypes()
             .Where(t => string.Equals(
-                t.GetTableGroupName(),
+                (string)t[DynamoAnnotationNames.TableGroupName]!,
                 tableGroupName,
                 StringComparison.Ordinal)))
         {

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using EntityFrameworkCore.DynamoDb.Extensions;
-using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -414,7 +413,7 @@ public class DynamoQueryableMethodTranslatingExpressionVisitor
     protected override ShapedQueryExpression? CreateShapedQueryExpression(IEntityType entityType)
     {
         // Get the table name from entity metadata.
-        var tableName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
+        var tableName = entityType.GetTableGroupName();
 
         var queryExpression = new SelectExpression(tableName, entityType.Name);
 
@@ -503,14 +502,14 @@ public class DynamoQueryableMethodTranslatingExpressionVisitor
     /// </summary>
     private bool RequiresDiscriminatorPredicate(IEntityType entityType)
     {
-        var tableGroupName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
+        var tableGroupName = entityType.GetTableGroupName();
 
         HashSet<IReadOnlyEntityType> concreteTypes = [];
         foreach (var rootEntityType in QueryCompilationContext
             .Model
             .EnumerateRootEntityTypes()
             .Where(t => string.Equals(
-                (string)t[DynamoAnnotationNames.TableGroupName]!,
+                t.GetTableGroupName(),
                 tableGroupName,
                 StringComparison.Ordinal)))
         {

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 using EntityFrameworkCore.DynamoDb.Extensions;
-using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -548,7 +547,7 @@ public class DynamoSqlTranslatingExpressionVisitor(
         if (runtimeModel is null)
             return false;
 
-        var tableGroupName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
+        var tableGroupName = entityType.GetTableGroupName();
         if (!runtimeModel.Tables.TryGetValue(tableGroupName, out var tableDescriptor))
             return false;
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -536,7 +536,8 @@ public class DynamoSqlTranslatingExpressionVisitor(
     private bool IsEffectivePartitionKey(IReadOnlyProperty property, IReadOnlyEntityType entityType)
     {
         // Always a partition key if it's the table-level partition key.
-        if (entityType.GetPartitionKeyProperty()?.Name == property.Name)
+        var keyEntityType = entityType.ResolveKeyMappedEntityType();
+        if (keyEntityType.GetPartitionKeyProperty()?.Name == property.Name)
             return true;
 
         // When a secondary index is active, also check the index's own partition key.

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -535,14 +535,12 @@ public class DynamoSqlTranslatingExpressionVisitor(
     /// </remarks>
     private bool IsEffectivePartitionKey(IReadOnlyProperty property, IReadOnlyEntityType entityType)
     {
-        // Always a partition key if it's the table-level partition key.
-        var keyEntityType = entityType.ResolveKeyMappedEntityType();
-        if (keyEntityType.GetPartitionKeyProperty()?.Name == property.Name)
-            return true;
-
-        // When a secondary index is active, also check the index's own partition key.
+        // When a secondary index is active, only that index's partition key is effective.
         if (queryCompilationContext?.ExplicitIndexName is not { } indexName)
-            return false;
+        {
+            var keyEntityType = entityType.ResolveKeyMappedEntityType();
+            return keyEntityType.GetPartitionKeyProperty()?.Name == property.Name;
+        }
 
         var runtimeModel = queryCompilationContext.Model.GetDynamoRuntimeTableModel();
         if (runtimeModel is null)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -547,7 +548,7 @@ public class DynamoSqlTranslatingExpressionVisitor(
         if (runtimeModel is null)
             return false;
 
-        var tableGroupName = entityType.GetTableGroupName();
+        var tableGroupName = (string)entityType[DynamoAnnotationNames.TableGroupName]!;
         if (!runtimeModel.Tables.TryGetValue(tableGroupName, out var tableDescriptor))
             return false;
 

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseCreator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseCreator.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EntityFrameworkCore.DynamoDb.Storage;
+
+/// <summary>Provides unsupported database lifecycle operations for the DynamoDB provider.</summary>
+internal sealed class DynamoDatabaseCreator : IDatabaseCreator
+{
+    private const string DatabaseLifecycleNotSupported =
+        "The DynamoDB database provider does not support database lifecycle operations.";
+
+    /// <summary>Ensures the database is deleted.</summary>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public bool EnsureDeleted() => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+
+    /// <summary>Ensures the database is deleted asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+
+    /// <summary>Ensures the database is created.</summary>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public bool EnsureCreated() => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+
+    /// <summary>Ensures the database is created asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+
+    /// <summary>Determines whether the database can be connected to.</summary>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public bool CanConnect() => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+
+    /// <summary>Determines whether the database can be connected to asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because database lifecycle operations are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because database lifecycle operations are
+    ///     unsupported.
+    /// </exception>
+    public Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(DatabaseLifecycleNotSupported);
+}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoDatabaseWrapper.cs
@@ -1,3 +1,4 @@
+using System.Transactions;
 using EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -32,6 +33,9 @@ public class DynamoDatabaseWrapper(
         new DynamoWriteExceptionMapper(),
         new DynamoTransactionTargetIdentityFactory(serializerSource));
 
+    private const string TransactionsNotSupported =
+        "The DynamoDB database provider does not support explicit transactions.";
+
     private readonly bool _saveEventsHooked = HookSaveEvents(
         currentDbContext.Context,
         transactionRuntimeOptions);
@@ -53,6 +57,9 @@ public class DynamoDatabaseWrapper(
 
         try
         {
+            if (Transaction.Current is not null)
+                throw new NotSupportedException(TransactionsNotSupported);
+
             var plan = _saveChangesPlanner.Plan(entries);
             if (plan.Operations.Count == 0)
                 return 0;

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoPartiqlStatementFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoPartiqlStatementFactory.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using Amazon.DynamoDBv2.Model;
-using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using EntityFrameworkCore.DynamoDb.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -18,7 +18,7 @@ internal sealed class DynamoPartiqlStatementFactory(
     internal (string tableName, string sql, List<AttributeValue> parameters)?
         BuildModifiedUpdateStatement(IUpdateEntry entry)
     {
-        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
+        var tableName = entry.EntityType.GetTableGroupName();
         var entityType = entry.EntityType;
         var rootEntry = (InternalEntityEntry)entry;
 
@@ -96,7 +96,7 @@ internal sealed class DynamoPartiqlStatementFactory(
     internal (string tableName, string sql, List<AttributeValue> parameters) BuildDeleteStatement(
         IUpdateEntry entry)
     {
-        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
+        var tableName = entry.EntityType.GetTableGroupName();
 
         if (tableName.Contains('"'))
             throw new ArgumentException(
@@ -105,8 +105,9 @@ internal sealed class DynamoPartiqlStatementFactory(
                 nameof(tableName));
 
         var entityType = entry.EntityType;
+        var keyEntityType = entityType.ResolveKeyMappedEntityType();
 
-        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+        var partitionKeyProperty = keyEntityType.GetPartitionKeyProperty()
             ?? throw new InvalidOperationException(
                 $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
 
@@ -120,7 +121,7 @@ internal sealed class DynamoPartiqlStatementFactory(
         sqlBuilder.Append(
             $"WHERE \"{EscapeIdentifier(partitionKeyProperty.GetAttributeName())}\" = ?");
 
-        var sortKeyProperty = entityType.GetSortKeyProperty();
+        var sortKeyProperty = keyEntityType.GetSortKeyProperty();
         if (sortKeyProperty is not null)
         {
             parameters.Add(
@@ -179,8 +180,9 @@ internal sealed class DynamoPartiqlStatementFactory(
             return null;
 
         var whereParameters = new List<AttributeValue>();
+        var keyEntityType = entityType.ResolveKeyMappedEntityType();
 
-        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+        var partitionKeyProperty = keyEntityType.GetPartitionKeyProperty()
             ?? throw new InvalidOperationException(
                 $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
 
@@ -192,7 +194,7 @@ internal sealed class DynamoPartiqlStatementFactory(
             $"\"{EscapeIdentifier(partitionKeyProperty.GetAttributeName())}\" = ?",
         };
 
-        var sortKeyProperty = entityType.GetSortKeyProperty();
+        var sortKeyProperty = keyEntityType.GetSortKeyProperty();
         if (sortKeyProperty is not null)
         {
             whereParameters.Add(

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoPartiqlStatementFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoPartiqlStatementFactory.cs
@@ -18,7 +18,7 @@ internal sealed class DynamoPartiqlStatementFactory(
     internal (string tableName, string sql, List<AttributeValue> parameters)?
         BuildModifiedUpdateStatement(IUpdateEntry entry)
     {
-        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
         var entityType = entry.EntityType;
         var rootEntry = (InternalEntityEntry)entry;
 
@@ -96,7 +96,7 @@ internal sealed class DynamoPartiqlStatementFactory(
     internal (string tableName, string sql, List<AttributeValue> parameters) BuildDeleteStatement(
         IUpdateEntry entry)
     {
-        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+        var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
 
         if (tableName.Contains('"'))
             throw new ArgumentException(
@@ -246,7 +246,8 @@ internal sealed class DynamoPartiqlStatementFactory(
         if (ShouldReplaceWholeComplexProperty(complexEntry, complexProperty))
         {
             setClauses.Add($"{path} = ?");
-            setParameters.Add(EntityWritePlan.SerializeComplexProperty(currentValue, complexProperty));
+            setParameters.Add(
+                EntityWritePlan.SerializeComplexProperty(currentValue, complexProperty));
             return;
         }
 

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using Amazon.DynamoDBv2.Model;
-using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using EntityFrameworkCore.DynamoDb.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Update;
 
@@ -46,7 +46,7 @@ internal sealed class DynamoSaveChangesPlanner(
                 case EntityState.Added:
                 {
                     var item = serializerSource.BuildItem(entry);
-                    var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
+                    var tableName = entry.EntityType.GetTableGroupName();
 
                     // DynamoDB rejects { NULL: true } for GSI key attributes via PartiQL INSERT.
                     // Sparse GSIs require these attributes to simply be absent when not applicable.

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoSaveChangesPlanner.cs
@@ -46,7 +46,7 @@ internal sealed class DynamoSaveChangesPlanner(
                 case EntityState.Added:
                 {
                     var item = serializerSource.BuildItem(entry);
-                    var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableName]!;
+                    var tableName = (string)entry.EntityType[DynamoAnnotationNames.TableGroupName]!;
 
                     // DynamoDB rejects { NULL: true } for GSI key attributes via PartiQL INSERT.
                     // Sparse GSIs require these attributes to simply be absent when not applicable.

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionManager.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionManager.cs
@@ -65,7 +65,7 @@ internal sealed class DynamoTransactionManager
         => throw new NotSupportedException(TransactionsNotSupported);
 
     /// <summary>Gets the current ambient transaction.</summary>
-    public Transaction? CurrentAmbientTransaction => null;
+    public Transaction? CurrentAmbientTransaction => Transaction.Current;
 
     /// <summary>Gets the current transaction.</summary>
     public IDbContextTransaction? CurrentTransaction => null;

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionManager.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionManager.cs
@@ -1,0 +1,93 @@
+using System.Transactions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EntityFrameworkCore.DynamoDb.Storage;
+
+/// <summary>Manages unsupported EF Core transactions for the DynamoDB provider.</summary>
+internal sealed class DynamoTransactionManager
+    : IDbContextTransactionManager, ITransactionEnlistmentManager
+{
+    private const string TransactionsNotSupported =
+        "The DynamoDB database provider does not support explicit transactions.";
+
+    /// <summary>Begins a transaction.</summary>
+    /// <returns>Never returns because explicit transactions are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public IDbContextTransaction BeginTransaction()
+        => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Begins a transaction asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because explicit transactions are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public Task<IDbContextTransaction> BeginTransactionAsync(
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Commits the current transaction.</summary>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public void CommitTransaction() => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Commits the current transaction asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because explicit transactions are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public Task CommitTransactionAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Rolls back the current transaction.</summary>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public void RollbackTransaction() => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Rolls back the current transaction asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Never returns because explicit transactions are unsupported.</returns>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Gets the current ambient transaction.</summary>
+    public Transaction? CurrentAmbientTransaction => null;
+
+    /// <summary>Gets the current transaction.</summary>
+    public IDbContextTransaction? CurrentTransaction => null;
+
+    /// <summary>Gets the enlisted transaction.</summary>
+    public Transaction? EnlistedTransaction => null;
+
+    /// <summary>Enlists in the specified transaction.</summary>
+    /// <param name="transaction">Transaction to enlist in.</param>
+    /// <exception cref="NotSupportedException">
+    ///     Always thrown because explicit transactions are
+    ///     unsupported.
+    /// </exception>
+    public void EnlistTransaction(Transaction? transaction)
+        => throw new NotSupportedException(TransactionsNotSupported);
+
+    /// <summary>Resets manager state.</summary>
+    public void ResetState() { }
+
+    /// <summary>Resets manager state asynchronously.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Completed task.</returns>
+    public Task ResetStateAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionTargetIdentityFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTransactionTargetIdentityFactory.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
@@ -11,14 +12,15 @@ internal sealed class DynamoTransactionTargetIdentityFactory(
     internal TransactionTargetItem Create(IUpdateEntry entry, string tableName)
     {
         var entityType = entry.EntityType;
+        var keyEntityType = entityType.ResolveKeyMappedEntityType();
 
-        var partitionKeyProperty = entityType.GetPartitionKeyProperty()
+        var partitionKeyProperty = keyEntityType.GetPartitionKeyProperty()
             ?? throw new InvalidOperationException(
                 $"Entity type '{entityType.DisplayName()}' does not define a partition key.");
 
         var partitionKeyValue = SerializeIdentityValue(entry, partitionKeyProperty);
 
-        var sortKeyProperty = entityType.GetSortKeyProperty();
+        var sortKeyProperty = keyEntityType.GetSortKeyProperty();
         var sortKeyValue = sortKeyProperty is null
             ? string.Empty
             : SerializeIdentityValue(entry, sortKeyProperty);

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
@@ -774,6 +774,30 @@ public class IndexQueryExtensionsTests
     /// <summary>Provides functionality for this member.</summary>
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
+    public async Task DerivedQuery_BasePartitionKey_Contains_51Items_ThrowsPartitionKeyLimitError()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        await using var context = CreateDerivedIndexQueryContext(client);
+
+        var ids = Enumerable.Range(1, 51).Select(i => $"ORDER#{i}").ToList();
+
+        var act = async ()
+            => await context
+                .Set<ArchivedOrderForIndexQuery>()
+                .Where(o => ids.Contains(o.Id))
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*50*partition key*");
+
+        await client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!);
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    /// <summary>Provides functionality for this member.</summary>
     public async Task WithIndex_GsiPartitionKey_Contains_51Items_ThrowsPartitionKeyLimitError()
     {
         // Before the fix, CustomerId was not recognised as a partition key when querying via

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/IndexQueryExtensionsTests.cs
@@ -853,6 +853,53 @@ public class IndexQueryExtensionsTests
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     /// <summary>Provides functionality for this member.</summary>
     public async Task
+        WithIndex_BaseTablePartitionKey_Contains_51Items_DoesNotThrowPartitionKeyLimitError()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+
+        await using var context = CreateGsiContext(client);
+
+        var tenantIds = Enumerable.Range(1, 51).Select(i => $"TENANT#{i}").ToList();
+
+        var act = async ()
+            => await context
+                .Orders
+                .WithIndex("ByCustomer")
+                .Where(o => tenantIds.Contains(o.TenantId))
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync<InvalidOperationException>();
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    /// <summary>Provides functionality for this member.</summary>
+    public async Task WithIndex_BaseTablePartitionKey_Contains_101Items_ThrowsNonKeyLimitError()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        await using var context = CreateGsiContext(client);
+
+        var tenantIds = Enumerable.Range(1, 101).Select(i => $"TENANT#{i}").ToList();
+
+        var act = async ()
+            => await context
+                .Orders
+                .WithIndex("ByCustomer")
+                .Where(o => tenantIds.Contains(o.TenantId))
+                .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*100*non-key*");
+
+        await client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!);
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    /// <summary>Provides functionality for this member.</summary>
+    public async Task
         AutoSelectedIndex_GsiPartitionKey_Contains_51Items_ThrowsPartitionKeyLimitError()
     {
         // Regression: analyzer-selected indexes are applied after translation. Ensure SQL

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDatabaseCreatorTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDatabaseCreatorTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
+
+/// <summary>Tests unsupported database lifecycle APIs for the DynamoDB provider.</summary>
+public sealed class DynamoDatabaseCreatorTests
+{
+    private const string DatabaseLifecycleNotSupported =
+        "The DynamoDB database provider does not support database lifecycle operations.";
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void EnsureCreated_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.EnsureCreated());
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task EnsureCreatedAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void EnsureDeleted_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.EnsureDeleted());
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task EnsureDeletedAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void CanConnect_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception = Assert.Throws<NotSupportedException>(() => context.Database.CanConnect());
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task CanConnectAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.CanConnectAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(DatabaseLifecycleNotSupported);
+    }
+
+    private static DatabaseCreatorContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<DatabaseCreatorContext>()
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+        return new DatabaseCreatorContext(options);
+    }
+
+    private sealed class DatabaseCreatorContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<DatabaseCreatorEntity>(b =>
+            {
+                b.ToTable("DatabaseCreator");
+                b.HasPartitionKey(e => e.Id);
+            });
+    }
+
+    private sealed class DatabaseCreatorEntity
+    {
+        public string Id { get; set; } = null!;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDerivedSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDerivedSaveChangesTests.cs
@@ -30,6 +30,16 @@ public class DynamoDerivedSaveChangesTests
                 """
                 INSERT INTO "Documents"
                 """);
+        captured[0].Statement.Should().Contain("'pk_attr': ?");
+        captured[0].Statement.Should().Contain("'sk_attr': ?");
+        captured[0].Statement.Should().Contain("'name': ?");
+        captured[0].Statement.Should().Contain("'$type': ?");
+        captured[0].Statement.Should().Contain("'extra': ?");
+        captured[0]
+            .Parameters
+            .Select(GetStringValue)
+            .Should()
+            .Contain(["DOC#1", "META#1", "before", "derived", "extra"]);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDerivedSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoDerivedSaveChangesTests.cs
@@ -1,0 +1,209 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
+
+/// <summary>Tests SaveChanges planning for derived entities mapped to shared DynamoDB tables.</summary>
+public class DynamoDerivedSaveChangesTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task SaveChanges_AddedDerivedEntity_WritesToBaseTableGroup()
+    {
+        var (context, captured) = CreateContext();
+        context.Add(
+            new DerivedDocument
+            {
+                Pk = "DOC#1", Sk = "META#1", Name = "before", Extra = "extra",
+            });
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        captured.Should().ContainSingle();
+        captured[0]
+            .Statement
+            .Should()
+            .StartWith(
+                """
+                INSERT INTO "Documents"
+                """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task SaveChanges_ModifiedDerivedEntity_UsesBaseKeyAttributesInWhereClause()
+    {
+        var (context, captured) = CreateContext();
+        var entity = new DerivedDocument
+        {
+            Pk = "DOC#1", Sk = "META#1", Name = "before", Extra = "extra",
+        };
+        context.Attach(entity);
+        entity.Name = "after";
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        captured.Should().ContainSingle();
+        captured[0]
+            .Statement
+            .Should()
+            .Be(
+                """
+                UPDATE "Documents"
+                SET "name" = ?
+                WHERE "pk_attr" = ? AND "sk_attr" = ?
+                """);
+        captured[0].Parameters.Select(GetStringValue).Should().Equal("after", "DOC#1", "META#1");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task SaveChanges_DeletedDerivedEntity_UsesBaseKeyAttributesInWhereClause()
+    {
+        var (context, captured) = CreateContext();
+        var entity = new DerivedDocument
+        {
+            Pk = "DOC#1", Sk = "META#1", Name = "before", Extra = "extra",
+        };
+        context.Attach(entity);
+        context.Remove(entity);
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        captured.Should().ContainSingle();
+        captured[0]
+            .Statement
+            .Should()
+            .Be(
+                """
+                DELETE FROM "Documents"
+                WHERE "pk_attr" = ? AND "sk_attr" = ?
+                """);
+        captured[0].Parameters.Select(GetStringValue).Should().Equal("DOC#1", "META#1");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void RuntimeModel_StoresTableGroupNameForDerivedAndSharedTableEntities()
+    {
+        var (context, _) = CreateContext();
+
+        context.Model.FindEntityType(typeof(BaseDocument))!.FindRuntimeAnnotation(
+                DynamoAnnotationNames.TableGroupName)!
+            .Value
+            .Should()
+            .Be("Documents");
+        context.Model.FindEntityType(typeof(DerivedDocument))!.FindRuntimeAnnotation(
+                DynamoAnnotationNames.TableGroupName)!
+            .Value
+            .Should()
+            .Be("Documents");
+        context.Model.FindEntityType(typeof(SharedRootA))!.FindRuntimeAnnotation(
+                DynamoAnnotationNames.TableGroupName)!
+            .Value
+            .Should()
+            .Be("SharedRoots");
+        context.Model.FindEntityType(typeof(SharedRootB))!.FindRuntimeAnnotation(
+                DynamoAnnotationNames.TableGroupName)!
+            .Value
+            .Should()
+            .Be("SharedRoots");
+    }
+
+    private static (DerivedSaveChangesContext context, List<ParameterizedStatement> captured)
+        CreateContext()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var captured = new List<ParameterizedStatement>();
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(r
+                    => captured.Add(
+                        new ParameterizedStatement
+                        {
+                            Statement = r.Statement, Parameters = r.Parameters,
+                        })),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse());
+
+        client
+            .ExecuteTransactionAsync(
+                Arg.Do<ExecuteTransactionRequest>(r
+                    => captured.AddRange(r.TransactStatements ?? [])),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteTransactionResponse());
+
+        var options = new DbContextOptionsBuilder<DerivedSaveChangesContext>()
+            .UseDynamo(options => options.DynamoDbClient(client))
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+        return (new DerivedSaveChangesContext(options), captured);
+    }
+
+    private static string GetStringValue(AttributeValue value)
+        => value.S ?? value.N ?? throw new InvalidOperationException("Expected scalar value.");
+
+    private abstract class BaseDocument
+    {
+        public string Pk { get; set; } = null!;
+        public string Sk { get; set; } = null!;
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class DerivedDocument : BaseDocument
+    {
+        public string Extra { get; set; } = null!;
+    }
+
+    private sealed class SharedRootA
+    {
+        public string Pk { get; set; } = null!;
+        public string Sk { get; set; } = null!;
+    }
+
+    private sealed class SharedRootB
+    {
+        public string Pk { get; set; } = null!;
+        public string Sk { get; set; } = null!;
+    }
+
+    private sealed class DerivedSaveChangesContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<BaseDocument>(b =>
+            {
+                b.ToTable("Documents");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasSortKey(x => x.Sk);
+                b.Property(x => x.Pk).HasAttributeName("pk_attr");
+                b.Property(x => x.Sk).HasAttributeName("sk_attr");
+                b.Property(x => x.Name).HasAttributeName("name");
+                b
+                    .HasDiscriminator<string>("$type")
+                    .HasValue<BaseDocument>("base")
+                    .HasValue<DerivedDocument>("derived");
+            });
+
+            modelBuilder.Entity<DerivedDocument>(b =>
+            {
+                b.Property(x => x.Extra).HasAttributeName("extra");
+            });
+
+            modelBuilder.Entity<SharedRootA>(b =>
+            {
+                b.ToTable("SharedRoots");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasSortKey(x => x.Sk);
+            });
+
+            modelBuilder.Entity<SharedRootB>(b =>
+            {
+                b.ToTable("SharedRoots");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasSortKey(x => x.Sk);
+            });
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
@@ -1,8 +1,11 @@
 using System.Transactions;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using NSubstitute;
 
 namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
 
@@ -103,6 +106,24 @@ public sealed class DynamoTransactionManagerTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task SaveChanges_InsideAmbientTransaction_ThrowsNotSupportedException()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse());
+        await using var context = CreateContext(client);
+        context.Add(new TransactionEntity { Id = "TRANSACTION#1" });
+
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public void CurrentTransaction_ReturnsNull()
     {
         using var context = CreateContext();
@@ -119,7 +140,7 @@ public sealed class DynamoTransactionManagerTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void CurrentAmbientTransaction_IgnoresTransactionScope()
+    public void CurrentAmbientTransaction_ReturnsAmbientTransactionScope()
     {
         using var context = CreateContext();
         var transactionManager =
@@ -129,16 +150,22 @@ public sealed class DynamoTransactionManagerTests
                 .BeAssignableTo<ITransactionEnlistmentManager>()
                 .Subject;
 
+        transactionManager.CurrentAmbientTransaction.Should().BeNull();
+
         using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
         Transaction.Current.Should().NotBeNull();
-        transactionManager.CurrentAmbientTransaction.Should().BeNull();
+        transactionManager.CurrentAmbientTransaction.Should().BeSameAs(Transaction.Current);
     }
 
-    private static TransactionContext CreateContext()
+    private static TransactionContext CreateContext(IAmazonDynamoDB? client = null)
     {
         var options = new DbContextOptionsBuilder<TransactionContext>()
-            .UseDynamo()
+            .UseDynamo(options =>
+            {
+                if (client is not null)
+                    options.DynamoDbClient(client);
+            })
             .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .Options;
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
@@ -1,0 +1,162 @@
+using System.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Storage;
+
+/// <summary>Tests unsupported transaction behavior for the DynamoDB provider.</summary>
+public sealed class DynamoTransactionManagerTests
+{
+    private const string TransactionsNotSupported =
+        "The DynamoDB database provider does not support explicit transactions.";
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void BeginTransaction_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.BeginTransaction());
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task BeginTransactionAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.BeginTransactionAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void CommitTransaction_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.CommitTransaction());
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task CommitTransactionAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.CommitTransactionAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void RollbackTransaction_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.RollbackTransaction());
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task RollbackTransactionAsync_ThrowsNotSupportedException()
+    {
+        await using var context = CreateContext();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(()
+            => context.Database.RollbackTransactionAsync(TestContext.Current.CancellationToken));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void EnlistTransaction_WithNull_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(() => context.Database.EnlistTransaction(null));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void EnlistTransaction_WithTransaction_ThrowsNotSupportedException()
+    {
+        using var context = CreateContext();
+        using var transaction = new CommittableTransaction();
+
+        var exception =
+            Assert.Throws<NotSupportedException>(()
+                => context.Database.EnlistTransaction(transaction));
+
+        exception.Message.Should().Be(TransactionsNotSupported);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void CurrentTransaction_ReturnsNull()
+    {
+        using var context = CreateContext();
+
+        context.Database.CurrentTransaction.Should().BeNull();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void GetEnlistedTransaction_ReturnsNull()
+    {
+        using var context = CreateContext();
+
+        context.Database.GetEnlistedTransaction().Should().BeNull();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void CurrentAmbientTransaction_IgnoresTransactionScope()
+    {
+        using var context = CreateContext();
+        var transactionManager =
+            context
+                .GetService<IDbContextTransactionManager>()
+                .Should()
+                .BeAssignableTo<ITransactionEnlistmentManager>()
+                .Subject;
+
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        Transaction.Current.Should().NotBeNull();
+        transactionManager.CurrentAmbientTransaction.Should().BeNull();
+    }
+
+    private static TransactionContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<TransactionContext>()
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+        return new TransactionContext(options);
+    }
+
+    private sealed class TransactionContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<TransactionEntity>(b =>
+            {
+                b.ToTable("Transactions");
+                b.HasPartitionKey(e => e.Id);
+            });
+    }
+
+    private sealed class TransactionEntity
+    {
+        public string Id { get; set; } = null!;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoTransactionManagerTests.cs
@@ -121,6 +121,8 @@ public sealed class DynamoTransactionManagerTests
             => context.SaveChangesAsync(TestContext.Current.CancellationToken));
 
         exception.Message.Should().Be(TransactionsNotSupported);
+        await client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!);
+        await client.DidNotReceiveWithAnyArgs().ExecuteTransactionAsync(default!);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]


### PR DESCRIPTION
## Summary

Moves the non-test functional work from the specification-test branch into a focused PR against `main`. This adds centralized key resolution/table-group handling and wires unsupported transaction handling so functional fixes can land before continuing integration/specification test work.

## Changes

- Add metadata helpers for resolving key properties and computing table group names.
- Streamline table-group usage across query translation, PartiQL statement creation, save planning, and transaction target identity creation.
- Add `DynamoTransactionManager` to explicitly handle unsupported transaction APIs.
- Fix solution folder path from `/git/` to `/.github/`.
- Update agent guidance for NuGet package management through the `dotnet` CLI.

## Validation

- `dotnet build`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj --no-build`

## Notes for Reviewers

Specification/integration test work remains on `feat/tests-specification-tests-v2` for follow-up after these functional changes land.
