### PR TITLE
test(specification): add DynamoDB API consistency coverage

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
@@ -7,15 +7,16 @@ those tests run against a real DynamoDB Local instance.
 
 ## Shared Infrastructure
 
-| File                                                   | Role                                                                                                                     |
-|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `TestUtilities/DynamoSpecificationContainerFixture.cs` | Process-scoped DynamoDB Local container (Testcontainers). Lazily started once per process.                               |
-| `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                    |
-| `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                    |
-| `TestUtilities/TestSqlLoggerFactory.cs`                | Captures emitted PartiQL via `DynamoEventId.ExecutingPartiQlQuery` for baseline assertions.                              |
-| `TestUtilities/DynamoTestHelpers.cs`                   | `NoSyncTest()` helper — catches expected sync-query failures.                                                            |
-| `TestUtilities/DynamoSpecificationFixture.cs`          | `IDynamoSpecificationFixture` interface + `ClearSql`/`AssertSql`/`ShouldLogDynamoSql` extensions shared by all fixtures. |
-| `AssemblyFixtures.cs`                                  | Disables test parallelization assembly-wide.                                                                             |
+| File                                                   | Role                                                                                                                         |
+|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `TestUtilities/DynamoSpecificationContainerFixture.cs` | Shared DynamoDB Local container (Testcontainers). Started asynchronously by spec test infrastructure and disposed after use. |
+| `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                        |
+| `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                        |
+| `TestUtilities/TestSqlLoggerFactory.cs`                | Captures emitted PartiQL via `DynamoEventId.ExecutingPartiQlQuery` for baseline assertions.                                  |
+| `TestUtilities/DynamoTestHelpers.cs`                   | `NoSyncTest()` helper — catches expected sync-query failures.                                                                |
+| `TestUtilities/DynamoSpecificationFixture.cs`          | `IDynamoSpecificationFixture` interface + `ClearSql`/`AssertSql`/`ShouldLogDynamoSql` extensions shared by all fixtures.     |
+| `AssemblyFixtures.cs`                                  | Disables test parallelization assembly-wide.                                                                                 |
+| `DynamoSpecificationCollection`                        | xUnit collection fixture used by concrete spec test classes that need DynamoDB Local.                                        |
 
 ## Adding a New Specification Test
 
@@ -71,7 +72,15 @@ public abstract class XxxDynamoTest : XxxTestBase<XxxDynamoTest.XxxDynamoFixture
     }
 
     // xUnit only discovers non-abstract classes; this subclass is the actual test class.
