### PR TITLE
feat(dynamodb): add secondary index builder fluent APIs

### DIFF
--- a/docs/modeling/secondary-indexes.md
+++ b/docs/modeling/secondary-indexes.md
@@ -116,9 +116,8 @@ The default when calling `HasGlobalSecondaryIndex` or `HasLocalSecondaryIndex` i
 You can override projection type after index creation:
 
 ```csharp
-var byStatus = entity.HasGlobalSecondaryIndex("ByStatus", x => x.Status, x => x.CreatedAt);
-byStatus.IndexBuilder.Metadata.SetSecondaryIndexProjectionType(
-    DynamoSecondaryIndexProjectionType.KeysOnly);
+entity.HasGlobalSecondaryIndex("ByStatus", x => x.Status, x => x.CreatedAt)
+    .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.KeysOnly);
 ```
 
 !!! warning "Non-All projection indexes cannot materialize full entities"

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoEntityTypeBuilderExtensions.cs
@@ -78,10 +78,10 @@ public static class DynamoEntityTypeBuilderExtensions
             partitionKeyPropertyName.NotEmpty();
 
             var indexBuilder = entityTypeBuilder.HasIndex([partitionKeyPropertyName], name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Global);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder(indexBuilder);
         }
@@ -99,10 +99,10 @@ public static class DynamoEntityTypeBuilderExtensions
 
             var indexBuilder =
                 entityTypeBuilder.HasIndex([partitionKeyPropertyName, sortKeyPropertyName], name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Global);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder(indexBuilder);
         }
@@ -117,10 +117,10 @@ public static class DynamoEntityTypeBuilderExtensions
             sortKeyPropertyName.NotEmpty();
 
             var indexBuilder = entityTypeBuilder.HasIndex([sortKeyPropertyName], name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Local);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Local)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder(indexBuilder);
         }
@@ -244,10 +244,10 @@ public static class DynamoEntityTypeBuilderExtensions
 
             var partitionKeyPropertyName = GetPropertyName(partitionKeyExpression);
             var indexBuilder = entityTypeBuilder.HasIndex([partitionKeyPropertyName], name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Global);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder<TEntity>(indexBuilder);
         }
@@ -266,10 +266,10 @@ public static class DynamoEntityTypeBuilderExtensions
             var indexBuilder = entityTypeBuilder.HasIndex(
                 [partitionKeyPropertyName, sortKeyPropertyName],
                 name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Global);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder<TEntity>(indexBuilder);
         }
@@ -284,10 +284,10 @@ public static class DynamoEntityTypeBuilderExtensions
 
             var sortKeyPropertyName = GetPropertyName(sortKeyExpression);
             var indexBuilder = entityTypeBuilder.HasIndex([sortKeyPropertyName], name);
-            indexBuilder.Metadata.SetSecondaryIndexName(name);
-            indexBuilder.Metadata.SetSecondaryIndexKind(DynamoSecondaryIndexKind.Local);
-            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
-                DynamoSecondaryIndexProjectionType.All);
+            indexBuilder
+                .HasSecondaryIndexName(name)
+                .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Local)
+                .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
 
             return new DynamoSecondaryIndexBuilder<TEntity>(indexBuilder);
         }

