### PR TITLE
feat(metadata): reject unsupported relationship modeling

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -221,6 +221,32 @@ operations, but successful statements within that batch have already been persis
 
 ## Modeling Constraints
 
+### Relationships and Foreign Keys Are Not Supported
+
+The provider does not support EF Core relationship modeling. `HasOne(...)`, `HasMany(...)`,
+`WithOne(...)`, `WithMany(...)`, `HasForeignKey(...)`, skip navigations, and relationship
+attributes such as `[ForeignKey]` and `[InverseProperty]` throw during model building or model
+validation.
+
+DynamoDB has no relational foreign-key enforcement or joins. Model embedded document data with
+EF Core complex types, and model separate DynamoDB items or tables as separate root entity types
+without EF navigation relationships.
+
+```csharp
+// ✅ Embedded data: complex types
+modelBuilder.Entity<Customer>(b =>
+{
+    b.ComplexProperty(x => x.Profile);
+    b.ComplexCollection(x => x.Contacts);
+});
+
+// ❌ Not supported: relational navigation/foreign-key modeling
+modelBuilder.Entity<Order>()
+    .HasOne(x => x.Customer)
+    .WithMany(x => x.Orders)
+    .HasForeignKey(x => x.CustomerId);
+```
+
 ### Owned Entity Types Are Not Supported
 
 The provider does not support EF Core owned entity types. `OwnsOne(...)`, `OwnsMany(...)`, and

--- a/docs/modeling/complex-types.md
+++ b/docs/modeling/complex-types.md
@@ -8,6 +8,11 @@ description: How complex properties and complex collections are stored and queri
 _Complex properties are stored inline within the owning entity's DynamoDB item as nested maps or
 lists, with no separate table or key._
 
+Use complex types for embedded DynamoDB document data. Do not model embedded data with EF Core
+relationships, foreign keys, navigations, or owned entity types; those relational modeling features
+are not supported by this provider. Separate DynamoDB items or tables should be modeled as separate
+root entity types without EF navigation relationships.
+
 ## Complex Properties
 
 `ComplexProperty(...)` maps a value-object-style member to a DynamoDB map (`AttributeValue.M`)
