### PR TITLE
fix(metadata): configure Dynamo value generation convention

### DIFF
--- a/docs/modeling/entities-keys.md
+++ b/docs/modeling/entities-keys.md
@@ -69,8 +69,12 @@ If a numeric key is left unset, EF Core treats the CLR default (for example `0`)
 write. If a string key is left `null`, the save fails because DynamoDB key attributes must be
 present and non-null.
 
-`Guid` keys keep EF Core's default client-side generation behavior. Leaving a `Guid` key as
-`Guid.Empty` lets EF Core assign a new Guid before writing the item.
+Single-property `Guid` keys keep EF Core's default client-side generation behavior. Leaving such a
+`Guid` key as `Guid.Empty` lets EF Core assign a new Guid before writing the item.
+
+Composite DynamoDB keys are application-assigned by convention, even when one key part is a `Guid`.
+Set both the partition key and sort key before saving, or explicitly configure a client-side value
+generator for the key part that should be generated.
 
 ```csharp
 public sealed class Session
@@ -78,10 +82,17 @@ public sealed class Session
     public Guid Id { get; set; }
     public string Name { get; set; } = null!;
 }
+
+modelBuilder.Entity<Session>(b =>
+{
+    b.HasPartitionKey(x => x.Id);
+});
 ```
 
 Explicit EF Core value-generation configuration still wins over provider conventions when you need
-a custom client-side generator. For example, use a custom generator for Guid v7 keys:
+a custom client-side generator. DynamoDB still does not generate the value; your EF Core
+configuration must produce a concrete CLR value before save. For example, use a custom generator for
+Guid v7 keys:
 
 ```csharp
 public sealed class GuidV7ValueGenerator : ValueGenerator<Guid>

--- a/docs/modeling/entities-keys.md
+++ b/docs/modeling/entities-keys.md
@@ -81,7 +81,28 @@ public sealed class Session
 ```
 
 Explicit EF Core value-generation configuration still wins over provider conventions when you need
-a custom client-side generator.
+a custom client-side generator. For example, use a custom generator for Guid v7 keys:
+
+```csharp
+public sealed class GuidV7ValueGenerator : ValueGenerator<Guid>
+{
+    public override bool GeneratesTemporaryValues => false;
+
+    public override Guid Next(EntityEntry entry)
+        => Guid.CreateVersion7();
+}
+
+modelBuilder.Entity<Session>(b =>
+{
+    b.HasPartitionKey(x => x.Id);
+    b.Property(x => x.Id)
+        .ValueGeneratedOnAdd()
+        .HasValueGenerator<GuidV7ValueGenerator>();
+});
+```
+
+A value generator creates the CLR key value. A value converter only changes how that value is stored
+in DynamoDB.
 
 ## Sort Key
 

--- a/docs/modeling/entities-keys.md
+++ b/docs/modeling/entities-keys.md
@@ -34,8 +34,8 @@ name.
 For root entity types, table/key mapping resolves in this order (highest precedence first):
 
 1. Explicit configuration (`ToTable(...)`, `HasPartitionKey(...)`, `HasSortKey(...)`)