--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoIndexBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoIndexBuilderExtensions.cs
@@ -1,0 +1,186 @@
+using EntityFrameworkCore.DynamoDb.Metadata;
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using EntityFrameworkCore.DynamoDb.Utilities;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+// ReSharper disable CheckNamespace
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>Provides DynamoDB-specific fluent configuration for EF index builders.</summary>
+public static class DynamoIndexBuilderExtensions
+{
+    extension(IndexBuilder indexBuilder)
+    {
+        /// <summary>Configures the DynamoDB secondary index name used for PartiQL index targeting.</summary>
+        /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder HasSecondaryIndexName(string? name)
+        {
+            indexBuilder.Metadata.SetSecondaryIndexName(name);
+            return indexBuilder;
+        }
+
+        /// <summary>Configures whether this EF index maps to a global or local DynamoDB secondary index.</summary>
+        /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder HasSecondaryIndexKind(DynamoSecondaryIndexKind? kind)
+        {
+            indexBuilder.Metadata.SetSecondaryIndexKind(kind);
+            return indexBuilder;
+        }
+
+        /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+        /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder HasSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType? projectionType)
+        {
+            indexBuilder.Metadata.SetSecondaryIndexProjectionType(projectionType);
+            return indexBuilder;
+        }
+    }
+
+    extension<TEntity>(IndexBuilder<TEntity> indexBuilder) where TEntity : class
+    {
+        /// <summary>Configures the DynamoDB secondary index name used for PartiQL index targeting.</summary>
+        /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder<TEntity> HasSecondaryIndexName(string? name)
+            => (IndexBuilder<TEntity>)((IndexBuilder)indexBuilder).HasSecondaryIndexName(name);
+
+        /// <summary>Configures whether this EF index maps to a global or local DynamoDB secondary index.</summary>
+        /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder<TEntity> HasSecondaryIndexKind(DynamoSecondaryIndexKind? kind)
+            => (IndexBuilder<TEntity>)((IndexBuilder)indexBuilder).HasSecondaryIndexKind(kind);
+
+        /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+        /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public IndexBuilder<TEntity> HasSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType? projectionType)
+            => (IndexBuilder<TEntity>)((IndexBuilder)indexBuilder).HasSecondaryIndexProjectionType(
+                projectionType);
+    }
+
+    extension(IConventionIndexBuilder indexBuilder)
+    {
+        /// <summary>Configures the DynamoDB secondary index name, respecting configuration source precedence.</summary>
+        /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>The same builder instance if the name was set; otherwise <see langword="null" />.</returns>
+        public IConventionIndexBuilder? HasSecondaryIndexName(
+            string? name,
+            bool fromDataAnnotation = false)
+        {
+            name = name.NullButNotEmpty();
+            if (!indexBuilder.CanSetSecondaryIndexName(name, fromDataAnnotation))
+                return null;
+
+            indexBuilder.Metadata.SetSecondaryIndexName(name, fromDataAnnotation);
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Returns whether the DynamoDB secondary index name can be set from the given configuration
+        ///     source.
+        /// </summary>
+        /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns><see langword="true" /> if the name can be set; otherwise <see langword="false" />.</returns>
+        public bool CanSetSecondaryIndexName(string? name, bool fromDataAnnotation = false)
+            => indexBuilder.CanSetAnnotation(
+                DynamoAnnotationNames.SecondaryIndexName,
+                name.NullButNotEmpty(),
+                fromDataAnnotation);
+
+        /// <summary>Configures whether this EF index maps to a global or local DynamoDB secondary index.</summary>
+        /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>The same builder instance if the kind was set; otherwise <see langword="null" />.</returns>
+        public IConventionIndexBuilder? HasSecondaryIndexKind(
+            DynamoSecondaryIndexKind? kind,
+            bool fromDataAnnotation = false)
+        {
+            if (!indexBuilder.CanSetSecondaryIndexKind(kind, fromDataAnnotation))
+                return null;
+
+            indexBuilder.Metadata.SetSecondaryIndexKind(kind, fromDataAnnotation);
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Returns whether the DynamoDB secondary index kind can be set from the given configuration
+        ///     source.
+        /// </summary>
+        /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns><see langword="true" /> if the kind can be set; otherwise <see langword="false" />.</returns>
+        public bool CanSetSecondaryIndexKind(
+            DynamoSecondaryIndexKind? kind,
+            bool fromDataAnnotation = false)
+            => indexBuilder.CanSetAnnotation(
+                DynamoAnnotationNames.SecondaryIndexKind,
+                kind?.ToString(),
+                fromDataAnnotation);
+
+        /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+        /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>
+        ///     The same builder instance if the projection type was set; otherwise
+        ///     <see langword="null" />.
+        /// </returns>
+        public IConventionIndexBuilder? HasSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType? projectionType,
+            bool fromDataAnnotation = false)
+        {
+            if (!indexBuilder.CanSetSecondaryIndexProjectionType(
+                projectionType,
+                fromDataAnnotation))
+                return null;
+
+            indexBuilder.Metadata.SetSecondaryIndexProjectionType(
+                projectionType,
+                fromDataAnnotation);
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Returns whether the DynamoDB projection type can be set from the given configuration
+        ///     source.
+        /// </summary>
+        /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+        /// <param name="fromDataAnnotation">
+        ///     <see langword="true" /> if configured via a data annotation;
+        ///     <see langword="false" /> for the fluent API.
+        /// </param>
+        /// <returns>
+        ///     <see langword="true" /> if the projection type can be set; otherwise
+        ///     <see langword="false" />.
+        /// </returns>
+        public bool CanSetSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType? projectionType,
+            bool fromDataAnnotation = false)
+            => indexBuilder.CanSetAnnotation(
+                DynamoAnnotationNames.SecondaryIndexProjectionType,
+                projectionType?.ToString(),
+                fromDataAnnotation);
+    }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
@@ -30,12 +30,19 @@ public class DynamoSecondaryIndexBuilder(IndexBuilder indexBuilder)
     /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
     /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual DynamoSecondaryIndexBuilder HasProjectionType(
+    public virtual DynamoSecondaryIndexBuilder HasSecondaryIndexProjectionType(
         DynamoSecondaryIndexProjectionType? projectionType)
     {
         IndexBuilder.HasSecondaryIndexProjectionType(projectionType);
         return this;
     }
+
+    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DynamoSecondaryIndexBuilder HasProjectionType(
+        DynamoSecondaryIndexProjectionType? projectionType)
+        => HasSecondaryIndexProjectionType(projectionType);
 }
 
 /// <summary>
@@ -64,7 +71,15 @@ public class DynamoSecondaryIndexBuilder<TEntity>(IndexBuilder<TEntity> indexBui
     /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
     /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DynamoSecondaryIndexBuilder<TEntity> HasSecondaryIndexProjectionType(
+        DynamoSecondaryIndexProjectionType? projectionType)
+        => (DynamoSecondaryIndexBuilder<TEntity>)base.HasSecondaryIndexProjectionType(
+            projectionType);
+
+    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public new virtual DynamoSecondaryIndexBuilder<TEntity> HasProjectionType(
         DynamoSecondaryIndexProjectionType? projectionType)
-        => (DynamoSecondaryIndexBuilder<TEntity>)base.HasProjectionType(projectionType);
+        => HasSecondaryIndexProjectionType(projectionType);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace EntityFrameworkCore.DynamoDb.Metadata.Builders;
@@ -6,7 +7,35 @@ namespace EntityFrameworkCore.DynamoDb.Metadata.Builders;
 public class DynamoSecondaryIndexBuilder(IndexBuilder indexBuilder)
 {
     /// <summary>Gets the underlying EF index builder used to configure this secondary index.</summary>
-    public IndexBuilder IndexBuilder { get; } = indexBuilder;
+    public virtual IndexBuilder IndexBuilder { get; } = indexBuilder;
+
+    /// <summary>Configures the DynamoDB secondary index name used for PartiQL index targeting.</summary>
+    /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DynamoSecondaryIndexBuilder HasSecondaryIndexName(string? name)
+    {
+        IndexBuilder.HasSecondaryIndexName(name);
+        return this;
+    }
+
+    /// <summary>Configures whether this EF index maps to a global or local DynamoDB secondary index.</summary>
+    /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DynamoSecondaryIndexBuilder HasSecondaryIndexKind(DynamoSecondaryIndexKind? kind)
+    {
+        IndexBuilder.HasSecondaryIndexKind(kind);
+        return this;
+    }
+
+    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DynamoSecondaryIndexBuilder HasProjectionType(
+        DynamoSecondaryIndexProjectionType? projectionType)
+    {
+        IndexBuilder.HasSecondaryIndexProjectionType(projectionType);
+        return this;
+    }
 }
 
 /// <summary>
@@ -17,5 +46,25 @@ public class DynamoSecondaryIndexBuilder<TEntity>(IndexBuilder<TEntity> indexBui
     : DynamoSecondaryIndexBuilder(indexBuilder) where TEntity : class
 {
     /// <summary>Gets the underlying typed EF index builder used to configure this secondary index.</summary>
-    public new IndexBuilder<TEntity> IndexBuilder { get; } = indexBuilder;
+    public new virtual IndexBuilder<TEntity> IndexBuilder { get; } = indexBuilder;
+
+    /// <summary>Configures the DynamoDB secondary index name used for PartiQL index targeting.</summary>
+    /// <param name="name">The DynamoDB secondary index name, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DynamoSecondaryIndexBuilder<TEntity> HasSecondaryIndexName(string? name)
+        => (DynamoSecondaryIndexBuilder<TEntity>)base.HasSecondaryIndexName(name);
+
+    /// <summary>Configures whether this EF index maps to a global or local DynamoDB secondary index.</summary>
+    /// <param name="kind">The secondary index kind, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DynamoSecondaryIndexBuilder<TEntity> HasSecondaryIndexKind(
+        DynamoSecondaryIndexKind? kind)
+        => (DynamoSecondaryIndexBuilder<TEntity>)base.HasSecondaryIndexKind(kind);
+
+    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
+    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DynamoSecondaryIndexBuilder<TEntity> HasProjectionType(
+        DynamoSecondaryIndexProjectionType? projectionType)
+        => (DynamoSecondaryIndexBuilder<TEntity>)base.HasProjectionType(projectionType);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Builders/DynamoSecondaryIndexBuilder.cs
@@ -36,13 +36,6 @@ public class DynamoSecondaryIndexBuilder(IndexBuilder indexBuilder)
         IndexBuilder.HasSecondaryIndexProjectionType(projectionType);
         return this;
     }
-
-    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
-    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual DynamoSecondaryIndexBuilder HasProjectionType(
-        DynamoSecondaryIndexProjectionType? projectionType)
-        => HasSecondaryIndexProjectionType(projectionType);
 }
 
 /// <summary>
@@ -75,11 +68,4 @@ public class DynamoSecondaryIndexBuilder<TEntity>(IndexBuilder<TEntity> indexBui
         DynamoSecondaryIndexProjectionType? projectionType)
         => (DynamoSecondaryIndexBuilder<TEntity>)base.HasSecondaryIndexProjectionType(
             projectionType);
-
-    /// <summary>Configures the DynamoDB projection type for this secondary index.</summary>
-    /// <param name="projectionType">The projection type, or <see langword="null" /> to clear it.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public new virtual DynamoSecondaryIndexBuilder<TEntity> HasProjectionType(
-        DynamoSecondaryIndexProjectionType? projectionType)
-        => HasSecondaryIndexProjectionType(projectionType);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexBuilderExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexBuilderExtensionsTests.cs
@@ -1,0 +1,102 @@
+using EntityFrameworkCore.DynamoDb.Metadata;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Metadata;
+
+/// <summary>Represents the SecondaryIndexBuilderExtensionsTests type.</summary>
+public class SecondaryIndexBuilderExtensionsTests
+{
+    /// <summary>Verifies that untyped index builder APIs configure DynamoDB secondary index annotations.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void IndexBuilder_ConfiguresSecondaryIndexMetadata()
+    {
+        var modelBuilder = new ModelBuilder();
+        var indexBuilder = modelBuilder
+            .Entity<Order>()
+            .HasIndex([nameof(Order.CustomerId)], "ByCustomer");
+
+        var returned = indexBuilder
+            .HasSecondaryIndexName("ByCustomerIndex")
+            .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+            .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.KeysOnly);
+
+        returned.Should().BeSameAs(indexBuilder);
+        indexBuilder.Metadata.GetSecondaryIndexName().Should().Be("ByCustomerIndex");
+        indexBuilder.Metadata.GetSecondaryIndexKind().Should().Be(DynamoSecondaryIndexKind.Global);
+        indexBuilder
+            .Metadata
+            .GetSecondaryIndexProjectionType()
+            .Should()
+            .Be(DynamoSecondaryIndexProjectionType.KeysOnly);
+    }
+
+    /// <summary>Verifies that typed index builder APIs configure DynamoDB secondary index annotations.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void TypedIndexBuilder_ConfiguresSecondaryIndexMetadata()
+    {
+        var modelBuilder = new ModelBuilder();
+        var indexBuilder = modelBuilder.Entity<Order>().HasIndex(x => x.CustomerId);
+
+        var returned = indexBuilder
+            .HasSecondaryIndexName("ByCustomer")
+            .HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global)
+            .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.All);
+
+        returned.Should().BeSameAs(indexBuilder);
+        indexBuilder.Metadata.GetSecondaryIndexName().Should().Be("ByCustomer");
+        indexBuilder.Metadata.GetSecondaryIndexKind().Should().Be(DynamoSecondaryIndexKind.Global);
+        indexBuilder
+            .Metadata
+            .GetSecondaryIndexProjectionType()
+            .Should()
+            .Be(DynamoSecondaryIndexProjectionType.All);
+    }
+
+    /// <summary>Verifies that secondary index builder APIs configure projection metadata fluently.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void SecondaryIndexBuilder_ConfiguresProjectionMetadata()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<ProjectionContext>();
+        optionsBuilder.UseDynamo();
+
+        using var context = new ProjectionContext(optionsBuilder.Options);
+
+        var index =
+            context.Model.FindEntityType(typeof(Order))!
+                .GetIndexes()
+                .Single(x => x.Name == "ByCustomer");
+
+        index
+            .GetSecondaryIndexProjectionType()
+            .Should()
+            .Be(DynamoSecondaryIndexProjectionType.KeysOnly);
+    }
+
+    private sealed class ProjectionContext(DbContextOptions<ProjectionContext> options) : DbContext(
+        options)
+    {
+        /// <summary>Configures the test model.</summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Order>(entity =>
+            {
+                entity.HasPartitionKey(x => x.TenantId);
+                entity.HasSortKey(x => x.OrderId);
+                entity
+                    .HasGlobalSecondaryIndex("ByCustomer", x => x.CustomerId)
+                    .HasProjectionType(DynamoSecondaryIndexProjectionType.KeysOnly);
+            });
+    }
+
+    private sealed class Order
+    {
+        /// <summary>Gets or sets the tenant ID.</summary>
+        public string TenantId { get; set; } = null!;
+
+        /// <summary>Gets or sets the order ID.</summary>
+        public string OrderId { get; set; } = null!;
+
+        /// <summary>Gets or sets the customer ID.</summary>
+        public string CustomerId { get; set; } = null!;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexBuilderExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/SecondaryIndexBuilderExtensionsTests.cs
@@ -1,9 +1,10 @@
 using EntityFrameworkCore.DynamoDb.Metadata;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace EntityFrameworkCore.DynamoDb.Tests.Metadata;
 
-/// <summary>Represents the SecondaryIndexBuilderExtensionsTests type.</summary>
 public class SecondaryIndexBuilderExtensionsTests
 {
     /// <summary>Verifies that untyped index builder APIs configure DynamoDB secondary index annotations.</summary>
@@ -35,7 +36,7 @@ public class SecondaryIndexBuilderExtensionsTests
     public void TypedIndexBuilder_ConfiguresSecondaryIndexMetadata()
     {
         var modelBuilder = new ModelBuilder();
-        var indexBuilder = modelBuilder.Entity<Order>().HasIndex(x => x.CustomerId);
+        var indexBuilder = modelBuilder.Entity<Order>().HasIndex(x => x.CustomerId, "ByCustomer");
 
         var returned = indexBuilder
             .HasSecondaryIndexName("ByCustomer")
@@ -57,7 +58,9 @@ public class SecondaryIndexBuilderExtensionsTests
     public void SecondaryIndexBuilder_ConfiguresProjectionMetadata()
     {
         var optionsBuilder = new DbContextOptionsBuilder<ProjectionContext>();
-        optionsBuilder.UseDynamo();
+        optionsBuilder
+            .UseDynamo()
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         using var context = new ProjectionContext(optionsBuilder.Options);
 
@@ -67,6 +70,83 @@ public class SecondaryIndexBuilderExtensionsTests
                 .Single(x => x.Name == "ByCustomer");
 
         index
+            .GetSecondaryIndexProjectionType()
+            .Should()
+            .Be(DynamoSecondaryIndexProjectionType.KeysOnly);
+    }
+
+    /// <summary>
+    ///     Verifies that <c>HasSecondaryIndexName</c> on <see cref="IConventionIndexBuilder" />
+    ///     returns <see langword="null" /> when a higher-precedence (data annotation) value is already
+    ///     set.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void
+        ConventionIndexBuilder_HasSecondaryIndexName_ReturnsNullWhenPrecededByDataAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var indexBuilder = modelBuilder
+            .Entity<Order>()
+            .HasIndex([nameof(Order.CustomerId)], "ByCustomer");
+        var conventionBuilder = indexBuilder.GetInfrastructure();
+
+        conventionBuilder.HasSecondaryIndexName("AnnotationName", true);
+
+        var result = conventionBuilder.HasSecondaryIndexName("FluentName", false);
+
+        result.Should().BeNull();
+        indexBuilder.Metadata.GetSecondaryIndexName().Should().Be("AnnotationName");
+    }
+
+    /// <summary>
+    ///     Verifies that <c>HasSecondaryIndexKind</c> on <see cref="IConventionIndexBuilder" />
+    ///     returns <see langword="null" /> when a higher-precedence (data annotation) value is already
+    ///     set.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void
+        ConventionIndexBuilder_HasSecondaryIndexKind_ReturnsNullWhenPrecededByDataAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var indexBuilder = modelBuilder
+            .Entity<Order>()
+            .HasIndex([nameof(Order.CustomerId)], "ByCustomer");
+        var conventionBuilder = indexBuilder.GetInfrastructure();
+
+        conventionBuilder.HasSecondaryIndexKind(DynamoSecondaryIndexKind.Global, true);
+
+        var result = conventionBuilder.HasSecondaryIndexKind(DynamoSecondaryIndexKind.Local, false);
+
+        result.Should().BeNull();
+        indexBuilder.Metadata.GetSecondaryIndexKind().Should().Be(DynamoSecondaryIndexKind.Global);
+    }
+
+    /// <summary>
+    ///     Verifies that <c>HasSecondaryIndexProjectionType</c> on
+    ///     <see cref="IConventionIndexBuilder" /> returns <see langword="null" /> when a higher-precedence
+    ///     (data annotation) value is already set.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void
+        ConventionIndexBuilder_HasSecondaryIndexProjectionType_ReturnsNullWhenPrecededByDataAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var indexBuilder = modelBuilder
+            .Entity<Order>()
+            .HasIndex([nameof(Order.CustomerId)], "ByCustomer");
+        var conventionBuilder = indexBuilder.GetInfrastructure();
+
+        conventionBuilder.HasSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType.KeysOnly,
+            true);
+
+        var result = conventionBuilder.HasSecondaryIndexProjectionType(
+            DynamoSecondaryIndexProjectionType.All,
+            false);
+
+        result.Should().BeNull();
+        indexBuilder
+            .Metadata
             .GetSecondaryIndexProjectionType()
             .Should()
             .Be(DynamoSecondaryIndexProjectionType.KeysOnly);
