### PR TITLE
test(dynamodb): re-enable composite key find specs

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -8,7 +8,6 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 /// <summary>Specification find tests for the DynamoDB provider.</summary>
 public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFixture>
 {
-    private const string CompositeKeysNotSupported = "DynamoDB does not support composite keys.";
     private const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
     private const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
 
@@ -39,14 +38,18 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     public override void Returns_null_for_string_key_not_in_store()
         => NoSyncTest(() => base.Returns_null_for_string_key_not_in_store());
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Find_composite_key_tracked() { }
+    public override void Find_composite_key_tracked()
+    {
+        base.Find_composite_key_tracked();
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Find_composite_key_from_store() { }
+        AssertSql();
+    }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_composite_key_not_in_store() { }
+    public override void Find_composite_key_from_store()
+        => NoSyncTest(() => base.Find_composite_key_from_store());
+
+    public override void Returns_null_for_composite_key_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_composite_key_not_in_store());
 
     public override void Find_base_type_from_store()
         => NoSyncTest(() => base.Find_base_type_from_store());
@@ -141,20 +144,36 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     [ConditionalFact(Skip = ShadowKeysNotSupported)]
     public override void Returns_null_for_shadow_key_not_in_store() { }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_null_key_values_array() { }
+    public override void Returns_null_for_null_key_values_array()
+    {
+        base.Returns_null_for_null_key_values_array();
+
+        AssertSql();
+    }
 
     [ConditionalFact(Skip = NullableKeysNotSupported)]
     public override void Returns_null_for_null_nullable_key() { }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_null_in_composite_key() { }
+    public override void Returns_null_for_null_in_composite_key()
+    {
+        base.Returns_null_for_null_in_composite_key();
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Throws_for_wrong_number_of_values_for_composite_key() { }
+        AssertSql();
+    }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Throws_for_bad_type_for_composite_key() { }
+    public override void Throws_for_wrong_number_of_values_for_composite_key()
+    {
+        base.Throws_for_wrong_number_of_values_for_composite_key();
+
+        AssertSql();
+    }
+
+    public override void Throws_for_bad_type_for_composite_key()
+    {
+        base.Throws_for_bad_type_for_composite_key();
+
+        AssertSql();
+    }
 
     [ConditionalFact(Skip = ShadowKeysNotSupported)]
     public override void Throws_for_bad_entity_type_with_different_namespace() { }
@@ -172,19 +191,6 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Find_composite_key_tracked_async(CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Find_composite_key_from_store_async(CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_composite_key_not_in_store_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
     [ConditionalTheory(Skip = ShadowKeysNotSupported)]
     public override Task Find_shadow_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
@@ -195,26 +201,6 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
     [ConditionalTheory(Skip = ShadowKeysNotSupported)]
     public override Task Returns_null_for_shadow_key_not_in_store_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_null_key_values_array_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_null_in_composite_key_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Throws_for_wrong_number_of_values_for_composite_key_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Throws_for_bad_type_for_composite_key_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
@@ -270,6 +256,39 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
             SELECT "id", "foo"
             FROM "strings"
             WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Find_composite_key_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_composite_key_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_composite_key_from_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_composite_key_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id1", "id2", "foo"
+            FROM "composite"
+            WHERE "id1" = ? AND "id2" = ?
+            """);
+    }
+
+    public override async Task Returns_null_for_composite_key_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_composite_key_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id1", "id2", "foo"
+            FROM "composite"
+            WHERE "id1" = ? AND "id2" = ?
             """);
     }
 
@@ -421,6 +440,38 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
+    public override async Task Returns_null_for_null_key_values_array_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_null_key_values_array_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Returns_null_for_null_in_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_null_in_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_wrong_number_of_values_for_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_wrong_number_of_values_for_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_bad_type_for_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_bad_type_for_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
     public override async Task Throws_for_bad_entity_type_async(CancellationType cancellationType)
     {
         await base.Throws_for_bad_entity_type_async(cancellationType);
@@ -470,6 +521,12 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
             modelBuilder.Entity<StringKey>().ToTable("strings").HasPartitionKey(x => x.Id);
 
+            modelBuilder
+                .Entity<CompositeKey>()
+                .ToTable("composite")
+                .HasPartitionKey(x => x.Id1)
+                .HasSortKey(x => x.Id2);
+
             modelBuilder.Entity<BaseType>().ToTable("base").HasPartitionKey(x => x.Id);
 
             modelBuilder.Entity<DerivedType>();
@@ -495,6 +552,7 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
                     OwnedCollection = [new Owned1 { Prop = 71 }, new Owned1 { Prop = 72 }],
                 },
                 new StringKey { Id = "Cat", Foo = "Alice" },
+                new CompositeKey { Id1 = 77, Id2 = "Dog", Foo = "Olive" },
                 new BaseType { Id = 77, Foo = "Baxter" },
                 new DerivedType { Id = 78, Foo = "Strawberry", Boo = "Cheesecake" });
 


### PR DESCRIPTION
## Summary
Re-enables DynamoDB `FindDynamoTest` coverage for composite primary keys now that the fixture maps a partition key plus sort key table. Adds SQL baselines for composite key `FindAsync` store lookups so the generated PartiQL is verified instead of skipped.

## Changes
- Removed the `CompositeKeysNotSupported` skip path from composite-key find tests.
- Restored sync and async composite-key find, null-key, wrong-count, and bad-type assertions.
- Added expected PartiQL for composite key lookups against the `composite` table.

## Validation
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --filter "FullyQualifiedName~FindDynamoTest" --no-restore`
  - Passed: 109
  - Skipped: 15
  - Failed: 0