@@ -101,7 +106,7 @@ The collection is stored as a List:
 ```
 
 Supported CLR collection shapes: `List<T>`, `IList<T>`. `ICollection<T>`,
-and `IReadOnlyList<T>`. Arrays are not supported for complex collections.
+`IReadOnlyList<T>`, and arrays are not supported for complex collections.
 
 !!! note "Collection updates replace the full list"
 
@@ -191,8 +196,8 @@ the EF model and applies them consistently for both missing attributes and expli
 
 Null and missing attribute handling:
 
-| Scenario                                               | Behavior                           |
-| ------------------------------------------------------ | ---------------------------------- |
+| Scenario                                                | Behavior                           |
+| ------------------------------------------------------- | ---------------------------------- |
 | Optional complex property missing or `NULL` in DynamoDB | Materializes as `null`             |
 | Required complex property missing or `NULL` in DynamoDB | Throws `InvalidOperationException` |
 | Any complex property present with a non-map wire shape  | Throws `InvalidOperationException` |
@@ -205,6 +210,28 @@ Null and missing attribute handling:
     the EF property is required, materialization throws. Likewise, if a complex property is present
     but encoded with the wrong DynamoDB wire shape (for example `S` instead of `M`), materialization
     throws even when the CLR property is nullable. Design your schemas accordingly.
+
+## Relationships vs Complex Types
+
+Use complex types when nested data belongs to the same DynamoDB item and is read or written with
+that item. This matches DynamoDB maps and lists.
+
+Do not use EF relationship APIs for DynamoDB document nesting:
+
+```csharp
+// ❌ Not supported
+modelBuilder.Entity<Customer>()
+    .HasMany(x => x.Contacts)
+    .WithOne();
+
+// ✅ Supported
+modelBuilder.Entity<Customer>()
+    .ComplexCollection(x => x.Contacts);
+```
+
+Use separate root entities only when the data is stored as separate DynamoDB items or in separate
+tables. Keep those roots independent in EF: query them separately and connect them in application
+code by key values if needed.
 
 ## See also
 

--- a/docs/modeling/entities-keys.md
+++ b/docs/modeling/entities-keys.md
@@ -11,6 +11,8 @@ _Every entity type in the DynamoDB EF Core provider must declare a partition key
 
 Root entity types (non-owned, non-derived) map to DynamoDB tables and must resolve table keys.
 Key mapping can be explicit (`HasPartitionKey(...)`, `HasSortKey(...)`) or convention-based.
+Root entities are independent DynamoDB items; the provider does not support EF Core foreign-key or
+navigation relationships between them.
 
 ```csharp
 modelBuilder.Entity<Order>(b =>
@@ -29,13 +31,20 @@ modelBuilder.Entity<Order>(b =>
 If no explicit `ToTable(...)` is configured, the provider uses the CLR type name as the table
 name.
 
+!!! warning "No EF relationships"
+
+    `HasOne(...)`, `HasMany(...)`, `WithOne(...)`, `WithMany(...)`, `HasForeignKey(...)`,
+    `[ForeignKey]`, and `[InverseProperty]` are not supported. Use complex types for embedded
+    data, or model separate DynamoDB items/tables as separate root entities and join them in
+    application code when needed.
+
 ## Defaults and Overrides
 
 For root entity types, table/key mapping resolves in this order (highest precedence first):
 
 1. Explicit configuration (`ToTable(...)`, `HasPartitionKey(...)`, `HasSortKey(...)`)
-1. Conventions (`PK`/`PartitionKey`, `SK`/`SortKey`; table name from CLR type)
-1. Validation outcome (missing partition key throws; partition key resolved with no sort key
+2. Conventions (`PK`/`PartitionKey`, `SK`/`SortKey`; table name from CLR type)
+3. Validation outcome (missing partition key throws; partition key resolved with no sort key
     means partition-key-only)
 
 `HasKey(...)` and `[Key]` are not DynamoDB key overrides.

--- a/docs/modeling/index.md
+++ b/docs/modeling/index.md
@@ -8,7 +8,7 @@ icon: lucide/database
 
 Entity modeling in the DynamoDB EF Core provider extends standard EF Core conventions with DynamoDB-specific configuration for partition keys, sort keys, secondary indexes, and complex properties.
 
-This section covers how to define your model and how the provider maps it to DynamoDB's data structures.
+This section covers how to define your model and how the provider maps it to DynamoDB's data structures. EF Core foreign-key and navigation relationships are not supported: use complex types for embedded data, and separate root entities for separate DynamoDB items or tables.
 
 - [Entities and Keys](entities-keys.md) — Define entities and configure partition and sort keys.
 - [Secondary Indexes](secondary-indexes.md) — Configure and query Global and Local Secondary Indexes.

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -19,6 +19,8 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
     {
         // Run DynamoDB-specific pre-flight checks before EF base validation so that
         // provider-specific error messages take precedence over EF's generic errors.
+        ValidateNoForeignKeyRelationships(model);
+        ValidateNoNavigationRelationships(model);
         ValidateRootEntityDoesNotUseExplicitPrimaryKeyConfiguration(model);
         ValidateRootEntityHasPartitionKey(model);
         ValidateSortKeyHasResolvablePartitionKey(model);
@@ -56,6 +58,77 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
                 || entityType.IsOwned()
                 || entityType.FindOwnership() != null)
                 throw DynamoModelValidationErrors.OwnedEntityTypesNotSupported(entityType);
+    }
+
+    /// <summary>Rejects non-ownership EF foreign-key relationships before EF base validation.</summary>
+    private static void ValidateNoForeignKeyRelationships(IModel model)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            foreach (var foreignKey in entityType.GetDeclaredForeignKeys())
+            {
+                if (foreignKey.IsOwnership)
+                    continue;
+
+                throw DynamoModelValidationErrors.ForeignKeyRelationshipsNotSupported(foreignKey);
+            }
+        }
+    }
+
+    /// <summary>Rejects CLR navigation properties before EF base validation emits generic errors.</summary>
+    private static void ValidateNoNavigationRelationships(IModel model)
+    {
+        var entityClrTypes = model
+            .GetEntityTypes()
+            .Select(static entityType => entityType.ClrType)
+            .ToHashSet();
+
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            var mappedMemberNames = entityType
+                .GetMembers()
+                .Select(static member => member.Name)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var propertyInfo in entityType.ClrType.GetProperties())
+            {
+                if (mappedMemberNames.Contains(propertyInfo.Name)
+                    || ((IConventionEntityType)entityType).FindIgnoredConfigurationSource(
+                        propertyInfo.Name)
+                    != null)
+                    continue;
+
+                var targetType = GetEntityNavigationTargetType(propertyInfo.PropertyType);
+                if (targetType is null || !entityClrTypes.Contains(targetType))
+                    continue;
+
+                throw DynamoModelValidationErrors.NavigationRelationshipsNotSupported(
+                    entityType,
+                    propertyInfo.Name,
+                    targetType);
+            }
+        }
+    }
+
+    /// <summary>Gets the entity CLR type targeted by a possible navigation property.</summary>
+    private static Type? GetEntityNavigationTargetType(Type propertyType)
+    {
+        if (propertyType == typeof(string) || propertyType == typeof(byte[]))
+            return null;
+
+        if (!propertyType.IsGenericType)
+            return propertyType;
+
+        if (propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            return Nullable.GetUnderlyingType(propertyType);
+
+        var enumerableType = propertyType
+            .GetInterfaces()
+            .Append(propertyType)
+            .FirstOrDefault(static type
+                => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        return enumerableType?.GetGenericArguments()[0] ?? propertyType;
     }
 
     /// <summary>

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
@@ -33,6 +33,12 @@ public sealed class DynamoConventionSetBuilder(
         conventionSet.ForeignKeyOwnershipChangedConventions.Add(
             ownedEntityTypeValidationConvention);
         conventionSet.ModelFinalizingConventions.Add(ownedEntityTypeValidationConvention);
+
+        var relationshipValidationConvention = new DynamoRelationshipValidationConvention();
+        conventionSet.ForeignKeyAddedConventions.Add(relationshipValidationConvention);
+        conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipValidationConvention);
+        conventionSet.ModelFinalizingConventions.Add(relationshipValidationConvention);
+
         conventionSet.ModelFinalizingConventions.Add(
             new DynamoComplexContainmentValidationConvention());
         // Must run before DynamoKeyAnnotationConvention so PK/SK attribute names are already

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoRelationshipValidationConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoRelationshipValidationConvention.cs
@@ -1,0 +1,44 @@
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EntityFrameworkCore.DynamoDb.Metadata.Conventions;
+
+/// <summary>Rejects EF Core foreign-key relationship configuration for DynamoDB models.</summary>
+public sealed class DynamoRelationshipValidationConvention
+    : IForeignKeyAddedConvention, IForeignKeyOwnershipChangedConvention, IModelFinalizingConvention
+{
+    /// <inheritdoc />
+    public void ProcessForeignKeyAdded(
+        IConventionForeignKeyBuilder foreignKeyBuilder,
+        IConventionContext<IConventionForeignKeyBuilder> context)
+        => ThrowIfUnsupportedRelationship(foreignKeyBuilder.Metadata);
+
+    /// <inheritdoc />
+    public void ProcessForeignKeyOwnershipChanged(
+        IConventionForeignKeyBuilder relationshipBuilder,
+        IConventionContext<bool?> context)
+        => ThrowIfUnsupportedRelationship(relationshipBuilder.Metadata);
+
+    /// <inheritdoc />
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+        {
+            foreach (var foreignKey in entityType.GetDeclaredForeignKeys())
+                ThrowIfUnsupportedRelationship(foreignKey);
+        }
+    }
+
+    /// <summary>Throws when a non-ownership foreign key relationship is configured.</summary>
+    private static void ThrowIfUnsupportedRelationship(IReadOnlyForeignKey foreignKey)
+    {
+        if (foreignKey.IsOwnership)
+            return;
+
+        throw DynamoModelValidationErrors.ForeignKeyRelationshipsNotSupported(foreignKey);
+    }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoModelValidationErrors.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoModelValidationErrors.cs
@@ -14,6 +14,47 @@ internal static class DynamoModelValidationErrors
             + "instead: annotate the CLR type with [ComplexType] and replace OwnsOne/OwnsMany "
             + "fluent calls with ComplexProperty()/ComplexCollection().");
 
+    /// <summary>Creates the provider error used when foreign-key relationships are configured.</summary>
+    public static InvalidOperationException ForeignKeyRelationshipsNotSupported(
+        IReadOnlyForeignKey foreignKey)
+    {
+        var dependentEntityType = foreignKey.DeclaringEntityType.DisplayName();
+        var principalEntityType = foreignKey.PrincipalEntityType.DisplayName();
+        var foreignKeyProperties = foreignKey.Properties.Count == 0
+            ? "<none>"
+            : string.Join(", ", foreignKey.Properties.Select(static property => property.Name));
+        var dependentNavigation = foreignKey.DependentToPrincipal?.Name ?? "<none>";
+        var principalNavigation = foreignKey.PrincipalToDependent?.Name ?? "<none>";
+
+        return new InvalidOperationException(
+            $"Foreign key relationship from dependent entity type '{dependentEntityType}' "
+            + $"to principal entity type '{principalEntityType}' is not supported by the "
+            + $"DynamoDB provider. Foreign key properties: [{foreignKeyProperties}]. "
+            + $"Dependent navigation: '{dependentNavigation}'. Principal navigation: "
+            + $"'{principalNavigation}'. DynamoDB provider does not support "
+            + "HasOne/HasMany/WithOne/WithMany/HasForeignKey or relational navigation "
+            + "relationships. Use EF Core complex types ([ComplexType], "
+            + "ComplexProperty(...), ComplexCollection(...)) for embedded data, or model "
+            + "separate DynamoDB items/tables as separate root entities without EF "
+            + "relationships.");
+    }
+
+    /// <summary>Creates the provider error used when unmapped CLR navigation properties are found.</summary>
+    public static InvalidOperationException
+        NavigationRelationshipsNotSupported(
+            IReadOnlyEntityType entityType,
+            string navigationName,
+            Type targetType)
+        => new(
+            $"Navigation relationship '{entityType.DisplayName()}.{navigationName}' targeting "
+            + $"'{targetType.Name}' is not supported by the DynamoDB provider. "
+            + "DynamoDB provider does not support HasOne/HasMany/WithOne/WithMany/"
+            + "HasForeignKey, [ForeignKey], [InverseProperty], or relational navigation "
+            + "relationships. Use EF Core complex types ([ComplexType], "
+            + "ComplexProperty(...), ComplexCollection(...)) for embedded data, or model "
+            + "separate DynamoDB items/tables as separate root entities without EF "
+            + "relationships.");
+
     /// <summary>
     ///     Creates the provider error used when a recursive complex-property containment cycle is
     ///     detected in the model.

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoComplexPropertyDiscoveryConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoComplexPropertyDiscoveryConventionTests.cs
@@ -217,7 +217,7 @@ public class DynamoComplexPropertyDiscoveryConventionTests
             .Should()
             .Throw<InvalidOperationException>()
             .WithMessage(
-                "*Unable to determine the relationship represented by navigation 'Employee.WorkAddress'*");
+                "*Navigation relationship 'Employee.WorkAddress'*not supported*DynamoDB*complex types*");
     }
 
     /// <summary>