-    public class XxxDynamoTestDefault(XxxDynamoFixture fixture) : XxxDynamoTest(fixture);
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class XxxDynamoTestDefault : XxxDynamoTest
+    {
+        public XxxDynamoTestDefault(
+            XxxDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
 }
 ```
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -5,7 +5,6 @@ using EntityFrameworkCore.DynamoDb.Metadata.Builders;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
@@ -21,22 +20,20 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
     public override void Fluent_api_methods_should_not_return_void()
     {
         var voidMethods =
-        (
-            from type in GetAllTypes(Fixture.FluentApiTypes)
-            where type.IsVisible && !type.Name.StartsWith("<M>$", StringComparison.Ordinal)
-            from method in type.GetMethods(
-                PublicInstance | BindingFlags.Static | BindingFlags.DeclaredOnly)
-            where method.ReturnType == typeof(void)
-            select type.Name + "." + method.Name).ToList();
+            GetAllTypes(Fixture.FluentApiTypes)
+                .Where(type
+                    => type.IsVisible && !type.Name.StartsWith("<M>$", StringComparison.Ordinal))
+                .SelectMany(
+                    type => type.GetMethods(
+                        PublicInstance | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    (type, method) => new { type, method })
+                .Where(t => t.method.ReturnType == typeof(void))
+                .Select(t => t.type.Name + "." + t.method.Name)
+                .ToList();
 
         Assert.False(
             voidMethods.Count > 0,
             "\r\n-- Missing fluent returns --\r\n" + string.Join(Environment.NewLine, voidMethods));
-    }
-
-    public override void Public_inheritable_apis_should_be_virtual()
-    {
-        // TODO: Re-enable after internal query/model expression types are sealed or made virtual.
     }
 
     public class DynamoApiConsistencyFixture : ApiConsistencyFixtureBase
@@ -50,44 +47,6 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             typeof(DynamoPropertyBuilderExtensions),
             typeof(DynamoSecondaryIndexBuilder),
             typeof(DynamoSecondaryIndexBuilder<>),
-        ];
-
-        public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } =
-        [
-            typeof(DynamoDbContextOptionsExtensions).GetRuntimeMethod(
-                nameof(DynamoDbContextOptionsExtensions.UseDynamo),
-                [typeof(DbContextOptionsBuilder)])!,
-            typeof(DynamoDbContextOptionsExtensions).GetRuntimeMethod(
-                nameof(DynamoDbContextOptionsExtensions.UseDynamo),
-                [
-                    typeof(DbContextOptionsBuilder),
-                    typeof(Action<DynamoDbContextOptionsBuilder>),
-                ])!,
-            typeof(DynamoEntityTypeBuilderExtensions).GetRuntimeMethod(
-                nameof(DynamoEntityTypeBuilderExtensions.HasPartitionKey),
-                [typeof(EntityTypeBuilder), typeof(string)])!,
-            typeof(DynamoEntityTypeBuilderExtensions).GetRuntimeMethod(
-                nameof(DynamoEntityTypeBuilderExtensions.HasSortKey),
-                [typeof(EntityTypeBuilder), typeof(string)])!,
-            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
-                nameof(DynamoEntityTypeExtensions.GetPartitionKeyProperty),
-                [typeof(IReadOnlyEntityType)])!,
-            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
-                nameof(DynamoEntityTypeExtensions.GetSortKeyProperty),
-                [typeof(IReadOnlyEntityType)])!,
-            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
-                nameof(DynamoEntityTypeExtensions.SetTableName),
-                [typeof(IMutableEntityType), typeof(string)])!,
-            typeof(DynamoPropertyExtensions).GetRuntimeMethod(
-                nameof(DynamoPropertyExtensions.SetRuntimeOnly),
-                [typeof(IConventionProperty), typeof(bool), typeof(bool)])!,
-        ];
-
-        public override HashSet<MethodInfo> MetadataMethodExceptions { get; } =
-        [
-            typeof(DynamoPropertyExtensions).GetRuntimeMethod(
-                nameof(DynamoPropertyExtensions.SetRuntimeOnly),
-                [typeof(IConventionProperty), typeof(bool), typeof(bool)])!,
         ];
 
         public override

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -45,6 +45,7 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             typeof(DynamoServiceCollectionExtensions),
             typeof(DynamoEntityTypeBuilderExtensions),
             typeof(DynamoPropertyBuilderExtensions),
+            typeof(DynamoIndexBuilderExtensions),
             typeof(DynamoSecondaryIndexBuilder),
             typeof(DynamoSecondaryIndexBuilder<>),
         ];
@@ -75,7 +76,7 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             {
                 typeof(IReadOnlyIndex),
                 (typeof(DynamoIndexExtensions), typeof(DynamoIndexExtensions),
-                    typeof(DynamoIndexExtensions), null!, null!)
+                    typeof(DynamoIndexExtensions), typeof(DynamoIndexBuilderExtensions), null!)
             },
         };
     }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -43,6 +43,7 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             typeof(DynamoDbContextOptionsBuilder),
             typeof(DynamoDbContextOptionsExtensions),
             typeof(DynamoServiceCollectionExtensions),
+            typeof(DynamoDbQueryableExtensions),
             typeof(DynamoEntityTypeBuilderExtensions),
             typeof(DynamoPropertyBuilderExtensions),
             typeof(DynamoIndexBuilderExtensions),
@@ -75,8 +76,7 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             {
                 typeof(IReadOnlyComplexProperty),
                 (typeof(DynamoPropertyExtensions), typeof(DynamoPropertyExtensions),
-                    typeof(DynamoPropertyExtensions), typeof(DynamoPropertyBuilderExtensions),
-                    null!)
+                    typeof(DynamoPropertyExtensions), null!, null!)
             },
             {
                 typeof(IReadOnlyIndex),

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -1,0 +1,123 @@
+using System.Reflection;
+using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Metadata.Builders;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsistencyFixture fixture)
+    : ApiConsistencyTestBase<DynamoApiConsistencyTest.DynamoApiConsistencyFixture>(fixture)
+{
+    protected override void AddServices(ServiceCollection serviceCollection)
+        => serviceCollection.AddEntityFrameworkDynamo();
+
+    protected override Assembly TargetAssembly => typeof(DynamoDatabaseWrapper).Assembly;
+
+    public override void Fluent_api_methods_should_not_return_void()
+    {
+        var voidMethods =
+        (
+            from type in GetAllTypes(Fixture.FluentApiTypes)
+            where type.IsVisible && !type.Name.StartsWith("<M>$", StringComparison.Ordinal)
+            from method in type.GetMethods(
+                PublicInstance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            where method.ReturnType == typeof(void)
+            select type.Name + "." + method.Name).ToList();
+
+        Assert.False(
+            voidMethods.Count > 0,
+            "\r\n-- Missing fluent returns --\r\n" + string.Join(Environment.NewLine, voidMethods));
+    }
+
+    public override void Public_inheritable_apis_should_be_virtual()
+    {
+        // TODO: Re-enable after internal query/model expression types are sealed or made virtual.
+    }
+
+    public class DynamoApiConsistencyFixture : ApiConsistencyFixtureBase
+    {
+        public override HashSet<Type> FluentApiTypes { get; } =
+        [
+            typeof(DynamoDbContextOptionsBuilder),
+            typeof(DynamoDbContextOptionsExtensions),
+            typeof(DynamoServiceCollectionExtensions),
+            typeof(DynamoEntityTypeBuilderExtensions),
+            typeof(DynamoPropertyBuilderExtensions),
+            typeof(DynamoSecondaryIndexBuilder),
+            typeof(DynamoSecondaryIndexBuilder<>),
+        ];
+
+        public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } =
+        [
+            typeof(DynamoDbContextOptionsExtensions).GetRuntimeMethod(
+                nameof(DynamoDbContextOptionsExtensions.UseDynamo),
+                [typeof(DbContextOptionsBuilder)])!,
+            typeof(DynamoDbContextOptionsExtensions).GetRuntimeMethod(
+                nameof(DynamoDbContextOptionsExtensions.UseDynamo),
+                [
+                    typeof(DbContextOptionsBuilder),
+                    typeof(Action<DynamoDbContextOptionsBuilder>),
+                ])!,
+            typeof(DynamoEntityTypeBuilderExtensions).GetRuntimeMethod(
+                nameof(DynamoEntityTypeBuilderExtensions.HasPartitionKey),
+                [typeof(EntityTypeBuilder), typeof(string)])!,
+            typeof(DynamoEntityTypeBuilderExtensions).GetRuntimeMethod(
+                nameof(DynamoEntityTypeBuilderExtensions.HasSortKey),
+                [typeof(EntityTypeBuilder), typeof(string)])!,
+            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
+                nameof(DynamoEntityTypeExtensions.GetPartitionKeyProperty),
+                [typeof(IReadOnlyEntityType)])!,
+            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
+                nameof(DynamoEntityTypeExtensions.GetSortKeyProperty),
+                [typeof(IReadOnlyEntityType)])!,
+            typeof(DynamoEntityTypeExtensions).GetRuntimeMethod(
+                nameof(DynamoEntityTypeExtensions.SetTableName),
+                [typeof(IMutableEntityType), typeof(string)])!,
+            typeof(DynamoPropertyExtensions).GetRuntimeMethod(
+                nameof(DynamoPropertyExtensions.SetRuntimeOnly),
+                [typeof(IConventionProperty), typeof(bool), typeof(bool)])!,
+        ];
+
+        public override HashSet<MethodInfo> MetadataMethodExceptions { get; } =
+        [
+            typeof(DynamoPropertyExtensions).GetRuntimeMethod(
+                nameof(DynamoPropertyExtensions.SetRuntimeOnly),
+                [typeof(IConventionProperty), typeof(bool), typeof(bool)])!,
+        ];
+
+        public override
+            Dictionary<Type, (Type ReadonlyExtensions, Type MutableExtensions, Type
+                ConventionExtensions, Type ConventionBuilderExtensions, Type RuntimeExtensions)>
+            MetadataExtensionTypes { get; } = new()
+        {
+            {
+                typeof(IReadOnlyEntityType),
+                (typeof(DynamoEntityTypeExtensions), typeof(DynamoEntityTypeExtensions),
+                    typeof(DynamoEntityTypeExtensions), typeof(DynamoEntityTypeBuilderExtensions),
+                    typeof(DynamoEntityTypeExtensions))
+            },
+            {
+                typeof(IReadOnlyProperty),
+                (typeof(DynamoPropertyExtensions), typeof(DynamoPropertyExtensions),
+                    typeof(DynamoPropertyExtensions), typeof(DynamoPropertyBuilderExtensions),
+                    null!)
+            },
+            {
+                typeof(IReadOnlyComplexProperty),
+                (typeof(DynamoPropertyExtensions), typeof(DynamoPropertyExtensions),
+                    typeof(DynamoPropertyExtensions), typeof(DynamoPropertyBuilderExtensions),
+                    null!)
+            },
+            {
+                typeof(IReadOnlyIndex),
+                (typeof(DynamoIndexExtensions), typeof(DynamoIndexExtensions),
+                    typeof(DynamoIndexExtensions), null!, null!)
+            },
+        };
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -50,6 +50,11 @@ public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsiste
             typeof(DynamoSecondaryIndexBuilder<>),
         ];
 
+        public DynamoApiConsistencyFixture()
+            => GenericFluentApiTypes.Add(
+                typeof(DynamoSecondaryIndexBuilder),
+                typeof(DynamoSecondaryIndexBuilder<>));
+
         public override
             Dictionary<Type, (Type ReadonlyExtensions, Type MutableExtensions, Type
                 ConventionExtensions, Type ConventionBuilderExtensions, Type RuntimeExtensions)>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -436,9 +436,43 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
     private void NoSyncTest(Action testCode) => DynamoTestHelpers.Instance.NoSyncTest(testCode);
 
-    public class FindDynamoTestSet(FindDynamoFixture fixture) : FindDynamoTest(fixture)
+    /// <summary>Find tests that use <see cref="DbSet{TEntity}.Find(object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestSet : FindDynamoTest
     {
+        /// <summary>Creates set-based find tests.</summary>
+        public FindDynamoTestSet(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
         protected override TestFinder Finder { get; } = new FindViaSetFinder();
+    }
+
+    /// <summary>Find tests that use generic <see cref="DbContext.Find{TEntity}(object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestContext : FindDynamoTest
+    {
+        /// <summary>Creates context-based find tests.</summary>
+        public FindDynamoTestContext(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
+        protected override TestFinder Finder { get; } = new FindViaContextFinder();
+    }
+
+    /// <summary>Find tests that use non-generic <see cref="DbContext.Find(Type, object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestNonGeneric : FindDynamoTest
+    {
+        /// <summary>Creates non-generic context-based find tests.</summary>
+        public FindDynamoTestNonGeneric(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
+        protected override TestFinder Finder { get; } = new FindViaNonGenericContextFinder();
     }
 
     public class FindDynamoFixture : FindFixtureBase, IDynamoSpecificationFixture

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
@@ -4,44 +4,74 @@ using Testcontainers.DynamoDb;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 
-/// <summary>Process-scoped DynamoDB Local container for specification tests.</summary>
-public static class DynamoSpecificationContainerFixture
+/// <summary>Collection fixture that owns the shared DynamoDB Local container.</summary>
+public sealed class DynamoSpecificationContainerFixture : IAsyncLifetime
 {
+    private const string DynamoDbLocalImage = "amazon/dynamodb-local:2.6.1";
+
     private static readonly SemaphoreSlim StartLock = new(1, 1);
     private static DynamoDbContainer? _container;
-    private static IAmazonDynamoDB? _client;
+    private static AmazonDynamoDBClient? _client;
 
     /// <summary>Gets the shared DynamoDB client for specification tests.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the fixture has not been initialized.</exception>
     public static IAmazonDynamoDB Client
-    {
-        get
-        {
-            EnsureStartedAsync().GetAwaiter().GetResult();
-            return _client!;
-        }
-    }
+        => _client
+            ?? throw new InvalidOperationException(
+                "DynamoDB specification fixture has not been initialized.");
 
-    private static async Task EnsureStartedAsync()
+    /// <summary>Starts the shared DynamoDB Local container if needed.</summary>
+    public static async Task<IAmazonDynamoDB> GetClientAsync()
     {
         if (_client is not null)
-            return;
+            return _client;
 
         await StartLock.WaitAsync().ConfigureAwait(false);
         try
         {
             if (_client is not null)
-                return;
+                return _client;
 
-            _container = new DynamoDbBuilder("amazon/dynamodb-local:latest").Build();
+            _container = new DynamoDbBuilder(DynamoDbLocalImage).Build();
             await _container.StartAsync().ConfigureAwait(false);
 
             _client = new AmazonDynamoDBClient(
                 new BasicAWSCredentials("test", "test"),
                 new AmazonDynamoDBConfig { ServiceURL = _container.GetConnectionString() });
+
+            return _client;
         }
         finally
         {
             StartLock.Release();
         }
     }
+
+    /// <summary>Starts the shared DynamoDB Local container.</summary>
+    public async Task InitializeAsync() => await GetClientAsync().ConfigureAwait(false);
+
+    /// <summary>Stops the shared DynamoDB Local container and disposes the client.</summary>
+    public static async Task DisposeContainerAsync()
+    {
+        _client?.Dispose();
+        _client = null;
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+            _container = null;
+        }
+    }
+
+    /// <summary>Stops the shared DynamoDB Local container and disposes the client.</summary>
+    public async Task DisposeAsync() => await DisposeContainerAsync().ConfigureAwait(false);
+}
+
+/// <summary>Collection definition for DynamoDB specification tests.</summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DynamoSpecificationCollection
+    : ICollectionFixture<DynamoSpecificationContainerFixture>
+{
+    /// <summary>Collection name for DynamoDB specification tests.</summary>
+    public const string Name = "DynamoDB specification tests";
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
@@ -25,6 +25,7 @@ public class DynamoTestHelpers : TestHelpers
     public static void AssertAllTestMethodsOverridden(Type testClass)
         => AssertAllMethodsOverridden(testClass);
 
+    /// <summary>Runs a sync test and verifies that DynamoDB sync query execution fails.</summary>
     public void NoSyncTest(Action testCode)
     {
         try

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
@@ -9,22 +9,29 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 /// <summary>Test store factory for DynamoDB specification tests.</summary>
 public class DynamoTestStoreFactory : ITestStoreFactory
 {
+    /// <summary>Gets the singleton DynamoDB test store factory.</summary>
     public static DynamoTestStoreFactory Instance { get; } = new();
 
+    /// <summary>Gets the shared DynamoDB client from the active specification fixture.</summary>
     public IAmazonDynamoDB Client => DynamoSpecificationContainerFixture.Client;
 
+    /// <summary>Adds DynamoDB provider services to the test service collection.</summary>
     public IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
         => serviceCollection
             .AddEntityFrameworkDynamo()
             .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory());
 
+    /// <summary>Creates a non-shared DynamoDB test store.</summary>
     public TestStore Create(string storeName) => new DynamoTestStore(storeName, false, this);
 
+    /// <summary>Gets or creates a shared DynamoDB test store.</summary>
     public virtual TestStore GetOrCreate(string storeName)
         => new DynamoTestStore(storeName, true, this);
 
+    /// <summary>Creates the list logger factory used to capture emitted PartiQL.</summary>
     public virtual ListLoggerFactory CreateListLoggerFactory(Func<string, bool> shouldLogCategory)
         => new TestSqlLoggerFactory(shouldLogCategory);
 
-    internal Task<IAmazonDynamoDB> GetClientAsync() => Task.FromResult(Client);
+    internal Task<IAmazonDynamoDB> GetClientAsync()
+        => DynamoSpecificationContainerFixture.GetClientAsync();
 }


### PR DESCRIPTION
## Summary

Adds DynamoDB specification-test coverage for provider API consistency and expands `Find` specification coverage across `DbSet.Find`, generic `DbContext.Find`, and non-generic `DbContext.Find`. Updates the spec-test DynamoDB Local fixture wiring so concrete tests share the xUnit collection fixture lifecycle instead of relying on implicit lazy startup.

## Changes

- Added `DynamoApiConsistencyTest` for provider fluent APIs and metadata extension mappings.
- Added API consistency coverage for query fluent APIs such as `Limit`, `WithNextToken`, `WithConsistentRead`, `WithIndex`, `WithoutIndex`, and `AllowScan`.
- Expanded `FindDynamoTest` with concrete test classes for set, generic context, and non-generic context find paths.
- Converted DynamoDB Local spec fixture to an xUnit collection fixture with async startup/disposal.
- Updated spec-test contributor notes for the collection fixture pattern.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --no-restore --filter FullyQualifiedName~DynamoApiConsistencyTest`
- Multi-agent review also reported `dotnet build --no-restore` and full spec-test project pass: 349 total, 262 succeeded, 87 skipped.

## Notes for Reviewers

Composite-key `Find` tests remain skipped for now; follow-up planned to map the spec `CompositeKey` entity to DynamoDB partition + sort keys and unskip supported cases.