-1. Conventions (`PK`/`PartitionKey`, `SK`/`SortKey`; table name from CLR type)
-1. Validation outcome (missing partition key throws; partition key resolved with no sort key
+2. Conventions (`PK`/`PartitionKey`, `SK`/`SortKey`; table name from CLR type)
+3. Validation outcome (missing partition key throws; partition key resolved with no sort key
     means partition-key-only)
 
 `HasKey(...)` and `[Key]` are not DynamoDB key overrides.
@@ -49,6 +49,39 @@ conventional property names (`PK` or `PartitionKey`, case-insensitive).
 
 Partition keys must be mapped, non-nullable EF properties and resolve to DynamoDB key-supported
 provider types (string, number, or binary).
+
+## Key Value Generation
+
+DynamoDB does not generate primary key values for you. By convention, string and numeric partition
+or sort keys are application-assigned: set them before calling `SaveChangesAsync`.
+
+```csharp
+context.Orders.Add(new Order
+{
+    CustomerId = "CUST#123",
+    OrderId = 42,
+    Description = "New order"
+});
+await context.SaveChangesAsync();
+```
+
+If a numeric key is left unset, EF Core treats the CLR default (for example `0`) as the value to
+write. If a string key is left `null`, the save fails because DynamoDB key attributes must be
+present and non-null.
+
+`Guid` keys keep EF Core's default client-side generation behavior. Leaving a `Guid` key as
+`Guid.Empty` lets EF Core assign a new Guid before writing the item.
+
+```csharp
+public sealed class Session
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+}
+```
+
+Explicit EF Core value-generation configuration still wins over provider conventions when you need
+a custom client-side generator.
 
 ## Sort Key
 

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoConventionSetBuilder.cs
@@ -24,6 +24,8 @@ public sealed class DynamoConventionSetBuilder(
         conventionSet.Replace<ComplexPropertyDiscoveryConvention>(
             new DynamoComplexPropertyDiscoveryConvention(Dependencies, useAttributes: true));
 
+        conventionSet.Replace<ValueGenerationConvention>(
+            new DynamoValueGenerationConvention(Dependencies));
         conventionSet.Replace<KeyDiscoveryConvention>(
             new DynamoKeyDiscoveryConvention(Dependencies));
         conventionSet.Replace<DiscriminatorConvention>(

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
@@ -20,8 +20,8 @@ public sealed class DynamoValueGenerationConvention(
     /// </summary>
     /// <param name="property">Property being configured by convention.</param>
     /// <returns>
-    ///     <see cref="ValueGenerated.OnAdd" /> for Guid keys; otherwise <see langword="null" /> so DynamoDB
-    ///     keys remain application-assigned by convention.
+    ///     EF Core's default conventional value-generation setting for Guid properties; otherwise
+    ///     <see langword="null" /> so DynamoDB-incompatible numeric and string key generation is suppressed.
     /// </returns>
     protected override ValueGenerated? GetValueGenerated(IConventionProperty property)
         => (Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType) == typeof(Guid)

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace EntityFrameworkCore.DynamoDb.Metadata.Conventions;
+
+/// <summary>
+///     Configures DynamoDB-compatible value generation by convention.
+/// </summary>
+/// <remarks>
+///     DynamoDB does not provide identity columns or integer key generators. Numeric and string keys are
+///     application-assigned unless users explicitly configure a client-side generator. Guid keys retain
+///     EF Core's default client-side generation behavior.
+/// </remarks>
+public sealed class DynamoValueGenerationConvention(
+    ProviderConventionSetBuilderDependencies dependencies) : ValueGenerationConvention(dependencies)
+{
+    /// <summary>
+    ///     Gets the conventional value-generation setting for <paramref name="property" />.
+    /// </summary>
+    /// <param name="property">Property being configured by convention.</param>
+    /// <returns>
+    ///     <see cref="ValueGenerated.OnAdd" /> for Guid keys; otherwise <see langword="null" /> so DynamoDB
+    ///     keys remain application-assigned by convention.
+    /// </returns>
+    protected override ValueGenerated? GetValueGenerated(IConventionProperty property)
+        => (Nullable.GetUnderlyingType(property.ClrType) ?? property.ClrType) == typeof(Guid)
+            ? base.GetValueGenerated(property)
+            : null;
+}

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoValueGenerationConvention.cs
@@ -1,4 +1,6 @@
+using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 
@@ -13,8 +15,33 @@ namespace EntityFrameworkCore.DynamoDb.Metadata.Conventions;
 ///     EF Core's default client-side generation behavior.
 /// </remarks>
 public sealed class DynamoValueGenerationConvention(
-    ProviderConventionSetBuilderDependencies dependencies) : ValueGenerationConvention(dependencies)
+    ProviderConventionSetBuilderDependencies dependencies)
+    : ValueGenerationConvention(dependencies), IEntityTypeAnnotationChangedConvention
 {
+    /// <summary>Updates key value-generation conventions when DynamoDB table mapping is added or removed.</summary>
+    /// <param name="entityTypeBuilder">Builder for the entity type whose annotation changed.</param>
+    /// <param name="name">Changed annotation name.</param>
+    /// <param name="annotation">New annotation value, or <see langword="null" /> when removed.</param>
+    /// <param name="oldAnnotation">Previous annotation value, or <see langword="null" /> when added.</param>
+    /// <param name="context">Convention execution context.</param>
+    public void ProcessEntityTypeAnnotationChanged(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        string name,
+        IConventionAnnotation? annotation,
+        IConventionAnnotation? oldAnnotation,
+        IConventionContext<IConventionAnnotation> context)
+    {
+        if (name != DynamoAnnotationNames.TableName || annotation is null == oldAnnotation is null)
+            return;
+
+        var primaryKey = entityTypeBuilder.Metadata.FindPrimaryKey();
+        if (primaryKey is null)
+            return;
+
+        foreach (var property in primaryKey.Properties)
+            property.Builder.ValueGenerated(GetValueGenerated(property));
+    }
+
     /// <summary>
     ///     Gets the conventional value-generation setting for <paramref name="property" />.
     /// </summary>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -1,6 +1,8 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -34,7 +36,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw["name"].S.Should().Be("assigned");
 
         var materialized =
-            await context.Entities.Where(x => x.Id == 123).ToListAsync(CancellationToken);
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == 123)
+                .ToListAsync(CancellationToken);
         materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
 
         AssertSql(
@@ -46,6 +52,122 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             SELECT "id", "name"
             FROM "value-generation-int-keys"
             WHERE "id" = 123
+            """);
+    }
+
+    /// <summary>Verifies CLR default integer keys are written as explicit DynamoDB keys.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_IntPartitionKey_DefaultZero_PersistsAsExplicitKey()
+    {
+        await using var context = CreateContext<IntKeyContext>();
+        await ResetTable(context);
+        var entity = new IntKeyEntity { Id = 0, Name = "zero" };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(IntKeyContext.TableName, "id", new AttributeValue { N = "0" });
+        raw.Should().NotBeNull();
+        raw!["id"].N.Should().Be("0");
+        raw["name"].S.Should().Be("zero");
+
+        var materialized =
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == 0)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-int-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-int-keys"
+            WHERE "id" = 0
+            """);
+    }
+
+    /// <summary>Verifies single string partition keys are explicitly written through SaveChanges.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_StringPartitionKey_ExplicitKey_PersistsAndMaterializes()
+    {
+        await using var context = CreateContext<StringKeyContext>();
+        await ResetTable(context);
+        var entity = new StringKeyEntity { Id = "SESSION#1", Name = "assigned" };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(
+            StringKeyContext.TableName,
+            "id",
+            new AttributeValue { S = entity.Id });
+        raw.Should().NotBeNull();
+        raw!["id"].S.Should().Be(entity.Id);
+        raw["name"].S.Should().Be(entity.Name);
+
+        var materialized =
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == entity.Id)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-string-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-string-keys"
+            WHERE "id" = ?
+            """);
+    }
+
+    /// <summary>Verifies explicit integer key generation runs before writing to DynamoDB.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_IntPartitionKey_ExplicitGenerator_GeneratesPersistsAndMaterializes()
+    {
+        await using var context = CreateContext<GeneratedIntKeyContext>();
+        await ResetTable(context);
+        var entity = new IntKeyEntity { Name = "generated" };
+
+        entity.Id.Should().Be(0);
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        entity.Id.Should().Be(777);
+        var raw = await GetItemAsync(
+            GeneratedIntKeyContext.TableName,
+            "id",
+            new AttributeValue { N = "777" });
+        raw.Should().NotBeNull();
+        raw!["id"].N.Should().Be("777");
+        raw["name"].S.Should().Be("generated");
+
+        var materialized =
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == entity.Id)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-generated-int-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-generated-int-keys"
+            WHERE "id" = ?
             """);
     }
 