@@ -236,7 +236,7 @@ public class DynamoComplexPropertyDiscoveryConventionTests
             .Should()
             .Throw<InvalidOperationException>()
             .WithMessage(
-                "*Unable to determine the relationship represented by navigation 'Team.Offices'*");
+                "*Navigation relationship 'Team.Offices'*not supported*DynamoDB*complex types*");
     }
 
     /// <summary>Verifies that unsupported collection abstractions remain rejected at model validation.</summary>

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/RelationshipRejectionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/RelationshipRejectionTests.cs
@@ -1,0 +1,301 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Amazon.DynamoDBv2;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Metadata;
+
+/// <summary>Verifies that DynamoDB models reject EF Core relationship metadata.</summary>
+public class RelationshipRejectionTests
+{
+    private static IAmazonDynamoDB MockClient() => Substitute.For<IAmazonDynamoDB>();
+
+    private static DbContextOptions BuildOptions<T>() where T : DbContext
+        => new DbContextOptionsBuilder<T>()
+            .UseDynamo(o => o.DynamoDbClient(MockClient()))
+            .ConfigureWarnings(w
+                => w
+                    .Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)
+                    .Ignore(DynamoEventId.ScanLikeQueryDetected))
+            .Options;
+
+    /// <summary>HasOne/WithOne with explicit foreign key throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void HasOne_WithOne_WithForeignKey_Throws_WithClearMessage()
+        => AssertRelationshipRejected<OneToOneContext>();
+
+    /// <summary>HasOne/WithMany with explicit foreign key throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void HasOne_WithMany_WithForeignKey_Throws_WithClearMessage()
+        => AssertRelationshipRejected<HasOneWithManyContext>();
+
+    /// <summary>HasMany/WithOne with explicit foreign key throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void HasMany_WithOne_WithForeignKey_Throws_WithClearMessage()
+        => AssertRelationshipRejected<HasManyWithOneContext>();
+
+    /// <summary>HasMany/WithMany skip-navigation relationship throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void HasMany_WithMany_Throws_WithClearMessage()
+        => AssertRelationshipRejected<ManyToManyContext>();
+
+    /// <summary>ForeignKey attribute-created relationship throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ForeignKeyAttribute_Throws_WithClearMessage()
+        => AssertRelationshipRejected<ForeignKeyAttributeContext>();
+
+    /// <summary>InverseProperty attribute-created relationship throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void InversePropertyAttribute_Throws_WithClearMessage()
+        => AssertRelationshipRejected<InversePropertyAttributeContext>();
+
+    /// <summary>Shadow foreign key relationship throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ShadowForeignKey_Throws_WithClearMessage()
+        => AssertRelationshipRejected<ShadowForeignKeyContext>();
+
+    /// <summary>Relationship without explicit HasForeignKey throws provider-specific message.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void RelationshipWithoutExplicitForeignKey_Throws_WithClearMessage()
+        => AssertRelationshipRejected<ConventionalForeignKeyContext>();
+
+    private static void AssertRelationshipRejected<TContext>() where TContext : DbContext
+    {
+        using var ctx =
+            (TContext)Activator.CreateInstance(typeof(TContext), BuildOptions<TContext>())!;
+        var act = () => ctx.Model;
+
+        act
+            .Should()
+            .Throw<InvalidOperationException>()
+            .Where(ex => ex.Message.Contains("DynamoDB", StringComparison.Ordinal)
+                && (ex.Message.Contains("foreign key", StringComparison.OrdinalIgnoreCase)
+                    || ex.Message.Contains("relationship", StringComparison.OrdinalIgnoreCase))
+                && ex.Message.Contains("not supported", StringComparison.OrdinalIgnoreCase)
+                && (ex.Message.Contains("HasOne/HasMany", StringComparison.Ordinal)
+                    || ex.Message.Contains(
+                        "navigation relationships",
+                        StringComparison.OrdinalIgnoreCase))
+                && ex.Message.Contains("complex types", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void ConfigurePrincipal(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<Principal>(b =>
+        {
+            b.ToTable("principals");
+            b.HasPartitionKey(e => e.Pk);
+        });
+
+    private static void ConfigureDependent(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<Dependent>(b =>
+        {
+            b.ToTable("dependents");
+            b.HasPartitionKey(e => e.Pk);
+        });
+
+    private sealed class OneToOneContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Principal> Principals => Set<Principal>();
+        public DbSet<Dependent> Dependents => Set<Dependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ConfigurePrincipal(modelBuilder);
+            ConfigureDependent(modelBuilder);
+            modelBuilder
+                .Entity<Dependent>()
+                .HasOne(e => e.Principal)
+                .WithOne(e => e.SingleDependent)
+                .HasForeignKey<Dependent>(e => e.PrincipalPk);
+        }
+    }
+
+    private sealed class HasOneWithManyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Principal> Principals => Set<Principal>();
+        public DbSet<Dependent> Dependents => Set<Dependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ConfigurePrincipal(modelBuilder);
+            ConfigureDependent(modelBuilder);
+            modelBuilder
+                .Entity<Dependent>()
+                .HasOne(e => e.Principal)
+                .WithMany(e => e.Dependents)
+                .HasForeignKey(e => e.PrincipalPk);
+        }
+    }
+
+    private sealed class HasManyWithOneContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Principal> Principals => Set<Principal>();
+        public DbSet<Dependent> Dependents => Set<Dependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ConfigurePrincipal(modelBuilder);
+            ConfigureDependent(modelBuilder);
+            modelBuilder
+                .Entity<Principal>()
+                .HasMany(e => e.Dependents)
+                .WithOne(e => e.Principal)
+                .HasForeignKey(e => e.PrincipalPk);
+        }
+    }
+
+    private sealed class ManyToManyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ManyLeft> Lefts => Set<ManyLeft>();
+        public DbSet<ManyRight> Rights => Set<ManyRight>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ManyLeft>(b =>
+            {
+                b.ToTable("lefts");
+                b.HasPartitionKey(e => e.Pk);
+            });
+            modelBuilder.Entity<ManyRight>(b =>
+            {
+                b.ToTable("rights");
+                b.HasPartitionKey(e => e.Pk);
+            });
+            modelBuilder.Entity<ManyLeft>().HasMany(e => e.Rights).WithMany(e => e.Lefts);
+        }
+    }
+
+    private sealed class ForeignKeyAttributeContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ForeignKeyAttributePrincipal> Principals
+            => Set<ForeignKeyAttributePrincipal>();
+
+        public DbSet<ForeignKeyAttributeDependent> Dependents
+            => Set<ForeignKeyAttributeDependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ForeignKeyAttributePrincipal>(b =>
+            {
+                b.ToTable("fk-principals");
+                b.HasPartitionKey(e => e.Pk);
+            });
+            modelBuilder.Entity<ForeignKeyAttributeDependent>(b =>
+            {
+                b.ToTable("fk-dependents");
+                b.HasPartitionKey(e => e.Pk);
+            });
+        }
+    }
+
+    private sealed class InversePropertyAttributeContext(DbContextOptions options) : DbContext(
+        options)
+    {
+        public DbSet<InversePropertyPrincipal> Principals => Set<InversePropertyPrincipal>();
+        public DbSet<InversePropertyDependent> Dependents => Set<InversePropertyDependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InversePropertyPrincipal>(b =>
+            {
+                b.ToTable("inverse-principals");
+                b.HasPartitionKey(e => e.Pk);
+            });
+            modelBuilder.Entity<InversePropertyDependent>(b =>
+            {
+                b.ToTable("inverse-dependents");
+                b.HasPartitionKey(e => e.Pk);
+            });
+        }
+    }
+
+    private sealed class ShadowForeignKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Principal> Principals => Set<Principal>();
+        public DbSet<Dependent> Dependents => Set<Dependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ConfigurePrincipal(modelBuilder);
+            ConfigureDependent(modelBuilder);
+            modelBuilder
+                .Entity<Dependent>()
+                .HasOne(e => e.Principal)
+                .WithMany(e => e.Dependents)
+                .HasForeignKey("PrincipalShadowPk");
+        }
+    }
+
+    private sealed class ConventionalForeignKeyContext(DbContextOptions options) : DbContext(
+        options)
+    {
+        public DbSet<Principal> Principals => Set<Principal>();
+        public DbSet<Dependent> Dependents => Set<Dependent>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ConfigurePrincipal(modelBuilder);
+            ConfigureDependent(modelBuilder);
+            modelBuilder.Entity<Dependent>().HasOne(e => e.Principal).WithMany(e => e.Dependents);
+        }
+    }
+
+    private sealed record Principal
+    {
+        public string Pk { get; set; } = null!;
+        public Dependent? SingleDependent { get; set; }
+        public List<Dependent> Dependents { get; set; } = [];
+    }
+
+    private sealed record Dependent
+    {
+        public string Pk { get; set; } = null!;
+        public string? PrincipalPk { get; set; }
+        public Principal? Principal { get; set; }
+    }
+
+    private sealed record ManyLeft
+    {
+        public string Pk { get; set; } = null!;
+        public List<ManyRight> Rights { get; set; } = [];
+    }
+
+    private sealed record ManyRight
+    {
+        public string Pk { get; set; } = null!;
+        public List<ManyLeft> Lefts { get; set; } = [];
+    }
+
+    private sealed record ForeignKeyAttributePrincipal
+    {
+        public string Pk { get; set; } = null!;
+        public List<ForeignKeyAttributeDependent> Dependents { get; set; } = [];
+    }
+
+    private sealed record ForeignKeyAttributeDependent
+    {
+        public string Pk { get; set; } = null!;
+        public string PrincipalPk { get; set; } = null!;
+
+        [ForeignKey(nameof(PrincipalPk))]
+        public ForeignKeyAttributePrincipal? Principal { get; set; }
+    }
+
+    private sealed record InversePropertyPrincipal
+    {
+        public string Pk { get; set; } = null!;
+
+        [InverseProperty(nameof(InversePropertyDependent.Principal))]
+        public List<InversePropertyDependent> Dependents { get; set; } = [];
+    }
+
+    private sealed record InversePropertyDependent
+    {
+        public string Pk { get; set; } = null!;
+        public string PrincipalPk { get; set; } = null!;
+
+        [InverseProperty(nameof(InversePropertyPrincipal.Dependents))]
+        public InversePropertyPrincipal? Principal { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Adds provider-wide rejection for EF Core relationship and foreign-key modeling in the DynamoDB provider. Relationship metadata now fails early with DynamoDB-specific guidance that points users to EF Core complex types for embedded data, or separate root entities for separate DynamoDB items/tables.

## Changes

### Relationship validation

- Added centralized validation errors for unsupported foreign-key and navigation relationships.
- Added a DynamoDB relationship validation convention that rejects non-ownership foreign keys during model building/finalization.
- Added model-validator defense before EF Core base validation so provider-specific messages win over generic EF relationship errors.
- Preserved existing owned-type rejection behavior and messaging.

### Tests

- Added coverage for unsupported relationship entry points:
  - `HasOne().WithOne().HasForeignKey(...)`
  - `HasOne().WithMany().HasForeignKey(...)`
  - `HasMany().WithOne().HasForeignKey(...)`
  - `HasMany().WithMany(...)`
  - `[ForeignKey]`
  - `[InverseProperty]`
  - shadow FK relationships
  - convention-created FK relationships
- Updated complex-property discovery assertions to expect provider-specific navigation rejection.

### Docs

- Documented that EF relationships, FKs, navigations, skip navigations, `[ForeignKey]`, and `[InverseProperty]` are unsupported.
- Clarified that complex types are the supported path for embedded DynamoDB document data.
- Clarified that separate DynamoDB items/tables should be separate root entities without EF navigation relationships.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -- --filter-class '*Relationship*'`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -- --filter-class '*OwnedTypeRejectionTests'`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj`
- `uv run zensical build`
- `dotnet build --no-restore`

## Breaking Changes

- Configuring EF Core relationships or foreign keys now throws a DynamoDB-provider-specific `InvalidOperationException` instead of allowing relationship metadata to reach later generic EF validation or runtime paths.

## Release Notes

DynamoDB provider now explicitly rejects EF Core foreign-key and navigation relationship modeling. Use EF Core complex types for embedded DynamoDB data, or model separate DynamoDB items/tables as independent root entities.