@@ -84,7 +164,7 @@ public class SecondaryIndexBuilderExtensionsTests
                 entity.HasSortKey(x => x.OrderId);
                 entity
                     .HasGlobalSecondaryIndex("ByCustomer", x => x.CustomerId)
-                    .HasProjectionType(DynamoSecondaryIndexProjectionType.KeysOnly);
+                    .HasSecondaryIndexProjectionType(DynamoSecondaryIndexProjectionType.KeysOnly);
             });
     }
 


### PR DESCRIPTION
## Summary

Adds DynamoDB-specific fluent APIs for configuring EF index builders and secondary index builders. This lets callers set secondary index name, kind, and projection metadata directly on `IndexBuilder`/`IndexBuilder<TEntity>` or through `DynamoSecondaryIndexBuilder`, including a shorter `HasProjectionType(...)` alias.

## Changes

- Added `DynamoIndexBuilderExtensions` for untyped, typed, and convention index builders.
- Updated secondary index setup helpers to use the new fluent APIs when initializing GSI/LSI metadata.
- Extended `DynamoSecondaryIndexBuilder` with chainable metadata configuration methods.
- Added unit coverage for untyped/typed index builder metadata and projection configuration through secondary index builders.

## Validation

- `git diff --check origin/main...HEAD` passed.
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj --no-restore` failed: `SecondaryIndexBuilderExtensionsTests.SecondaryIndexBuilder_ConfiguresProjectionMetadata` hit `ManyServiceProvidersCreatedWarning` after 528 passed / 2 skipped.

## Notes for Reviewers

Opened as draft because unit test validation currently fails on EF Core service provider warning. Review focus: public API shape and whether `HasProjectionType(...)` alias should stay alongside `HasSecondaryIndexProjectionType(...)`.
