### PR TITLE
refactor(core): seal provider classes

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDbContextOptionsExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoDbContextOptionsExtensions.cs
@@ -48,6 +48,23 @@ public static class DynamoDbContextOptionsExtensions
         }
     }
 
+    extension<TContext>(DbContextOptionsBuilder<TContext> optionsBuilder) where TContext : DbContext
+    {
+        /// <summary>Configures this context to use the DynamoDB provider.</summary>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public DbContextOptionsBuilder<TContext> UseDynamo()
+            => (DbContextOptionsBuilder<TContext>)((DbContextOptionsBuilder)optionsBuilder)
+                .UseDynamo();
+
+        /// <summary>Configures this context to use the DynamoDB provider.</summary>
+        /// <param name="configure">Provider-specific options to configure.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public DbContextOptionsBuilder<TContext> UseDynamo(
+            Action<DynamoDbContextOptionsBuilder> configure)
+            => (DbContextOptionsBuilder<TContext>)((DbContextOptionsBuilder)optionsBuilder)
+                .UseDynamo(configure);
+    }
+
     private static void ConfigureWarnings(DbContextOptionsBuilder optionsBuilder)
     {
         var coreOptionsExtension =

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
@@ -180,6 +180,39 @@ public static class DynamoEntityTypeBuilderExtensions
         }
     }
 
+    extension(IConventionEntityTypeBuilder entityTypeBuilder)
+    {
+        /// <summary>Configures the table that the entity type maps to when targeting AWS DynamoDB.</summary>
+        /// <param name="name">The table name, or <see langword="null" /> to clear the explicit table mapping.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>The same builder instance if the table name was set; otherwise <see langword="null" />.</returns>
+        public IConventionEntityTypeBuilder? ToTable(string? name, bool fromDataAnnotation = false)
+        {
+            name = name.NullButNotEmpty();
+            if (!entityTypeBuilder.CanSetTable(name, fromDataAnnotation))
+                return null;
+
+            entityTypeBuilder.Metadata.SetTableName(name, fromDataAnnotation);
+            return entityTypeBuilder;
+        }
+
+        /// <summary>Returns whether the table name can be set from the given configuration source.</summary>
+        /// <param name="name">The table name, or <see langword="null" /> to clear the explicit table mapping.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns><see langword="true" /> if the table name can be set; otherwise <see langword="false" />.</returns>
+        public bool CanSetTable(string? name, bool fromDataAnnotation = false)
+            => entityTypeBuilder.CanSetAnnotation(
+                DynamoAnnotationNames.TableName,
+                name.NullButNotEmpty(),
+                fromDataAnnotation);
+    }
+
     extension<TEntity>(EntityTypeBuilder<TEntity> entityTypeBuilder) where TEntity : class
     {
         /// <summary>Configures the table that the entity type maps to when targeting AWS DynamoDB.</summary>
@@ -190,6 +223,26 @@ public static class DynamoEntityTypeBuilderExtensions
         /// <returns>The same builder instance so that multiple calls can be chained.</returns>
         public EntityTypeBuilder<TEntity> ToTable(string? name)
             => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)entityTypeBuilder).ToTable(name);
+
+        /// <summary>
+        ///     Configures which property provides the DynamoDB partition key attribute name for this
+        ///     entity type.
+        /// </summary>
+        /// <param name="propertyName">The EF property name whose attribute name maps to the DynamoDB partition key.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public EntityTypeBuilder<TEntity> HasPartitionKey(string propertyName)
+            => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)entityTypeBuilder).HasPartitionKey(
+                propertyName);
+
+        /// <summary>
+        ///     Configures which property provides the DynamoDB sort key attribute name for this entity
+        ///     type.
+        /// </summary>
+        /// <param name="propertyName">The EF property name whose attribute name maps to the DynamoDB sort key.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public EntityTypeBuilder<TEntity> HasSortKey(string propertyName)
+            => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)entityTypeBuilder).HasSortKey(
+                propertyName);
 
         /// <summary>
         ///     Configures which property provides the DynamoDB partition key attribute name for this

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeExtensions.cs
@@ -64,6 +64,25 @@ public static class DynamoEntityTypeExtensions
             => entityType.SetOrRemoveAnnotation(
                 DynamoAnnotationNames.AttributeNamingConvention,
                 descriptor);