@@ -71,7 +193,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw["name"].S.Should().Be("generated");
 
         var materialized =
-            await context.Entities.Where(x => x.Id == entity.Id).ToListAsync(CancellationToken);
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == entity.Id)
+                .ToListAsync(CancellationToken);
         materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
 
         AssertSql(
@@ -82,6 +208,47 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             """
             SELECT "id", "name"
             FROM "value-generation-guid-keys"
+            WHERE "id" = ?
+            """);
+    }
+
+    /// <summary>Verifies explicit no-generation on Guid keys writes the supplied key value.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_GuidPartitionKey_ValueGeneratedNever_PersistsExplicitKey()
+    {
+        await using var context = CreateContext<ExplicitGuidNoGenerationContext>();
+        await ResetTable(context);
+        var id = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var entity = new GuidKeyEntity { Id = id, Name = "explicit" };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        entity.Id.Should().Be(id);
+        var raw = await GetItemAsync(
+            ExplicitGuidNoGenerationContext.TableName,
+            "id",
+            new AttributeValue { S = id.ToString() });
+        raw.Should().NotBeNull();
+        raw!["id"].S.Should().Be(id.ToString());
+        raw["name"].S.Should().Be("explicit");
+
+        var materialized =
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == id)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-explicit-guid-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-explicit-guid-keys"
             WHERE "id" = ?
             """);
     }
@@ -111,6 +278,7 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         var materialized =
             await context
                 .Entities
+                .AsNoTracking()
                 .Where(x => x.Pk == entity.Pk && x.Sk == entity.Sk)
                 .ToListAsync(CancellationToken);
         materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
@@ -124,6 +292,53 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             SELECT "pk", "sk", "name"
             FROM "value-generation-composite-keys"
             WHERE "pk" = ? AND "sk" = ?
+            """);
+    }
+
+    /// <summary>Verifies composite Guid/string keys are application-assigned through SaveChanges.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_CompositeGuidStringKeys_ExplicitKeys_PersistsAndMaterializes()
+    {
+        await using var context = CreateContext<CompositeGuidKeyContext>();
+        await ResetTable(context);
+        var entity = new CompositeGuidKeyEntity
+        {
+            Id = Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            Sk = "ORDER#1",
+            Name = "composite-guid",
+        };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(
+            CompositeGuidKeyContext.TableName,
+            "id",
+            new AttributeValue { S = entity.Id.ToString() },
+            "sk",
+            new AttributeValue { S = entity.Sk });
+        raw.Should().NotBeNull();
+        raw!["id"].S.Should().Be(entity.Id.ToString());
+        raw["sk"].S.Should().Be(entity.Sk);
+        raw["name"].S.Should().Be(entity.Name);
+
+        var materialized =
+            await context
+                .Entities
+                .AsNoTracking()
+                .Where(x => x.Id == entity.Id && x.Sk == entity.Sk)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-composite-guid-keys"
+            VALUE {'id': ?, 'sk': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "sk", "name"
+            FROM "value-generation-composite-guid-keys"
+            WHERE "id" = ? AND "sk" = ?
             """);
     }
 
@@ -189,6 +404,64 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         public string Name { get; set; } = null!;
     }
 
+    private sealed record StringKeyEntity
+    {
+        public string Id { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class StringKeyContext(DbContextOptions<StringKeyContext> options) : DbContext(
+        options)
+    {
+        public const string TableName = "value-generation-string-keys";
+
+        public DbSet<StringKeyEntity> Entities => Set<StringKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<StringKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed class GeneratedIntKeyContext(DbContextOptions<GeneratedIntKeyContext> options)
+        : DbContext(options)
+    {
+        public const string TableName = "value-generation-generated-int-keys";
+
+        public DbSet<IntKeyEntity> Entities => Set<IntKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity
+                    .Property(x => x.Id)
+                    .HasAttributeName("id")
+                    .ValueGeneratedOnAdd()
+                    .HasValueGenerator<StaticIntValueGenerator>();
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed class StaticIntValueGenerator : ValueGenerator<int>
+    {
+        public override bool GeneratesTemporaryValues => false;
+
+        public override int Next(EntityEntry entry) => 777;
+    }
+
     private sealed class GuidKeyContext(DbContextOptions<GuidKeyContext> options) : DbContext(
         options)
     {
@@ -204,6 +477,26 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             {
                 entity.ToTable(TableName);
                 entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed class ExplicitGuidNoGenerationContext(
+        DbContextOptions<ExplicitGuidNoGenerationContext> options) : DbContext(options)
+    {
+        public const string TableName = "value-generation-explicit-guid-keys";
+
+        public DbSet<GuidKeyEntity> Entities => Set<GuidKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id").ValueGeneratedNever();
                 entity.Property(x => x.Name).HasAttributeName("name");
                 entity.HasPartitionKey(x => x.Id);
             });
@@ -236,6 +529,37 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
                 entity.Property(x => x.Sk).HasAttributeName("sk");
                 entity.Property(x => x.Name).HasAttributeName("name");
                 entity.HasPartitionKey(x => x.Pk);
+                entity.HasSortKey(x => x.Sk);
+            });
+    }
+
+    private sealed record CompositeGuidKeyEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Sk { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class CompositeGuidKeyContext(DbContextOptions<CompositeGuidKeyContext> options)
+        : DbContext(options)
+    {
+        public const string TableName = "value-generation-composite-guid-keys";
+
+        public DbSet<CompositeGuidKeyEntity> Entities => Set<CompositeGuidKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<CompositeGuidKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Sk).HasAttributeName("sk");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
                 entity.HasSortKey(x => x.Sk);
             });
     }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -1,0 +1,242 @@
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+/// <summary>Integration coverage for DynamoDB value-generation conventions through SaveChanges.</summary>
+[Collection("ValueGenerationSaveChangesTests")]
+public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixture)
+    : DynamoTestFixtureBase(fixture)
+{
+    protected override bool UseSharedInternalServiceProvider => false;
+
+    /// <summary>
+    ///     Verifies explicit integer keys are written and materialized without EF treating them as
+    ///     generated.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_IntPartitionKey_ExplicitKey_PersistsAndMaterializes()
+    {
+        await using var context = CreateContext<IntKeyContext>();
+        await ResetTable(context);
+        var entity = new IntKeyEntity { Id = 123, Name = "assigned" };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(
+            IntKeyContext.TableName,
+            "id",
+            new AttributeValue { N = "123" });
+        raw.Should().NotBeNull();
+        raw!["id"].N.Should().Be("123");
+        raw["name"].S.Should().Be("assigned");
+
+        var materialized =
+            await context.Entities.Where(x => x.Id == 123).ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-int-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-int-keys"
+            WHERE "id" = 123
+            """);
+    }
+
+    /// <summary>Verifies Guid partition keys still use EF Core client-side generation before writing.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_GuidPartitionKey_DefaultGuid_GeneratesPersistsAndMaterializes()
+    {
+        await using var context = CreateContext<GuidKeyContext>();
+        await ResetTable(context);
+        var entity = new GuidKeyEntity { Name = "generated" };
+
+        entity.Id.Should().Be(Guid.Empty);
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        entity.Id.Should().NotBe(Guid.Empty);
+        var raw = await GetItemAsync(
+            GuidKeyContext.TableName,
+            "id",
+            new AttributeValue { S = entity.Id.ToString() });
+        raw.Should().NotBeNull();
+        raw!["id"].S.Should().Be(entity.Id.ToString());
+        raw["name"].S.Should().Be("generated");
+
+        var materialized =
+            await context.Entities.Where(x => x.Id == entity.Id).ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-guid-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-guid-keys"
+            WHERE "id" = ?
+            """);
+    }
+
+    /// <summary>Verifies composite string keys are explicitly written through SaveChanges.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_CompositeStringKeys_ExplicitKeys_PersistsAndMaterializes()
+    {
+        await using var context = CreateContext<CompositeKeyContext>();
+        await ResetTable(context);
+        var entity = new CompositeKeyEntity { Pk = "TENANT#1", Sk = "ORDER#1", Name = "composite" };
+
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(CancellationToken);
+
+        var raw = await GetItemAsync(
+            CompositeKeyContext.TableName,
+            "pk",
+            new AttributeValue { S = entity.Pk },
+            "sk",
+            new AttributeValue { S = entity.Sk });
+        raw.Should().NotBeNull();
+        raw!["pk"].S.Should().Be(entity.Pk);
+        raw["sk"].S.Should().Be(entity.Sk);
+        raw["name"].S.Should().Be(entity.Name);
+
+        var materialized =
+            await context
+                .Entities
+                .Where(x => x.Pk == entity.Pk && x.Sk == entity.Sk)
+                .ToListAsync(CancellationToken);
+        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-composite-keys"
+            VALUE {'pk': ?, 'sk': ?, 'name': ?}
+            """,
+            """
+            SELECT "pk", "sk", "name"
+            FROM "value-generation-composite-keys"
+            WHERE "pk" = ? AND "sk" = ?
+            """);
+    }
+
+    private TContext CreateContext<TContext>() where TContext : DbContext
+        => (TContext)Activator.CreateInstance(
+            typeof(TContext),
+            CreateOptions<TContext>(o => o.DynamoDbClient(Client)))!;
+
+    private static async Task ResetTable(DbContext context)
+    {
+        await context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<Dictionary<string, AttributeValue>?> GetItemAsync(
+        string tableName,
+        string partitionKeyName,
+        AttributeValue partitionKeyValue,
+        string? sortKeyName = null,
+        AttributeValue? sortKeyValue = null)
+    {
+        var key = new Dictionary<string, AttributeValue> { [partitionKeyName] = partitionKeyValue };
+        if (sortKeyName is not null && sortKeyValue is not null)
+            key[sortKeyName] = sortKeyValue;
+
+        var response = await Client.GetItemAsync(
+            new GetItemRequest { TableName = tableName, Key = key },
+            CancellationToken);
+
+        return response.Item is { Count: > 0 } item ? item : null;
+    }
+
+    private sealed record IntKeyEntity
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class IntKeyContext(DbContextOptions<IntKeyContext> options) : DbContext(options)
+    {
+        public const string TableName = "value-generation-int-keys";
+
+        public DbSet<IntKeyEntity> Entities => Set<IntKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed record GuidKeyEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class GuidKeyContext(DbContextOptions<GuidKeyContext> options) : DbContext(
+        options)
+    {
+        public const string TableName = "value-generation-guid-keys";
+
+        public DbSet<GuidKeyEntity> Entities => Set<GuidKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed record CompositeKeyEntity
+    {
+        public string Pk { get; set; } = null!;
+
+        public string Sk { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class CompositeKeyContext(DbContextOptions<CompositeKeyContext> options)
+        : DbContext(options)
+    {
+        public const string TableName = "value-generation-composite-keys";
+
+        public DbSet<CompositeKeyEntity> Entities => Set<CompositeKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<CompositeKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Pk).HasAttributeName("pk");
+                entity.Property(x => x.Sk).HasAttributeName("sk");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Pk);
+                entity.HasSortKey(x => x.Sk);
+            });
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
@@ -1,6 +1,7 @@
 using Amazon.DynamoDBv2;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using NSubstitute;
 
@@ -123,6 +124,98 @@ public class DynamoKeyInPrimaryKeyConventionTests
         primaryKey.Properties[1].Name.Should().Be("CustomSk");
         entityType.GetPartitionKeyPropertyName().Should().Be("CustomPk");
         entityType.GetSortKeyPropertyName().Should().Be("CustomSk");
+    }
+
+    // -------------------------------------------------------------------
+    // Integer partition keys are application-assigned by convention
+    // -------------------------------------------------------------------
+
+    private sealed record IntPartitionKeyEntity
+    {
+        /// <summary>Provides functionality for this member.</summary>
+        public int Id { get; set; }
+
+        /// <summary>Provides functionality for this member.</summary>
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class IntPartitionKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        /// <summary>Provides functionality for this member.</summary>
+        public DbSet<IntPartitionKeyEntity> Entities { get; set; } = null!;
+
+        /// <summary>Provides functionality for this member.</summary>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntPartitionKeyEntity>(b =>
+            {
+                b.ToTable("IntPartitionKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        /// <summary>Provides functionality for this member.</summary>
+        public static IntPartitionKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<IntPartitionKeyContext>(client));
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void IntegerPartitionKey_IsNotValueGeneratedByConvention()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = IntPartitionKeyContext.Create(client);
+
+        var entityType = ctx.Model.FindEntityType(typeof(IntPartitionKeyEntity))!;
+
+        entityType.FindProperty(nameof(IntPartitionKeyEntity.Id))!
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    // -------------------------------------------------------------------
+    // Guid partition keys keep EF Core client-side generation by convention
+    // -------------------------------------------------------------------
+
+    private sealed record GuidPartitionKeyEntity
+    {
+        /// <summary>Provides functionality for this member.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Provides functionality for this member.</summary>
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class GuidPartitionKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        /// <summary>Provides functionality for this member.</summary>
+        public DbSet<GuidPartitionKeyEntity> Entities { get; set; } = null!;
+
+        /// <summary>Provides functionality for this member.</summary>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
+            {
+                b.ToTable("GuidPartitionKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        /// <summary>Provides functionality for this member.</summary>
+        public static GuidPartitionKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<GuidPartitionKeyContext>(client));
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void GuidPartitionKey_IsValueGeneratedByConvention()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = GuidPartitionKeyContext.Create(client);
+
+        var entityType = ctx.Model.FindEntityType(typeof(GuidPartitionKeyEntity))!;
+
+        entityType.FindProperty(nameof(GuidPartitionKeyEntity.Id))!
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.OnAdd);
     }
 
     // -------------------------------------------------------------------

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoKeyInPrimaryKeyConventionTests.cs
@@ -1,7 +1,6 @@
 using Amazon.DynamoDBv2;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using NSubstitute;
 
@@ -124,98 +123,6 @@ public class DynamoKeyInPrimaryKeyConventionTests
         primaryKey.Properties[1].Name.Should().Be("CustomSk");
         entityType.GetPartitionKeyPropertyName().Should().Be("CustomPk");
         entityType.GetSortKeyPropertyName().Should().Be("CustomSk");
-    }
-
-    // -------------------------------------------------------------------
-    // Integer partition keys are application-assigned by convention
-    // -------------------------------------------------------------------
-
-    private sealed record IntPartitionKeyEntity
-    {
-        /// <summary>Provides functionality for this member.</summary>
-        public int Id { get; set; }
-
-        /// <summary>Provides functionality for this member.</summary>
-        public string Name { get; set; } = null!;
-    }
-
-    private sealed class IntPartitionKeyContext(DbContextOptions options) : DbContext(options)
-    {
-        /// <summary>Provides functionality for this member.</summary>
-        public DbSet<IntPartitionKeyEntity> Entities { get; set; } = null!;
-
-        /// <summary>Provides functionality for this member.</summary>
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<IntPartitionKeyEntity>(b =>
-            {
-                b.ToTable("IntPartitionKeyTable");
-                b.HasPartitionKey(x => x.Id);
-            });
-
-        /// <summary>Provides functionality for this member.</summary>
-        public static IntPartitionKeyContext Create(IAmazonDynamoDB client)
-            => new(BuildOptions<IntPartitionKeyContext>(client));
-    }
-
-    /// <summary>Provides functionality for this member.</summary>
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void IntegerPartitionKey_IsNotValueGeneratedByConvention()
-    {
-        var client = Substitute.For<IAmazonDynamoDB>();
-        using var ctx = IntPartitionKeyContext.Create(client);
-
-        var entityType = ctx.Model.FindEntityType(typeof(IntPartitionKeyEntity))!;
-
-        entityType.FindProperty(nameof(IntPartitionKeyEntity.Id))!
-            .ValueGenerated
-            .Should()
-            .Be(ValueGenerated.Never);
-    }
-
-    // -------------------------------------------------------------------
-    // Guid partition keys keep EF Core client-side generation by convention
-    // -------------------------------------------------------------------
-
-    private sealed record GuidPartitionKeyEntity
-    {
-        /// <summary>Provides functionality for this member.</summary>
-        public Guid Id { get; set; }
-
-        /// <summary>Provides functionality for this member.</summary>
-        public string Name { get; set; } = null!;
-    }
-
-    private sealed class GuidPartitionKeyContext(DbContextOptions options) : DbContext(options)
-    {
-        /// <summary>Provides functionality for this member.</summary>
-        public DbSet<GuidPartitionKeyEntity> Entities { get; set; } = null!;
-
-        /// <summary>Provides functionality for this member.</summary>
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
-            {
-                b.ToTable("GuidPartitionKeyTable");
-                b.HasPartitionKey(x => x.Id);
-            });
-
-        /// <summary>Provides functionality for this member.</summary>
-        public static GuidPartitionKeyContext Create(IAmazonDynamoDB client)
-            => new(BuildOptions<GuidPartitionKeyContext>(client));
-    }
-
-    /// <summary>Provides functionality for this member.</summary>
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void GuidPartitionKey_IsValueGeneratedByConvention()
-    {
-        var client = Substitute.For<IAmazonDynamoDB>();
-        using var ctx = GuidPartitionKeyContext.Create(client);
-
-        var entityType = ctx.Model.FindEntityType(typeof(GuidPartitionKeyEntity))!;
-
-        entityType.FindProperty(nameof(GuidPartitionKeyEntity.Id))!
-            .ValueGenerated
-            .Should()
-            .Be(ValueGenerated.OnAdd);
     }
 
     // -------------------------------------------------------------------

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
@@ -20,6 +20,100 @@ public class DynamoValueGenerationConventionTests
                     .Ignore(DynamoEventId.ScanLikeQueryDetected))
             .Options;
 