+
+        /// <summary>Gets the mutable EF property that maps to the DynamoDB partition key.</summary>
+        /// <returns>
+        ///     The partition key property, or <see langword="null" /> when no partition key is
+        ///     configured.
+        /// </returns>
+        public IMutableProperty? GetPartitionKeyProperty()
+        {
+            var name = entityType.GetPartitionKeyPropertyName();
+            return name is not null ? entityType.FindProperty(name) : null;
+        }
+
+        /// <summary>Gets the mutable EF property that maps to the DynamoDB sort key.</summary>
+        /// <returns>The sort key property, or <see langword="null" /> when no sort key is configured.</returns>
+        public IMutableProperty? GetSortKeyProperty()
+        {
+            var name = entityType.GetSortKeyPropertyName();
+            return name is not null ? entityType.FindProperty(name) : null;
+        }
     }
 
     extension(IReadOnlyEntityType entityType)
@@ -193,6 +212,44 @@ public static class DynamoEntityTypeExtensions
 
     extension(IConventionEntityType entityType)
     {
+        /// <summary>Sets the DynamoDB table name at the given configuration source.</summary>
+        /// <param name="name">The table name, or <see langword="null" /> to clear the explicit mapping.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>The configured table name, or <see langword="null" /> if configuration was not applied.</returns>
+        public string? SetTableName(string? name, bool fromDataAnnotation = false)
+            => (string?)entityType.SetOrRemoveAnnotation(
+                    DynamoAnnotationNames.TableName,
+                    name.NullButNotEmpty(),
+                    fromDataAnnotation)
+                ?.Value;
+
+        /// <summary>Returns the configuration source for the table name annotation.</summary>
+        /// <returns>The configuration source, or <see langword="null" /> if no table name is configured.</returns>
+        public ConfigurationSource? GetTableNameConfigurationSource()
+            => entityType.FindAnnotation(DynamoAnnotationNames.TableName)?.GetConfigurationSource();
+
+        /// <summary>Gets the convention EF property that maps to the DynamoDB partition key.</summary>
+        /// <returns>
+        ///     The partition key property, or <see langword="null" /> when no partition key is
+        ///     configured.
+        /// </returns>
+        public IConventionProperty? GetPartitionKeyProperty()
+        {
+            var name = entityType.GetPartitionKeyPropertyName();
+            return name is not null ? entityType.FindProperty(name) : null;
+        }
+
+        /// <summary>Gets the convention EF property that maps to the DynamoDB sort key.</summary>
+        /// <returns>The sort key property, or <see langword="null" /> when no sort key is configured.</returns>
+        public IConventionProperty? GetSortKeyProperty()
+        {
+            var name = entityType.GetSortKeyPropertyName();
+            return name is not null ? entityType.FindProperty(name) : null;
+        }
+
         /// <summary>
         ///     Sets the EF property name designated as the DynamoDB partition key at the given
         ///     configuration source.

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyExtensions.cs
@@ -33,13 +33,13 @@ public static class DynamoPropertyExtensions
             => property.SetOrRemoveAnnotation(DynamoAnnotationNames.AttributeName, name);
 
         /// <summary>Marks this property as runtime-only provider metadata.</summary>
-        public void SetRuntimeOnly(bool runtimeOnly)
+        internal void SetRuntimeOnly(bool runtimeOnly)
             => property.SetOrRemoveAnnotation(
                 DynamoAnnotationNames.RuntimeOnlyProperty,
                 runtimeOnly ? true : null);
 
         /// <summary>Sets or clears the runtime value source identifier for this property.</summary>
-        public void SetRuntimeValueSource(string? runtimeValueSource)
+        internal void SetRuntimeValueSource(string? runtimeValueSource)
             => property.SetOrRemoveAnnotation(
                 DynamoAnnotationNames.RuntimeValueSource,
                 runtimeValueSource);
@@ -59,18 +59,24 @@ public static class DynamoPropertyExtensions
         ///     Sets whether this property is runtime-only provider metadata, recording the configuration
         ///     source.
         /// </summary>
-        public bool? SetRuntimeOnly(bool runtimeOnly, bool fromDataAnnotation = false)
+        internal bool? SetRuntimeOnly(bool runtimeOnly, bool fromDataAnnotation = false)
             => (bool?)property.SetOrRemoveAnnotation(
                     DynamoAnnotationNames.RuntimeOnlyProperty,
                     runtimeOnly ? true : null,
                     fromDataAnnotation)
                 ?.Value;
 
+        /// <summary>Returns the configuration source for the runtime-only marker, or null if not set.</summary>
+        internal ConfigurationSource? GetRuntimeOnlyConfigurationSource()
+            => property
+                .FindAnnotation(DynamoAnnotationNames.RuntimeOnlyProperty)
+                ?.GetConfigurationSource();
+
         /// <summary>
         ///     Sets the runtime value source identifier for this property, recording the configuration
         ///     source.
         /// </summary>
-        public string? SetRuntimeValueSource(
+        internal string? SetRuntimeValueSource(
             string? runtimeValueSource,
             bool fromDataAnnotation = false)
             => (string?)property.SetOrRemoveAnnotation(
@@ -78,6 +84,12 @@ public static class DynamoPropertyExtensions
                     runtimeValueSource,
                     fromDataAnnotation)
                 ?.Value;
+
+        /// <summary>Returns the configuration source for the runtime value source, or null if not set.</summary>
+        internal ConfigurationSource? GetRuntimeValueSourceConfigurationSource()
+            => property
+                .FindAnnotation(DynamoAnnotationNames.RuntimeValueSource)
+                ?.GetConfigurationSource();
     }
 
     extension(IReadOnlyComplexProperty complexProperty)

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoDbOptionsExtension.cs
@@ -1,13 +1,12 @@
 using Amazon.DynamoDBv2;
 using EntityFrameworkCore.DynamoDb.Extensions;
-using EntityFrameworkCore.DynamoDb.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFrameworkCore.DynamoDb.Infrastructure.Internal;
 
 /// <summary>Represents the DynamoDbOptionsExtension type.</summary>
-public class DynamoDbOptionsExtension : IDbContextOptionsExtension
+public sealed class DynamoDbOptionsExtension : IDbContextOptionsExtension
 {
     private const int DynamoTransactionLimit = 100;
     private const int DynamoPartiQlBatchLimit = 25;
@@ -48,8 +47,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     public DynamoTableLifecycleOptions TableLifecycleOptions { get; private set; } = new();
 
     /// <summary>Registers provider services in the EF Core internal service container.</summary>
-    public virtual void ApplyServices(IServiceCollection services)
-        => services.AddEntityFrameworkDynamo();
+    public void ApplyServices(IServiceCollection services) => services.AddEntityFrameworkDynamo();
 
     /// <summary>Validates configured options for this provider extension.</summary>
     public void Validate(IDbContextOptions options) { }
@@ -65,7 +63,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets a preconfigured DynamoDB client instance for provider operations.</summary>
-    public virtual DynamoDbOptionsExtension WithDynamoDbClient(IAmazonDynamoDB? client)
+    public DynamoDbOptionsExtension WithDynamoDbClient(IAmazonDynamoDB? client)
     {
         var clone = Clone();
 
@@ -75,7 +73,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets the base SDK configuration used when creating the DynamoDB client.</summary>
-    public virtual DynamoDbOptionsExtension WithDynamoDbClientConfig(AmazonDynamoDBConfig? config)
+    public DynamoDbOptionsExtension WithDynamoDbClientConfig(AmazonDynamoDBConfig? config)
     {
         var clone = Clone();
 
@@ -85,7 +83,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets a callback that configures SDK client configuration before client creation.</summary>
-    public virtual DynamoDbOptionsExtension WithDynamoDbClientConfigAction(
+    public DynamoDbOptionsExtension WithDynamoDbClientConfigAction(
         Action<AmazonDynamoDBConfig>? configure)
     {
         var clone = Clone();
@@ -97,7 +95,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
 
     /// <summary>Sets how the provider should apply automatic secondary index selection.</summary>
     /// <returns>A cloned options extension containing the updated mode.</returns>
-    public virtual DynamoDbOptionsExtension WithAutomaticIndexSelectionMode(
+    public DynamoDbOptionsExtension WithAutomaticIndexSelectionMode(
         DynamoAutomaticIndexSelectionMode mode)
     {
         var clone = Clone();
@@ -111,7 +109,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     /// Sets how transactional SaveChanges should behave when one transaction cannot represent
     /// the full write unit.
     /// </summary>
-    public virtual DynamoDbOptionsExtension WithTransactionOverflowBehavior(
+    public DynamoDbOptionsExtension WithTransactionOverflowBehavior(
         TransactionOverflowBehavior behavior)
     {
         var clone = Clone();
@@ -124,7 +122,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     /// <summary>
     /// Sets the maximum number of write operations sent in a single DynamoDB transaction.
     /// </summary>
-    public virtual DynamoDbOptionsExtension WithMaxTransactionSize(int maxTransactionSize)
+    public DynamoDbOptionsExtension WithMaxTransactionSize(int maxTransactionSize)
     {
         if (maxTransactionSize is <= 0 or > DynamoTransactionLimit)
             throw new InvalidOperationException(
@@ -139,7 +137,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets the maximum number of write operations sent in a single non-atomic PartiQL batch.</summary>
-    public virtual DynamoDbOptionsExtension WithMaxBatchWriteSize(int maxBatchWriteSize)
+    public DynamoDbOptionsExtension WithMaxBatchWriteSize(int maxBatchWriteSize)
     {
         if (maxBatchWriteSize is <= 0 or > DynamoPartiQlBatchLimit)
             throw new InvalidOperationException(
@@ -154,7 +152,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets whether DynamoDB should return consumed capacity in responses.</summary>
-    public virtual DynamoDbOptionsExtension WithReturnConsumedCapacity(
+    public DynamoDbOptionsExtension WithReturnConsumedCapacity(
         ReturnConsumedCapacity? returnConsumedCapacity)
     {
         var clone = Clone();
@@ -165,7 +163,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Sets whether DynamoDB should use strongly consistent reads by default.</summary>
-    public virtual DynamoDbOptionsExtension WithConsistentRead(bool consistentRead)
+    public DynamoDbOptionsExtension WithConsistentRead(bool consistentRead)
     {
         var clone = Clone();
 
@@ -175,7 +173,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Configures DynamoDB table lifecycle waits.</summary>
-    public virtual DynamoDbOptionsExtension WithTableLifecycleOptions(
+    public DynamoDbOptionsExtension WithTableLifecycleOptions(
         Action<DynamoTableLifecycleOptions> configure)
     {
         var options = TableLifecycleOptions.Clone();
@@ -189,7 +187,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>Creates a copy of this extension with the current option values.</summary>
-    protected virtual DynamoDbOptionsExtension Clone()
+    private DynamoDbOptionsExtension Clone()
         => new()
         {
             DynamoDbClient = DynamoDbClient,
@@ -205,7 +203,7 @@ public class DynamoDbOptionsExtension : IDbContextOptionsExtension
         };
 
     /// <summary>Represents the DynamoOptionsExtensionInfo type.</summary>
-    public class DynamoOptionsExtensionInfo(IDbContextOptionsExtension extension)
+    public sealed class DynamoOptionsExtensionInfo(IDbContextOptionsExtension extension)
         : DbContextOptionsExtensionInfo(extension)
     {
         private int? _serviceProviderHash;

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.DynamoDb.Metadata.Builders;
 public class DynamoSecondaryIndexBuilder(IndexBuilder indexBuilder)
 {
     /// <summary>Gets the underlying EF index builder used to configure this secondary index.</summary>
-    public IndexBuilder IndexBuilder { get; } = indexBuilder;
+    public virtual IndexBuilder IndexBuilder { get; } = indexBuilder;
 }
 
 /// <summary>
@@ -17,5 +17,5 @@ public class DynamoSecondaryIndexBuilder<TEntity>(IndexBuilder<TEntity> indexBui
     : DynamoSecondaryIndexBuilder(indexBuilder) where TEntity : class
 {
     /// <summary>Gets the underlying typed EF index builder used to configure this secondary index.</summary>
-    public new IndexBuilder<TEntity> IndexBuilder { get; } = indexBuilder;
+    public new virtual IndexBuilder<TEntity> IndexBuilder { get; } = indexBuilder;
 }

--- a/src/EntityFrameworkCore.DynamoDb/Query/DynamoQueryCompilationContext.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/DynamoQueryCompilationContext.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query;
 
 /// <summary>Represents the DynamoQueryCompilationContext type.</summary>
-public class DynamoQueryCompilationContext(
+public sealed class DynamoQueryCompilationContext(
     QueryCompilationContextDependencies dependencies,
     bool async) : QueryCompilationContext(dependencies, async)
 {

--- a/src/EntityFrameworkCore.DynamoDb/Query/DynamoQueryCompilationContextFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/DynamoQueryCompilationContextFactory.cs
@@ -3,7 +3,8 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query;
 
 /// <summary>Represents the DynamoQueryCompilationContextFactory type.</summary>
-public class DynamoQueryCompilationContextFactory(QueryCompilationContextDependencies dependencies)
+public sealed class DynamoQueryCompilationContextFactory(
+    QueryCompilationContextDependencies dependencies)
     : IQueryCompilationContextFactory
 {
     /// <summary>Provides functionality for this member.</summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoInjectingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoInjectingExpressionVisitor.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using System.Reflection;
-using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
@@ -11,7 +10,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 ///     with parameter access expressions. Similar to JObjectInjectingExpressionVisitor (Cosmos)
 ///     and BsonDocumentInjectingExpressionVisitor (MongoDB).
 /// </summary>
-public class DynamoInjectingExpressionVisitor : ExpressionVisitor
+public sealed class DynamoInjectingExpressionVisitor : ExpressionVisitor
 {
     private static readonly MethodInfo GetParameterValueMethodInfo =
         typeof(DynamoInjectingExpressionVisitor)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingExpressionVisitor.cs
@@ -13,7 +13,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 ///     Translates Select lambda bodies into projection mappings (ProjectionMember →
 ///     SqlExpression). Supports anonymous types, DTOs, and scalar projections.
 /// </summary>
-public class DynamoProjectionBindingExpressionVisitor(
+public sealed class DynamoProjectionBindingExpressionVisitor(
     DynamoSqlTranslatingExpressionVisitor sqlTranslator,
     ISqlExpressionFactory sqlExpressionFactory,
     IModel model) : ExpressionVisitor

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -30,7 +30,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 ///     <see cref="DynamoComplexCollectionInitializationExpression" /> markers emitted by
 ///     <see cref="DynamoShapedQueryCompilingExpressionVisitor.AddStructuralTypeInitialization" />.
 /// </remarks>
-public class DynamoProjectionBindingRemovingExpressionVisitor(
+public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
     ParameterExpression itemParameter,
     SelectExpression selectExpression) : ExpressionVisitor
 {

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContext.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContext.cs
@@ -7,23 +7,23 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
 /// <summary>Represents the DynamoQueryContext type.</summary>
-public class DynamoQueryContext(
+public sealed class DynamoQueryContext(
     QueryContextDependencies dependencies,
     IDynamoClientWrapper client,
     IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
     IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger) : QueryContext(dependencies)
 {
     /// <summary>Provides functionality for this member.</summary>
-    public virtual IDynamoClientWrapper Client { get; } = client;
+    public IDynamoClientWrapper Client { get; } = client;
 
     /// <summary>Provides functionality for this member.</summary>
-    public virtual IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandDiagnosticsLogger
+    public IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandDiagnosticsLogger
     {
         get;
     } = commandLogger;
 
     /// <summary>Provides functionality for this member.</summary>
-    public virtual IDiagnosticsLogger<DbLoggerCategory.Query> QueryDiagnosticsLogger { get; } =
+    public IDiagnosticsLogger<DbLoggerCategory.Query> QueryDiagnosticsLogger { get; } =
         queryLogger;
 
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContextFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryContextFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
 /// <summary>Represents the DynamoQueryContextFactory type.</summary>
-public class DynamoQueryContextFactory(
+public sealed class DynamoQueryContextFactory(
     QueryContextDependencies dependencies,
     IDynamoClientWrapper client,
     IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
@@ -11,7 +11,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// <summary>
 /// Generates PartiQL SQL from a SelectExpression query model.
 /// </summary>
-public class DynamoQuerySqlGenerator : SqlExpressionVisitor
+public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
 {
     private readonly StringBuilder _sql = new();
     private readonly List<AttributeValue> _parameters = [];
@@ -101,7 +101,7 @@ public class DynamoQuerySqlGenerator : SqlExpressionVisitor
     /// <summary>
     /// Visits an ordering expression.
     /// </summary>
-    protected virtual void VisitOrdering(OrderingExpression orderingExpression)
+    private void VisitOrdering(OrderingExpression orderingExpression)
     {
         Visit(orderingExpression.Expression);
         _sql.Append(orderingExpression.IsAscending ? " ASC" : " DESC");
@@ -322,7 +322,7 @@ public class DynamoQuerySqlGenerator : SqlExpressionVisitor
     /// Gets the precedence and associativity for an operator expression.
     /// Based on standard SQL operator precedence.
     /// </summary>
-    protected virtual bool TryGetOperatorInfo(
+    private bool TryGetOperatorInfo(
         SqlExpression expression,
         out int precedence,
         out bool isAssociative)
@@ -354,9 +354,7 @@ public class DynamoQuerySqlGenerator : SqlExpressionVisitor
     /// <summary>
     /// Determines if an inner expression needs parentheses when nested inside an outer expression.
     /// </summary>
-    protected virtual bool RequiresParentheses(
-        SqlExpression outerExpression,
-        SqlExpression innerExpression)
+    private bool RequiresParentheses(SqlExpression outerExpression, SqlExpression innerExpression)
     {
         // Non-binary expressions never need parentheses
         if (innerExpression is not SqlBinaryExpression)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGeneratorFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGeneratorFactory.cs
@@ -1,8 +1,8 @@
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
 /// <summary>Creates <c>DynamoQuerySqlGenerator</c> instances for individual query executions.</summary>
-public class DynamoQuerySqlGeneratorFactory : IDynamoQuerySqlGeneratorFactory
+public sealed class DynamoQuerySqlGeneratorFactory : IDynamoQuerySqlGeneratorFactory
 {
     /// <inheritdoc />
-    public virtual DynamoQuerySqlGenerator Create() => new();
+    public DynamoQuerySqlGenerator Create() => new();
 }

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQueryableMethodTranslatingExpressionVisitor.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
 /// <summary>Represents the DynamoQueryableMethodTranslatingExpressionVisitor type.</summary>
-public class DynamoQueryableMethodTranslatingExpressionVisitor
+public sealed class DynamoQueryableMethodTranslatingExpressionVisitor
     : QueryableMethodTranslatingExpressionVisitor
 {
     private readonly bool _subquery;

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitorFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
 /// <summary>Represents the DynamoShapedQueryCompilingExpressionVisitorFactory type.</summary>
-public class DynamoShapedQueryCompilingExpressionVisitorFactory(
+public sealed class DynamoShapedQueryCompilingExpressionVisitorFactory(
     ShapedQueryCompilingExpressionVisitorDependencies dependencies,
     IDynamoQuerySqlGeneratorFactory sqlGeneratorFactory)
     : IShapedQueryCompilingExpressionVisitorFactory

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -12,7 +12,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// <summary>
 /// Translates C# expression trees to SQL expression trees.
 /// </summary>
-public class DynamoSqlTranslatingExpressionVisitor(
+public sealed class DynamoSqlTranslatingExpressionVisitor(
     ISqlExpressionFactory sqlExpressionFactory,
     DynamoQueryCompilationContext? queryCompilationContext = null) : ExpressionVisitor
 {
@@ -107,7 +107,7 @@ public class DynamoSqlTranslatingExpressionVisitor(
         => Visit(expression) as SqlExpression;
 
     /// <summary>Adds a translation error detail message for the current translation attempt.</summary>
-    protected virtual void AddTranslationErrorDetails(string details)
+    private void AddTranslationErrorDetails(string details)
         => TranslationErrorDetails =
             TranslationErrorDetails == null
                 ? details

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/ExpressionPrinter.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/ExpressionPrinter.cs
@@ -7,7 +7,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// <summary>
 /// Helper class for printing expression trees for debugging.
 /// </summary>
-public class ExpressionPrinter : ExpressionVisitor
+public sealed class ExpressionPrinter : ExpressionVisitor
 {
     private readonly StringBuilder _builder = new();
     private int _indent;

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoEntityProjectionExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoEntityProjectionExpression.cs
@@ -10,7 +10,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 ///     Represents an entity projection expression that lazily binds properties on-demand.
 ///     This ensures a single source of truth for entity-to-SQL property mapping.
 /// </summary>
-public class DynamoEntityProjectionExpression : SqlExpression
+public sealed class DynamoEntityProjectionExpression : SqlExpression
 {
     private readonly Dictionary<IProperty, SqlExpression> _propertyExpressionsMap = new();
     private readonly ISqlExpressionFactory _sqlExpressionFactory;

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/OrderingExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/OrderingExpression.cs
@@ -3,7 +3,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents an ORDER BY clause component.
 /// </summary>
-public class OrderingExpression(SqlExpression expression, bool isAscending)
+public sealed class OrderingExpression(SqlExpression expression, bool isAscending)
 {
     /// <summary>
     /// The expression to order by.

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/ProjectionExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/ProjectionExpression.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents a single projected column in a SELECT statement.
 /// </summary>
-public class ProjectionExpression(SqlExpression expression, string alias) : Expression
+public sealed class ProjectionExpression(SqlExpression expression, string alias) : Expression
 {
     /// <summary>
     /// The SQL expression being projected.

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SelectExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SelectExpression.cs
@@ -7,7 +7,8 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 
 /// <summary>Represents a SELECT query expression for DynamoDB PartiQL.</summary>
-public class SelectExpression(string tableName, string? queryEntityTypeName = null) : Expression
+public sealed class
+    SelectExpression(string tableName, string? queryEntityTypeName = null) : Expression
 {
     private readonly List<OrderingExpression> _orderings = [];
     private readonly List<ProjectionExpression> _projection = [];

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlBinaryExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlBinaryExpression.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents a binary operation in a SQL expression.
 /// </summary>
-public class SqlBinaryExpression(
+public sealed class SqlBinaryExpression(
     ExpressionType operatorType,
     SqlExpression left,
     SqlExpression right,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlConstantExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlConstantExpression.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents a constant value in a SQL expression.
 /// </summary>
-public class SqlConstantExpression(object? value, Type type, CoreTypeMapping? typeMapping)
+public sealed class SqlConstantExpression(object? value, Type type, CoreTypeMapping? typeMapping)
     : SqlExpression(type, typeMapping)
 {
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlFunctionExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlFunctionExpression.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 
 /// <summary>Represents a function invocation in a SQL expression.</summary>
-public class SqlFunctionExpression(
+public sealed class SqlFunctionExpression(
     string name,
     IReadOnlyList<SqlExpression> arguments,
     Type type,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlInExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlInExpression.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 
 /// <summary>Represents an IN predicate in a SQL expression.</summary>
-public class SqlInExpression(
+public sealed class SqlInExpression(
     SqlExpression item,
     IReadOnlyList<SqlExpression>? values,
     SqlParameterExpression? valuesParameter,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlParameterExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlParameterExpression.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents a parameter in a SQL expression that will be substituted at execution time.
 /// </summary>
-public class SqlParameterExpression(string name, Type type, CoreTypeMapping? typeMapping)
+public sealed class SqlParameterExpression(string name, Type type, CoreTypeMapping? typeMapping)
     : SqlExpression(type, typeMapping)
 {
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlPropertyExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/SqlPropertyExpression.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
 /// <summary>
 /// Represents a property access in a SQL expression (e.g., Item.Name).
 /// </summary>
-public class SqlPropertyExpression(
+public sealed class SqlPropertyExpression(
     string propertyName,
     Type type,
     CoreTypeMapping? typeMapping,

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -7,7 +7,8 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// <summary>
 /// Factory for creating SQL expressions with proper type mappings.
 /// </summary>
-public class SqlExpressionFactory(ITypeMappingSource typeMappingSource) : ISqlExpressionFactory
+public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
+    : ISqlExpressionFactory
 {
     /// <inheritdoc />
     public SqlBinaryExpression Binary(


### PR DESCRIPTION
## Summary

Seals internal provider classes where inheritance is not intended and removes redundant `virtual` modifiers. This keeps extensibility surface tighter while preserving existing behavior.

## Changes

- Marked applicable provider, query, and expression classes as `sealed`.
- Removed `virtual` from members that no longer need overriding.
- Added missing configuration-source helpers for Dynamo property annotations needed by the refactor.

## Validation

- Cherry-picked onto latest `origin/main`.
- Resolved `DynamoPropertyExtensions.cs` conflict during branch split.
- No build or test run performed.