+    /// <summary>Verifies numeric DynamoDB partition keys are application-assigned by convention.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void IntegerPartitionKey_IsNotValueGeneratedByConvention()
+    {
+        using var ctx = IntPartitionKeyContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<IntPartitionKeyEntity>(ctx, nameof(IntPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    /// <summary>Verifies string DynamoDB partition keys are application-assigned by convention.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void StringPartitionKey_IsNotValueGeneratedByConvention()
+    {
+        using var ctx = StringPartitionKeyContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<StringPartitionKeyEntity>(ctx, nameof(StringPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    /// <summary>
+    ///     Verifies Guid DynamoDB partition keys keep EF Core client-side value generation by
+    ///     convention.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void GuidPartitionKey_IsValueGeneratedByConvention()
+    {
+        using var ctx = GuidPartitionKeyContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<GuidPartitionKeyEntity>(ctx, nameof(GuidPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.OnAdd);
+    }
+
+    /// <summary>Verifies explicit value generation on non-Guid keys overrides DynamoDB conventions.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ExplicitValueGeneratedOnAdd_ForIntegerKey_IsPreserved()
+    {
+        using var ctx = ExplicitIntegerGenerationContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<IntPartitionKeyEntity>(ctx, nameof(IntPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.OnAdd);
+    }
+
+    /// <summary>Verifies explicit no-generation on Guid keys overrides EF Core conventions.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ExplicitValueGeneratedNever_ForGuidKey_IsPreserved()
+    {
+        using var ctx = ExplicitGuidNoGenerationContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<GuidPartitionKeyEntity>(ctx, nameof(GuidPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    /// <summary>Verifies composite DynamoDB keys are application-assigned by convention.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void CompositeGuidPartitionAndStringSortKey_AreNotValueGeneratedByConvention()
+    {
+        using var ctx = CompositeKeyContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<CompositeKeyEntity>(ctx, nameof(CompositeKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+        FindProperty<CompositeKeyEntity>(ctx, nameof(CompositeKeyEntity.SortKey))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    /// <summary>Verifies non-key Guid properties are not accidentally configured for generation.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void NonKeyGuidProperty_IsNotValueGeneratedByConvention()
+    {
+        using var ctx = GuidNonKeyContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<GuidNonKeyEntity>(ctx, nameof(GuidNonKeyEntity.ExternalId))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    private static IProperty FindProperty<TEntity>(DbContext context, string name)
+        => context.Model.FindEntityType(typeof(TEntity))!.FindProperty(name)!;
+
     private sealed record IntPartitionKeyEntity
     {
         public int Id { get; set; }
@@ -42,21 +136,26 @@ public class DynamoValueGenerationConventionTests
             => new(BuildOptions<IntPartitionKeyContext>(client));
     }
 
-    /// <summary>
-    ///     Verifies numeric DynamoDB partition keys are application-assigned by convention.
-    /// </summary>
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void IntegerPartitionKey_IsNotValueGeneratedByConvention()
+    private sealed record StringPartitionKeyEntity
     {
-        var client = Substitute.For<IAmazonDynamoDB>();
-        using var ctx = IntPartitionKeyContext.Create(client);
+        public string Id { get; set; } = null!;
 
-        var entityType = ctx.Model.FindEntityType(typeof(IntPartitionKeyEntity))!;
+        public string Name { get; set; } = null!;
+    }
 
-        entityType.FindProperty(nameof(IntPartitionKeyEntity.Id))!
-            .ValueGenerated
-            .Should()
-            .Be(ValueGenerated.Never);
+    private sealed class StringPartitionKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<StringPartitionKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<StringPartitionKeyEntity>(b =>
+            {
+                b.ToTable("StringPartitionKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        public static StringPartitionKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<StringPartitionKeyContext>(client));
     }
 
     private sealed record GuidPartitionKeyEntity
@@ -81,20 +180,86 @@ public class DynamoValueGenerationConventionTests
             => new(BuildOptions<GuidPartitionKeyContext>(client));
     }
 
-    /// <summary>
-    ///     Verifies Guid DynamoDB partition keys keep EF Core client-side value generation by convention.
-    /// </summary>
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void GuidPartitionKey_IsValueGeneratedByConvention()
+    private sealed class ExplicitIntegerGenerationContext(DbContextOptions options) : DbContext(
+        options)
     {
-        var client = Substitute.For<IAmazonDynamoDB>();
-        using var ctx = GuidPartitionKeyContext.Create(client);
+        public DbSet<IntPartitionKeyEntity> Entities { get; set; } = null!;
 
-        var entityType = ctx.Model.FindEntityType(typeof(GuidPartitionKeyEntity))!;
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntPartitionKeyEntity>(b =>
+            {
+                b.ToTable("ExplicitIntegerGenerationTable");
+                b.HasPartitionKey(x => x.Id);
+                b.Property(x => x.Id).ValueGeneratedOnAdd();
+            });
 
-        entityType.FindProperty(nameof(GuidPartitionKeyEntity.Id))!
-            .ValueGenerated
-            .Should()
-            .Be(ValueGenerated.OnAdd);
+        public static ExplicitIntegerGenerationContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<ExplicitIntegerGenerationContext>(client));
+    }
+
+    private sealed class ExplicitGuidNoGenerationContext(DbContextOptions options) : DbContext(
+        options)
+    {
+        public DbSet<GuidPartitionKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
+            {
+                b.ToTable("ExplicitGuidNoGenerationTable");
+                b.HasPartitionKey(x => x.Id);
+                b.Property(x => x.Id).ValueGeneratedNever();
+            });
+
+        public static ExplicitGuidNoGenerationContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<ExplicitGuidNoGenerationContext>(client));
+    }
+
+    private sealed record CompositeKeyEntity
+    {
+        public Guid Id { get; set; }
+
+        public string SortKey { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class CompositeKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<CompositeKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<CompositeKeyEntity>(b =>
+            {
+                b.ToTable("CompositeKeyTable");
+                b.HasPartitionKey(x => x.Id);
+                b.HasSortKey(x => x.SortKey);
+            });
+
+        public static CompositeKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<CompositeKeyContext>(client));
+    }
+
+    private sealed record GuidNonKeyEntity
+    {
+        public int Id { get; set; }
+
+        public Guid ExternalId { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class GuidNonKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<GuidNonKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidNonKeyEntity>(b =>
+            {
+                b.ToTable("GuidNonKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        public static GuidNonKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<GuidNonKeyContext>(client));
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
@@ -1,0 +1,100 @@
+using Amazon.DynamoDBv2;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Metadata.Conventions;
+
+/// <summary>
+///     Tests for <c>DynamoValueGenerationConvention</c>.
+/// </summary>
+public class DynamoValueGenerationConventionTests
+{
+    private static DbContextOptions BuildOptions<T>(IAmazonDynamoDB client) where T : DbContext
+        => new DbContextOptionsBuilder<T>()
+            .UseDynamo(o => o.DynamoDbClient(client))
+            .ConfigureWarnings(w
+                => w
+                    .Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)
+                    .Ignore(DynamoEventId.ScanLikeQueryDetected))
+            .Options;
+
+    private sealed record IntPartitionKeyEntity
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class IntPartitionKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<IntPartitionKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntPartitionKeyEntity>(b =>
+            {
+                b.ToTable("IntPartitionKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        public static IntPartitionKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<IntPartitionKeyContext>(client));
+    }
+
+    /// <summary>
+    ///     Verifies numeric DynamoDB partition keys are application-assigned by convention.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void IntegerPartitionKey_IsNotValueGeneratedByConvention()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = IntPartitionKeyContext.Create(client);
+
+        var entityType = ctx.Model.FindEntityType(typeof(IntPartitionKeyEntity))!;
+
+        entityType.FindProperty(nameof(IntPartitionKeyEntity.Id))!
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
+    private sealed record GuidPartitionKeyEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private sealed class GuidPartitionKeyContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<GuidPartitionKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<GuidPartitionKeyEntity>(b =>
+            {
+                b.ToTable("GuidPartitionKeyTable");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+        public static GuidPartitionKeyContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<GuidPartitionKeyContext>(client));
+    }
+
+    /// <summary>
+    ///     Verifies Guid DynamoDB partition keys keep EF Core client-side value generation by convention.
+    /// </summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void GuidPartitionKey_IsValueGeneratedByConvention()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = GuidPartitionKeyContext.Create(client);
+
+        var entityType = ctx.Model.FindEntityType(typeof(GuidPartitionKeyEntity))!;
+
+        entityType.FindProperty(nameof(GuidPartitionKeyEntity.Id))!
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.OnAdd);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/Conventions/DynamoValueGenerationConventionTests.cs
@@ -111,6 +111,18 @@ public class DynamoValueGenerationConventionTests
             .Be(ValueGenerated.Never);
     }
 
+    /// <summary>Verifies table mapping annotation changes re-apply DynamoDB key-generation conventions.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void LateTableMapping_ReappliesDynamoValueGenerationConvention()
+    {
+        using var ctx = LateTableMappingContext.Create(Substitute.For<IAmazonDynamoDB>());
+
+        FindProperty<IntPartitionKeyEntity>(ctx, nameof(IntPartitionKeyEntity.Id))
+            .ValueGenerated
+            .Should()
+            .Be(ValueGenerated.Never);
+    }
+
     private static IProperty FindProperty<TEntity>(DbContext context, string name)
         => context.Model.FindEntityType(typeof(TEntity))!.FindProperty(name)!;
 
@@ -261,5 +273,20 @@ public class DynamoValueGenerationConventionTests
 
         public static GuidNonKeyContext Create(IAmazonDynamoDB client)
             => new(BuildOptions<GuidNonKeyContext>(client));
+    }
+
+    private sealed class LateTableMappingContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<IntPartitionKeyEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<IntPartitionKeyEntity>(b =>
+            {
+                b.HasPartitionKey(x => x.Id);
+                b.ToTable("LateTableMappingTable");
+            });
+
+        public static LateTableMappingContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<LateTableMappingContext>(client));
     }
 }


### PR DESCRIPTION
## Summary

Adds a DynamoDB-specific value-generation convention so EF Core no longer marks numeric or string keys as generated by convention. This matches non-relational provider behavior: DynamoDB does not have identity columns, while Guid keys can continue using EF Core client-side generation.

## Changes

- Register `DynamoValueGenerationConvention` in the provider convention set.
- Keep `Guid` key generation via EF Core client-side defaults.
- Leave non-Guid keys application-assigned unless users explicitly configure generation.
- Add dedicated convention tests for `int` and `Guid` partition keys.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -- --filter-class '*DynamoKeyInPrimaryKeyConventionTests'`\n- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -- --filter-class '*DynamoValueGenerationConventionTests'`\n- `dotnet build --no-restore`\n\n## Notes for Reviewers\n\nThis mirrors Cosmos/Mongo-style non-relational provider conventions: suppress default integer key value generation and only preserve supported client-side generation patterns.