### PR TITLE
fix(query): apply property mappings to query values

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -48,6 +48,8 @@ See [Supported Operators](querying/operators.md) for the full list of what does 
 | Conditional skipping | `SkipWhile`, `TakeWhile`                                                     | Not supported                                                               |
 | Queryable `Contains` | `Queryable.Contains(source, item)`                                           | Not supported; in-memory `collection.Contains(property)` translates to `IN` |
 
+Value-converted enum numeric casts are also rejected when compared to parameters. For example, `(int)entity.Status == value` is not translated if `Status` uses `.HasConversion<string>()`, because DynamoDB stores the converted string value. Compare `entity.Status` to an enum value directly, or map the enum numerically.
+
 **Workaround for unsupported operators:** switch to `AsAsyncEnumerable()` before the unsupported
 operator to move evaluation in-process:
 

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -30,8 +30,8 @@ _This page is the authoritative reference for which LINQ operators translate to 
 
 ## Projection Operators
 
-| LINQ Operator | PartiQL Translation  | Notes                                                                  |
-| ------------- | -------------------- | ---------------------------------------------------------------------- |
+| LINQ Operator | PartiQL Translation  | Notes                                                                                                      |
+| ------------- | -------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `Select`      | Explicit column list | `SELECT *` is never emitted; computed expressions and nested complex-property shaping evaluate client-side |
 
 ## Ordering Operators
@@ -75,13 +75,13 @@ it needs to query DynamoDB.
 
 The following extension methods are unique to this provider and have no standard LINQ equivalent. They compose with the query before a terminal operator is called.
 
-| Extension              | Behavior                                                          | Notes                                                                                                                                          |
-| ---------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Limit(n)`             | Sets `ExecuteStatementRequest.Limit` — evaluation budget          | DynamoDB reads up to `n` items then applies filters; returned count is 0..n. Last call wins. See [Ordering and Limiting](ordering-limiting.md) |
-| `WithNextToken(token)` | Seeds the first request with a saved continuation cursor          | Resumes a previous query from a known position. See [Pagination](pagination.md)                                                                |
+| Extension              | Behavior                                                          | Notes                                                                                                                                                                                                                                                                          |
+| ---------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Limit(n)`             | Sets `ExecuteStatementRequest.Limit` — evaluation budget          | DynamoDB reads up to `n` items then applies filters; returned count is 0..n. Last call wins. See [Ordering and Limiting](ordering-limiting.md)                                                                                                                                 |
+| `WithNextToken(token)` | Seeds the first request with a saved continuation cursor          | Resumes a previous query from a known position. See [Pagination](pagination.md)                                                                                                                                                                                                |
 | `WithConsistentRead()` | Requests strongly consistent reads for this query                 | Sets `ExecuteStatementRequest.ConsistentRead = true` for base-table and LSI reads. Throws if the finalized source is a GSI because DynamoDB does not support strong consistency on GSIs. `WithConsistentRead(false)` explicitly uses eventually consistent reads for one query |
-| `WithIndex(name)`      | Routes the query to a named GSI or LSI                            | Emits `FROM "Table"."Index"` in PartiQL. See [Index Selection](index-selection.md)                                                             |
-| `WithoutIndex()`       | Forces base-table execution; suppresses automatic index selection | Emits diagnostic `DYNAMO_IDX006`. Cannot combine with `WithIndex(...)`                                                                         |
+| `WithIndex(name)`      | Routes the query to a named GSI or LSI                            | Emits `FROM "Table"."Index"` in PartiQL. See [Index Selection](index-selection.md)                                                                                                                                                                                             |
+| `WithoutIndex()`       | Forces base-table execution; suppresses automatic index selection | Emits diagnostic `DYNAMO_IDX006`. Cannot combine with `WithIndex(...)`                                                                                                                                                                                                         |
 
 ## Unsupported Operators
 
@@ -120,7 +120,7 @@ All scalar entity properties must map to a DynamoDB attribute type. Types withou
 | `TimeSpan`                              | `S`                     | Constant (`"c"`) format, e.g. `"01:30:00"`                  |
 | Enum                                    | `N`                     | Underlying numeric value (string names require a converter) |
 
-Nullable variants of all types above are supported. Numeric comparisons use DynamoDB's single `N` wire type, so C# numeric promotions such as `short` to `int` still bind as DynamoDB numbers. Custom types can be mapped using EF Core [value converters](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions); query parameters and constants use the property mapping so converters apply consistently.
+Nullable variants of all types above are supported. Numeric comparisons use DynamoDB's single `N` wire type, so promotions to `int`, such as `short` to `int`, still bind as DynamoDB numbers. Custom types can be mapped using EF Core [value converters](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions); query parameters and constants use the property mapping so converters apply consistently.
 
 ## See also
 

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -122,6 +122,8 @@ All scalar entity properties must map to a DynamoDB attribute type. Types withou
 
 Nullable variants of all types above are supported. Numeric comparisons use DynamoDB's single `N` wire type, so promotions to `int`, such as `short` to `int`, still bind as DynamoDB numbers. Custom types can be mapped using EF Core [value converters](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions); query parameters and constants use the property mapping so converters apply consistently.
 
+Value-converted enums compare using the converter provider type. For example, an enum mapped with `.HasConversion<string>()` binds parameters as DynamoDB strings. Numeric casts of value-converted enums, such as `(int)entity.Status == value`, are not translated for parameter comparisons because the DynamoDB attribute stores the converted provider value. Compare enum values directly, or map the enum numerically if numeric comparisons are required.
+
 ## See also
 
 - [How Queries Execute](how-queries-execute.md)

--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -104,22 +104,23 @@ The following operators are not supported and throw `InvalidOperationException` 
 
 All scalar entity properties must map to a DynamoDB attribute type. Types without a native wire representation use built-in EF Core value converters.
 
-| .NET Type                                   | DynamoDB Attribute Type | Wire Format                                                 |
-| ------------------------------------------- | ----------------------- | ----------------------------------------------------------- |
-| `string`                                    | `S`                     | —                                                           |
-| `bool`                                      | `BOOL`                  | —                                                           |
-| `int`, `long`, `float`, `double`, `decimal` | `N`                     | Numeric string                                              |
-| `ushort`, `uint`, `ulong`                   | `N`                     | Numeric string                                              |
-| `byte[]`                                    | `B`                     | Binary                                                      |
-| `Guid`                                      | `S`                     | `"D"` format, e.g. `"550e8400-e29b-41d4-a716-446655440000"` |
-| `DateTime`                                  | `S`                     | ISO 8601 round-trip (`"O"`)                                 |
-| `DateTimeOffset`                            | `S`                     | ISO 8601 round-trip (`"O"`)                                 |
-| `DateOnly`                                  | `S`                     | `"yyyy-MM-dd"`, e.g. `"2026-04-19"`                         |
-| `TimeOnly`                                  | `S`                     | `"HH:mm:ss"` (whole-second) or `"o"` (sub-second)           |
-| `TimeSpan`                                  | `S`                     | Constant (`"c"`) format, e.g. `"01:30:00"`                  |
-| Enum                                        | `N`                     | Underlying numeric value (string names require a converter) |
+| .NET Type                               | DynamoDB Attribute Type | Wire Format                                                 |
+| --------------------------------------- | ----------------------- | ----------------------------------------------------------- |
+| `string`                                | `S`                     | —                                                           |
+| `bool`                                  | `BOOL`                  | —                                                           |
+| `byte`, `sbyte`, `short`, `int`, `long` | `N`                     | Numeric string                                              |
+| `ushort`, `uint`, `ulong`               | `N`                     | Numeric string                                              |
+| `float`, `double`, `decimal`            | `N`                     | Numeric string                                              |
+| `byte[]`                                | `B`                     | Binary                                                      |
+| `Guid`                                  | `S`                     | `"D"` format, e.g. `"550e8400-e29b-41d4-a716-446655440000"` |
+| `DateTime`                              | `S`                     | ISO 8601 round-trip (`"O"`)                                 |
+| `DateTimeOffset`                        | `S`                     | ISO 8601 round-trip (`"O"`)                                 |
+| `DateOnly`                              | `S`                     | `"yyyy-MM-dd"`, e.g. `"2026-04-19"`                         |
+| `TimeOnly`                              | `S`                     | `"HH:mm:ss"` (whole-second) or `"o"` (sub-second)           |
+| `TimeSpan`                              | `S`                     | Constant (`"c"`) format, e.g. `"01:30:00"`                  |
+| Enum                                    | `N`                     | Underlying numeric value (string names require a converter) |
 
-Nullable variants of all types above are supported. Custom types can be mapped using EF Core [value converters](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions).
+Nullable variants of all types above are supported. Numeric comparisons use DynamoDB's single `N` wire type, so C# numeric promotions such as `short` to `int` still bind as DynamoDB numbers. Custom types can be mapped using EF Core [value converters](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions); query parameters and constants use the property mapping so converters apply consistently.
 
 ## See also
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
@@ -167,10 +167,13 @@ public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
     /// <inheritdoc />
     protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
     {
-        // Constants and parameters must go through the same mapping-owned serialization rules so
-        // inline literals and AttributeValue parameters stay behaviorally aligned.
+        // Use the runtime value type when available so promoted constants (short property vs int
+        // literal) serialize as DynamoDB N without trying to unbox int as short.
         if (sqlConstantExpression.TypeMapping is DynamoTypeMapping dynamoTypeMapping)
-            _sql.Append(dynamoTypeMapping.GenerateConstant(sqlConstantExpression.Value));
+            _sql.Append(
+                dynamoTypeMapping.GenerateConstant(
+                    sqlConstantExpression.Value,
+                    sqlConstantExpression.Value?.GetType() ?? sqlConstantExpression.Type));
         else
             // Fallback for cases without type mapping (shouldn't happen in normal usage)
             throw new InvalidOperationException(
@@ -190,7 +193,7 @@ public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
             throw new InvalidOperationException(
                 $"Parameter '{sqlParameterExpression.Name}' not found in parameter values.");
 
-        AppendParameter(value, sqlParameterExpression.TypeMapping);
+        AppendParameter(value, sqlParameterExpression.Type, sqlParameterExpression.TypeMapping);
 
         return sqlParameterExpression;
     }
@@ -510,7 +513,10 @@ public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
             if (count > 0)
                 _sql.Append(", ");
 
-            AppendParameter(value, sqlInExpression.Item.TypeMapping);
+            AppendParameter(
+                value,
+                value?.GetType() ?? sqlInExpression.Item.Type,
+                sqlInExpression.Item.TypeMapping);
             count++;
         }
 
@@ -579,13 +585,13 @@ public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
     }
 
     /// <summary>Appends a parameter placeholder and converted AttributeValue in lockstep.</summary>
-    private void AppendParameter(object? value, CoreTypeMapping? typeMapping)
+    private void AppendParameter(object? value, Type sourceType, CoreTypeMapping? typeMapping)
     {
         _sql.Append('?');
         _parameters.Add(
-            // Parameter conversion is model-value-facing; the mapping composes any EF converter and
-            // then serializes to the correct DynamoDB wire shape.
-            (typeMapping as DynamoTypeMapping)?.CreateAttributeValue(value)
+            // EF stores parameter values as object; sourceType lets the mapping unbox once and
+            // continue through a cached typed serializer.
+            (typeMapping as DynamoTypeMapping)?.CreateAttributeValue(value, sourceType)
             ?? throw new InvalidOperationException(
                 $"Query parameter requires a DynamoTypeMapping. Got: {typeMapping?.GetType().Name ?? "null"}"));
     }

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -315,10 +315,12 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
             if (rootEntityType?.FindProperty(node.Member.Name) is { } directProperty)
             {
                 var isPartitionKey = IsEffectivePartitionKey(directProperty, rootEntityType);
-                return sqlExpressionFactory.Property(
-                    directProperty.GetAttributeName(),
-                    node.Type,
-                    isPartitionKey);
+                return sqlExpressionFactory.ApplyTypeMapping(
+                    sqlExpressionFactory.Property(
+                        directProperty.GetAttributeName(),
+                        node.Type,
+                        isPartitionKey),
+                    directProperty.GetTypeMapping());
             }
 
             // When entity type is known but FindProperty returned null the member is a non-scalar
@@ -373,7 +375,9 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
                 var attributeName = property.GetAttributeName();
                 var typeMapping = property.GetTypeMapping();
                 return sqlExpr == null
-                    ? sqlExpressionFactory.Property(attributeName, leafType)
+                    ? sqlExpressionFactory.ApplyTypeMapping(
+                        sqlExpressionFactory.Property(attributeName, leafType),
+                        typeMapping)
                     : new DynamoScalarAccessExpression(
                         sqlExpr,
                         attributeName,
@@ -504,10 +508,12 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
                 if (rootEntityType.FindProperty(propertyName) is { } rootProperty)
                 {
                     var isPartitionKey = IsEffectivePartitionKey(rootProperty, rootEntityType);
-                    return sqlExpressionFactory.Property(
-                        rootProperty.GetAttributeName(),
-                        node.Type,
-                        isPartitionKey);
+                    return sqlExpressionFactory.ApplyTypeMapping(
+                        sqlExpressionFactory.Property(
+                            rootProperty.GetAttributeName(),
+                            node.Type,
+                            isPartitionKey),
+                        rootProperty.GetTypeMapping());
                 }
 
                 AddTranslationErrorDetails(DynamoStrings.MemberAccessNotSupported);
@@ -589,7 +595,12 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
                 return QueryCompilationContext.NotTranslatedExpression;
 
             if (operand is SqlExpression sqlOperand)
+            {
+                if (IsImplicitClrConvert(node.Operand.Type, node.Type))
+                    return sqlOperand;
+
                 return sqlExpressionFactory.ApplyTypeMapping(sqlOperand, node.Type);
+            }
 
             return QueryCompilationContext.NotTranslatedExpression;
         }
@@ -613,6 +624,32 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
 
         AddTranslationErrorDetails(DynamoStrings.UnaryOperatorNotSupported);
         return QueryCompilationContext.NotTranslatedExpression;
+    }
+
+    private static bool IsImplicitClrConvert(Type sourceType, Type targetType)
+    {
+        if (sourceType == targetType)
+            return true;
+
+        var sourceUnderlyingType = Nullable.GetUnderlyingType(sourceType) ?? sourceType;
+        var targetUnderlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        var sourceNullable = sourceType != sourceUnderlyingType;
+        var targetNullable = targetType != targetUnderlyingType;
+
+        if (sourceNullable != targetNullable)
+            return false;
+
+        if (sourceUnderlyingType.IsEnum
+            && Enum.GetUnderlyingType(sourceUnderlyingType) == targetUnderlyingType)
+            return true;
+
+        return targetUnderlyingType == typeof(int)
+            && sourceUnderlyingType is { } source
+            && (source == typeof(byte)
+                || source == typeof(sbyte)
+                || source == typeof(short)
+                || source == typeof(ushort)
+                || source == typeof(char));
     }
 
     /// <summary>Translates EF.Functions IS NULL/MISSING extension methods to SQL IS predicates.</summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoSqlTranslatingExpressionVisitor.cs
@@ -531,7 +531,7 @@ public sealed class DynamoSqlTranslatingExpressionVisitor(
     }
 
     /// <summary>
-    ///     Returns  when <paramref name="property" /> is the effective
+    ///     Returns true when <paramref name="property" /> is the effective
     ///     partition key for the current query — either the table partition key, or the partition key of
     ///     the active secondary index when <c>.WithIndex()</c> has been applied.
     /// </summary>

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoStrings.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoStrings.cs
@@ -35,6 +35,10 @@ internal static class DynamoStrings
     public const string CastNotSupported =
         "DynamoDB PartiQL does not support CAST in query translation.";
 
+    /// <summary>Error message for value-converted enum casts to the numeric underlying type.</summary>
+    public const string ConvertedEnumUnderlyingCastNotSupported =
+        "Casting a value-converted enum to its numeric underlying type is not supported because DynamoDB stores the converter provider type. Compare enum values directly or map the enum numerically.";
+
     /// <summary>Error message for unsupported Last/LastOrDefault.</summary>
     public const string LastNotSupported =
         "Last/LastOrDefault is not supported in this iteration. Reverse traversal "

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoScalarAccessExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoScalarAccessExpression.cs
@@ -33,9 +33,13 @@ public sealed class DynamoScalarAccessExpression(
             : new DynamoScalarAccessExpression(visitedParent, PropertyName, Type, TypeMapping);
     }
 
+    /// <summary>Creates a new scalar access expression with the specified type mapping.</summary>
+    public DynamoScalarAccessExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
+        => new(Parent, PropertyName, Type, typeMapping);
+
     /// <inheritdoc />
     protected override SqlExpression WithTypeMapping(CoreTypeMapping? typeMapping)
-        => new DynamoScalarAccessExpression(Parent, PropertyName, Type, typeMapping);
+        => ApplyTypeMapping(typeMapping);
 
     /// <inheritdoc />
     public override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoScalarAccessExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/Expressions/DynamoScalarAccessExpression.cs
@@ -34,6 +34,8 @@ public sealed class DynamoScalarAccessExpression(
     }
 
     /// <summary>Creates a new scalar access expression with the specified type mapping.</summary>
+    /// <param name="typeMapping">The type mapping to apply.</param>
+    /// <returns>A scalar access expression with the specified type mapping.</returns>
     public DynamoScalarAccessExpression ApplyTypeMapping(CoreTypeMapping? typeMapping)
         => new(Parent, PropertyName, Type, typeMapping);
 

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
@@ -56,7 +56,12 @@ public interface ISqlExpressionFactory
     SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, Type type);
 
     /// <summary>Applies an exact type mapping to an existing SQL expression.</summary>
-    SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping);
+    /// <param name="sqlExpression">The SQL expression to map.</param>
+    /// <param name="typeMapping">The exact type mapping to apply.</param>
+    /// <returns>The mapped SQL expression.</returns>
+    SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping)
+        => throw new NotSupportedException(
+            "Exact type mapping is not supported by this SQL expression factory.");
 
     /// <summary>Creates a SQL NOT expression that negates the given boolean operand.</summary>
     SqlUnaryExpression Not(SqlExpression operand);

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using EntityFrameworkCore.DynamoDb.Query.Internal.Expressions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 
@@ -53,6 +54,9 @@ public interface ISqlExpressionFactory
     /// Applies a type mapping to an existing SQL expression.
     /// </summary>
     SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, Type type);
+
+    /// <summary>Applies an exact type mapping to an existing SQL expression.</summary>
+    SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping);
 
     /// <summary>Creates a SQL NOT expression that negates the given boolean operand.</summary>
     SqlUnaryExpression Not(SqlExpression operand);

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/ISqlExpressionFactory.cs
@@ -59,9 +59,7 @@ public interface ISqlExpressionFactory
     /// <param name="sqlExpression">The SQL expression to map.</param>
     /// <param name="typeMapping">The exact type mapping to apply.</param>
     /// <returns>The mapped SQL expression.</returns>
-    SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping)
-        => throw new NotSupportedException(
-            "Exact type mapping is not supported by this SQL expression factory.");
+    SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping);
 
     /// <summary>Creates a SQL NOT expression that negates the given boolean operand.</summary>
     SqlUnaryExpression Not(SqlExpression operand);

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -16,7 +16,6 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         SqlExpression left,
         SqlExpression right)
     {
-        // Determine the result type based on the operator
         var resultType = operatorType switch
         {
             ExpressionType.Equal
@@ -30,13 +29,23 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
             _ => left.Type,
         };
 
-        // Apply type mapping to operands if needed
-        var typeMapping = left.TypeMapping ?? right.TypeMapping;
-        if (typeMapping == null
-            && operatorType is not (ExpressionType.AndAlso or ExpressionType.OrElse))
-            typeMapping = typeMappingSource.FindMapping(left.Type);
+        var isLogical = operatorType is ExpressionType.AndAlso or ExpressionType.OrElse;
+        var operandTypeMapping =
+            isLogical ? typeMappingSource.FindMapping(typeof(bool)) : InferTypeMapping(left, right);
+        if (operandTypeMapping == null && !isLogical)
+            operandTypeMapping = typeMappingSource.FindMapping(left.Type);
 
-        return new SqlBinaryExpression(operatorType, left, right, resultType, typeMapping);
+        if (operandTypeMapping != null)
+        {
+            left = ApplyTypeMapping(left, operandTypeMapping);
+            right = ApplyTypeMapping(right, operandTypeMapping);
+        }
+
+        var resultTypeMapping = resultType == typeof(bool)
+            ? typeMappingSource.FindMapping(typeof(bool))
+            : operandTypeMapping;
+
+        return new SqlBinaryExpression(operatorType, left, right, resultType, resultTypeMapping);
     }
 
     /// <inheritdoc />
@@ -72,7 +81,17 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
     {
         SqlInExpression.ValidateValueSource(values, null);
         var mappedItem = ApplyDefaultTypeMapping(item);
-        return new SqlInExpression(mappedItem, values, null, isPartitionKeyComparison, null);
+        var itemTypeMapping = mappedItem.TypeMapping;
+        var mappedValues = itemTypeMapping == null
+            ? values
+            : values.Select(value => ApplyTypeMapping(value, itemTypeMapping)).ToArray();
+
+        return new SqlInExpression(
+            mappedItem,
+            mappedValues,
+            null,
+            isPartitionKeyComparison,
+            typeMappingSource.FindMapping(typeof(bool)));
     }
 
     /// <inheritdoc />
@@ -88,7 +107,7 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
             null,
             valuesParameter,
             isPartitionKeyComparison,
-            null);
+            typeMappingSource.FindMapping(typeof(bool)));
     }
 
     /// <inheritdoc />
@@ -121,20 +140,48 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         SqlExpression subject,
         SqlExpression low,
         SqlExpression high)
-        => new(subject, low, high);
+    {
+        var typeMapping = InferTypeMapping(subject, low, high)
+            ?? typeMappingSource.FindMapping(subject.Type);
+
+        if (typeMapping != null)
+        {
+            subject = ApplyTypeMapping(subject, typeMapping);
+            low = ApplyTypeMapping(low, typeMapping);
+            high = ApplyTypeMapping(high, typeMapping);
+        }
+
+        return new SqlBetweenExpression(subject, low, high);
+    }
+
+    private static CoreTypeMapping? InferTypeMapping(params SqlExpression[] expressions)
+    {
+        foreach (var expression in expressions)
+            if (expression is not SqlConstantExpression and not SqlParameterExpression
+                && expression.TypeMapping is { } typeMapping)
+                return typeMapping;
+
+        foreach (var expression in expressions)
+            if (expression.TypeMapping is { } typeMapping)
+                return typeMapping;
+
+        return null;
+    }
 
     /// <inheritdoc />
     public SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, Type type)
-    {
-        var typeMapping = typeMappingSource.FindMapping(type);
-        return sqlExpression switch
+        => ApplyTypeMapping(sqlExpression, typeMappingSource.FindMapping(type));
+
+    /// <inheritdoc />
+    public SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping)
+        => sqlExpression switch
         {
             SqlConstantExpression constant => constant.ApplyTypeMapping(typeMapping),
             SqlParameterExpression parameter => parameter.ApplyTypeMapping(typeMapping),
             SqlPropertyExpression property => property.ApplyTypeMapping(typeMapping),
+            DynamoScalarAccessExpression scalarAccess => scalarAccess.ApplyTypeMapping(typeMapping),
             _ => sqlExpression,
         };
-    }
 
     /// <inheritdoc />
     public SqlExpression ApplyDefaultTypeMapping(SqlExpression sqlExpression)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -30,9 +30,15 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         };
 
         var isLogical = operatorType is ExpressionType.AndAlso or ExpressionType.OrElse;
+        // A string-converted enum compared to an int parameter would bind the parameter as N
+        // against an S attribute. Reject that shape instead of silently producing no matches.
+        if (!isLogical && IsConvertedEnumComparedToUnderlyingNumber(left, right))
+            throw new InvalidOperationException(
+                DynamoStrings.ConvertedEnumUnderlyingCastNotSupported);
+
         var operandTypeMapping = isLogical
             ? typeMappingSource.FindMapping(typeof(bool))
-            : InferEnumUnderlyingCastMapping(left, right) ?? InferTypeMapping(left, right);
+            : InferTypeMapping(left, right);
         if (operandTypeMapping == null && !isLogical)
             operandTypeMapping = typeMappingSource.FindMapping(left.Type);
 
@@ -166,25 +172,26 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         return new SqlBetweenExpression(subject, low, high);
     }
 
-    private CoreTypeMapping? InferEnumUnderlyingCastMapping(SqlExpression left, SqlExpression right)
-        => InferEnumUnderlyingCastMappingFrom(left, right)
-            ?? InferEnumUnderlyingCastMappingFrom(right, left);
+    private static bool IsConvertedEnumComparedToUnderlyingNumber(
+        SqlExpression left,
+        SqlExpression right)
+        => IsConvertedEnumComparedToUnderlyingNumberFrom(left, right)
+            || IsConvertedEnumComparedToUnderlyingNumberFrom(right, left);
 
-    private CoreTypeMapping? InferEnumUnderlyingCastMappingFrom(
-        SqlExpression convertedEnumExpression,
+    private static bool IsConvertedEnumComparedToUnderlyingNumberFrom(
+        SqlExpression enumExpression,
         SqlExpression otherExpression)
     {
-        var enumType = Nullable.GetUnderlyingType(convertedEnumExpression.Type)
-            ?? convertedEnumExpression.Type;
-        if (otherExpression is SqlConstantExpression
-            || !enumType.IsEnum
-            || convertedEnumExpression.TypeMapping?.Converter == null)
-            return null;
+        var enumType = Nullable.GetUnderlyingType(enumExpression.Type) ?? enumExpression.Type;
+        if (!enumType.IsEnum || enumExpression.TypeMapping?.Converter == null)
+            return false;
 
         var otherType = Nullable.GetUnderlyingType(otherExpression.Type) ?? otherExpression.Type;
-        return Enum.GetUnderlyingType(enumType) == otherType
-            ? otherExpression.TypeMapping ?? typeMappingSource.FindMapping(otherExpression.Type)
-            : null;
+        // Constants like e.Status == Status.Active are typed as the enum in C# but appear with an
+        // underlying value in expression trees; property mapping still makes those safe. The unsafe
+        // case is parameter comparison after an explicit numeric cast.
+        return otherExpression is SqlParameterExpression
+            && otherType == Enum.GetUnderlyingType(enumType);
     }
 
     private static CoreTypeMapping? InferTypeMapping(SqlExpression first, SqlExpression second)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -203,10 +203,17 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         if (nonNullableType.IsArray)
             return nonNullableType.GetElementType()!;
 
-        return nonNullableType.IsGenericType
-            && nonNullableType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                ? nonNullableType.GetGenericArguments()[0]
-                : nonNullableType;
+        if (nonNullableType.IsGenericType
+            && nonNullableType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            return nonNullableType.GetGenericArguments()[0];
+
+        var enumerableInterface =
+            nonNullableType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType
+                    && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        return enumerableInterface?.GetGenericArguments()[0] ?? nonNullableType;
     }
 
     private static CoreTypeMapping? InferTypeMapping(SqlExpression first, SqlExpression second)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -30,8 +30,9 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         };
 
         var isLogical = operatorType is ExpressionType.AndAlso or ExpressionType.OrElse;
-        var operandTypeMapping =
-            isLogical ? typeMappingSource.FindMapping(typeof(bool)) : InferTypeMapping(left, right);
+        var operandTypeMapping = isLogical
+            ? typeMappingSource.FindMapping(typeof(bool))
+            : InferEnumUnderlyingCastMapping(left, right) ?? InferTypeMapping(left, right);
         if (operandTypeMapping == null && !isLogical)
             operandTypeMapping = typeMappingSource.FindMapping(left.Type);
 
@@ -82,9 +83,20 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         SqlInExpression.ValidateValueSource(values, null);
         var mappedItem = ApplyDefaultTypeMapping(item);
         var itemTypeMapping = mappedItem.TypeMapping;
-        var mappedValues = itemTypeMapping == null
-            ? values
-            : values.Select(value => ApplyTypeMapping(value, itemTypeMapping)).ToArray();
+        var mappedValues = values;
+        if (itemTypeMapping != null)
+        {
+            var remappedValues = new SqlExpression[values.Count];
+            var changed = false;
+            for (var i = 0; i < values.Count; i++)
+            {
+                remappedValues[i] = ApplyTypeMapping(values[i], itemTypeMapping);
+                changed |= !ReferenceEquals(remappedValues[i], values[i]);
+            }
+
+            if (changed)
+                mappedValues = remappedValues;
+        }
 
         return new SqlInExpression(
             mappedItem,
@@ -154,19 +166,44 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         return new SqlBetweenExpression(subject, low, high);
     }
 
-    private static CoreTypeMapping? InferTypeMapping(params SqlExpression[] expressions)
+    private CoreTypeMapping? InferEnumUnderlyingCastMapping(SqlExpression left, SqlExpression right)
+        => InferEnumUnderlyingCastMappingFrom(left, right)
+            ?? InferEnumUnderlyingCastMappingFrom(right, left);
+
+    private CoreTypeMapping? InferEnumUnderlyingCastMappingFrom(
+        SqlExpression convertedEnumExpression,
+        SqlExpression otherExpression)
     {
-        foreach (var expression in expressions)
-            if (expression is not SqlConstantExpression and not SqlParameterExpression
-                && expression.TypeMapping is { } typeMapping)
-                return typeMapping;
+        var enumType = Nullable.GetUnderlyingType(convertedEnumExpression.Type)
+            ?? convertedEnumExpression.Type;
+        if (otherExpression is SqlConstantExpression
+            || !enumType.IsEnum
+            || convertedEnumExpression.TypeMapping?.Converter == null)
+            return null;
 
-        foreach (var expression in expressions)
-            if (expression.TypeMapping is { } typeMapping)
-                return typeMapping;
-
-        return null;
+        var otherType = Nullable.GetUnderlyingType(otherExpression.Type) ?? otherExpression.Type;
+        return Enum.GetUnderlyingType(enumType) == otherType
+            ? otherExpression.TypeMapping ?? typeMappingSource.FindMapping(otherExpression.Type)
+            : null;
     }
+
+    private static CoreTypeMapping? InferTypeMapping(SqlExpression first, SqlExpression second)
+        => PreferNonValueMapping(first)
+            ?? PreferNonValueMapping(second) ?? first.TypeMapping ?? second.TypeMapping;
+
+    private static CoreTypeMapping? InferTypeMapping(
+        SqlExpression first,
+        SqlExpression second,
+        SqlExpression third)
+        => PreferNonValueMapping(first)
+            ?? PreferNonValueMapping(second)
+            ?? PreferNonValueMapping(third)
+            ?? first.TypeMapping ?? second.TypeMapping ?? third.TypeMapping;
+
+    private static CoreTypeMapping? PreferNonValueMapping(SqlExpression expression)
+        => expression is not SqlConstantExpression and not SqlParameterExpression
+            ? expression.TypeMapping
+            : null;
 
     /// <inheritdoc />
     public SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, Type type)
@@ -174,7 +211,11 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
 
     /// <inheritdoc />
     public SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, CoreTypeMapping? typeMapping)
-        => sqlExpression switch
+    {
+        if (ReferenceEquals(sqlExpression.TypeMapping, typeMapping))
+            return sqlExpression;
+
+        return sqlExpression switch
         {
             SqlConstantExpression constant => constant.ApplyTypeMapping(typeMapping),
             SqlParameterExpression parameter => parameter.ApplyTypeMapping(typeMapping),
@@ -182,6 +223,7 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
             DynamoScalarAccessExpression scalarAccess => scalarAccess.ApplyTypeMapping(typeMapping),
             _ => sqlExpression,
         };
+    }
 
     /// <inheritdoc />
     public SqlExpression ApplyDefaultTypeMapping(SqlExpression sqlExpression)

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/SqlExpressionFactory.cs
@@ -30,11 +30,10 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         };
 
         var isLogical = operatorType is ExpressionType.AndAlso or ExpressionType.OrElse;
-        // A string-converted enum compared to an int parameter would bind the parameter as N
+        // A string-converted enum compared to its underlying numeric value would bind the value
         // against an S attribute. Reject that shape instead of silently producing no matches.
-        if (!isLogical && IsConvertedEnumComparedToUnderlyingNumber(left, right))
-            throw new InvalidOperationException(
-                DynamoStrings.ConvertedEnumUnderlyingCastNotSupported);
+        if (!isLogical)
+            ThrowIfConvertedEnumComparedToUnderlyingNumber(left, right);
 
         var operandTypeMapping = isLogical
             ? typeMappingSource.FindMapping(typeof(bool))
@@ -96,6 +95,7 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
             var changed = false;
             for (var i = 0; i < values.Count; i++)
             {
+                ThrowIfConvertedEnumComparedToUnderlyingNumber(mappedItem, values[i]);
                 remappedValues[i] = ApplyTypeMapping(values[i], itemTypeMapping);
                 changed |= !ReferenceEquals(remappedValues[i], values[i]);
             }
@@ -120,6 +120,7 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
     {
         SqlInExpression.ValidateValueSource(null, valuesParameter);
         var mappedItem = ApplyDefaultTypeMapping(item);
+        ThrowIfConvertedEnumComparedToUnderlyingNumber(mappedItem, valuesParameter);
         return new SqlInExpression(
             mappedItem,
             null,
@@ -164,6 +165,8 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
 
         if (typeMapping != null)
         {
+            ThrowIfConvertedEnumComparedToUnderlyingNumber(subject, low);
+            ThrowIfConvertedEnumComparedToUnderlyingNumber(subject, high);
             subject = ApplyTypeMapping(subject, typeMapping);
             low = ApplyTypeMapping(low, typeMapping);
             high = ApplyTypeMapping(high, typeMapping);
@@ -172,11 +175,15 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         return new SqlBetweenExpression(subject, low, high);
     }
 
-    private static bool IsConvertedEnumComparedToUnderlyingNumber(
+    private static void ThrowIfConvertedEnumComparedToUnderlyingNumber(
         SqlExpression left,
         SqlExpression right)
-        => IsConvertedEnumComparedToUnderlyingNumberFrom(left, right)
-            || IsConvertedEnumComparedToUnderlyingNumberFrom(right, left);
+    {
+        if (IsConvertedEnumComparedToUnderlyingNumberFrom(left, right)
+            || IsConvertedEnumComparedToUnderlyingNumberFrom(right, left))
+            throw new InvalidOperationException(
+                DynamoStrings.ConvertedEnumUnderlyingCastNotSupported);
+    }
 
     private static bool IsConvertedEnumComparedToUnderlyingNumberFrom(
         SqlExpression enumExpression,
@@ -186,12 +193,20 @@ public sealed class SqlExpressionFactory(ITypeMappingSource typeMappingSource)
         if (!enumType.IsEnum || enumExpression.TypeMapping?.Converter == null)
             return false;
 
-        var otherType = Nullable.GetUnderlyingType(otherExpression.Type) ?? otherExpression.Type;
-        // Constants like e.Status == Status.Active are typed as the enum in C# but appear with an
-        // underlying value in expression trees; property mapping still makes those safe. The unsafe
-        // case is parameter comparison after an explicit numeric cast.
         return otherExpression is SqlParameterExpression
-            && otherType == Enum.GetUnderlyingType(enumType);
+            && GetValueOrElementType(otherExpression.Type) == Enum.GetUnderlyingType(enumType);
+    }
+
+    private static Type GetValueOrElementType(Type type)
+    {
+        var nonNullableType = Nullable.GetUnderlyingType(type) ?? type;
+        if (nonNullableType.IsArray)
+            return nonNullableType.GetElementType()!;
+
+        return nonNullableType.IsGenericType
+            && nonNullableType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                ? nonNullableType.GetGenericArguments()[0]
+                : nonNullableType;
     }
 
     private static CoreTypeMapping? InferTypeMapping(SqlExpression first, SqlExpression second)

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Storage.Internal;
@@ -104,6 +105,11 @@ public class DynamoTypeMapping : CoreTypeMapping
         if (value == null)
             return new AttributeValue { NULL = true };
 
+        if (TryFormatUnconvertedNumeric(value, out var numericValue))
+            return new AttributeValue { N = numericValue };
+
+        ValidateRuntimeValue(value);
+
         return _untypedValueWriter?.Write(value)
             ?? throw new NotSupportedException(
                 $"CLR type '{ClrType.Name}' is not supported for DynamoDB AttributeValue serialization.");
@@ -126,9 +132,115 @@ public class DynamoTypeMapping : CoreTypeMapping
     ///     the cached typed adapter in the mapping-owned codec pipeline.
     /// </remarks>
     protected virtual string GenerateNonNullConstant(object value)
-        => _untypedValueWriter?.ToPartiQlLiteral(value)
+    {
+        if (TryFormatUnconvertedNumeric(value, out var numericValue))
+            return numericValue;
+
+        ValidateRuntimeValue(value);
+
+        return _untypedValueWriter?.ToPartiQlLiteral(value)
             ?? throw new NotSupportedException(
                 $"CLR type '{ClrType.Name}' is not supported for PartiQL constant generation.");
+    }
+
+    private void ValidateRuntimeValue(object value)
+    {
+        var expectedType = ClrType;
+        var expectedNonNullableType = Nullable.GetUnderlyingType(expectedType) ?? expectedType;
+        var valueType = value.GetType();
+
+        if (expectedType == typeof(object)
+            || expectedType.IsAssignableFrom(valueType)
+            || expectedNonNullableType.IsAssignableFrom(valueType))
+            return;
+
+        throw new InvalidOperationException(
+            $"DynamoDB type mapping for CLR type '{ClrType.Name}' cannot serialize runtime "
+            + $"value of type '{valueType.Name}'. This usually means query type-mapping "
+            + "inference applied an incompatible mapping to a parameter or constant.");
+    }
+
+    private bool TryFormatUnconvertedNumeric(object value, out string formatted)
+    {
+        formatted = null!;
+
+        if (Parameters.Converter != null)
+            return false;
+
+        var mappingType = Nullable.GetUnderlyingType(ClrType) ?? ClrType;
+        var valueType = value.GetType();
+        if (valueType == mappingType || !IsNumericType(mappingType) || !IsNumericType(valueType))
+            return false;
+
+        if (valueType.IsEnum)
+        {
+            formatted = FormatEnum(value);
+            return true;
+        }
+
+        formatted = value switch
+        {
+            byte numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            sbyte numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            short numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            ushort numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            int numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            uint numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            long numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            ulong numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            float numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
+            double numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
+            decimal numeric => numeric.ToString(CultureInfo.InvariantCulture),
+            _ => null!,
+        };
+
+        return formatted != null;
+    }
+
+    private static string FormatEnum(object value)
+        => Type.GetTypeCode(Enum.GetUnderlyingType(value.GetType())) switch
+        {
+            TypeCode.Byte => Convert
+                .ToByte(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.SByte => Convert
+                .ToSByte(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int16 => Convert
+                .ToInt16(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt16 => Convert
+                .ToUInt16(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int32 => Convert
+                .ToInt32(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt32 => Convert
+                .ToUInt32(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int64 => Convert
+                .ToInt64(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt64 => Convert
+                .ToUInt64(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            _ => throw new InvalidOperationException(
+                $"Enum type '{value.GetType().Name}' has an unsupported underlying type."),
+        };
+
+    private static bool IsNumericType(Type type)
+        => type.IsEnum
+            || type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal);
 
     private static DynamoValueReaderWriter? CreateReaderWriter(CoreTypeMappingParameters parameters)
     {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using Amazon.DynamoDBv2.Model;
@@ -25,7 +26,7 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 ///         property via model builder is ignored by this provider.
 ///     </para>
 ///     <para>
-///         Literal generation uses <see cref="GenerateConstant" /> rather than
+///         Literal generation uses <see cref="GenerateConstant(object?)" /> rather than
 ///         <c>RelationalTypeMapping.GenerateSqlLiteral</c>. The latter is relational-only and
 ///         is neither inherited by <see cref="Microsoft.EntityFrameworkCore.Storage.CoreTypeMapping" />
 ///         subclasses nor auto-invoked by EF Core infrastructure for non-relational providers.
@@ -96,26 +97,21 @@ public class DynamoTypeMapping : CoreTypeMapping
 
     /// <summary>Serializes a model CLR value to an <see cref="AttributeValue" />.</summary>
     /// <remarks>
-    ///     EF exposes runtime values to mappings as <see cref="object" />. This is the unavoidable
-    ///     untyped provider boundary; the cast happens in the cached adapter and the typed codec
-    ///     pipeline resumes immediately after that handoff.
+    ///     EF exposes runtime query values to mappings as <see cref="object" />. The runtime value
+    ///     serializer is the narrow adapter back into typed expression-based conversion.
     /// </remarks>
     internal virtual AttributeValue CreateAttributeValue(object? value)
-    {
-        if (value == null)
-            return new AttributeValue { NULL = true };
+        => DynamoRuntimeValueSerializer.CreateAttributeValue(this, value);
 
-        value = NormalizeRuntimeValue(value);
+    /// <summary>Serializes a value whose runtime/source CLR type is already known.</summary>
+    internal virtual AttributeValue CreateAttributeValue(object? value, Type sourceType)
+        => DynamoRuntimeValueSerializer.CreateAttributeValue(this, value, sourceType);
 
-        if (TryFormatUnconvertedNumeric(value, out var numericValue))
-            return new AttributeValue { N = numericValue };
-
-        ValidateRuntimeValue(value);
-
-        return _untypedValueWriter?.Write(value)
+    /// <summary>Builds the typed expression used by cached query/runtime serializers.</summary>
+    internal virtual Expression CreateAttributeValueExpression(Expression valueExpression)
+        => ReaderWriter?.CreateWriteExpression(valueExpression)
             ?? throw new NotSupportedException(
                 $"CLR type '{ClrType.Name}' is not supported for DynamoDB AttributeValue serialization.");
-    }
 
     /// <summary>Generates a PartiQL literal for a constant value.</summary>
     /// <remarks>
@@ -125,7 +121,17 @@ public class DynamoTypeMapping : CoreTypeMapping
     ///     <see cref="GenerateNonNullConstant" /> rather than this method.
     /// </remarks>
     public virtual string GenerateConstant(object? value)
-        => value == null ? "NULL" : GenerateNonNullConstant(value);
+        => DynamoRuntimeValueSerializer.GenerateLiteral(this, value);
+
+    /// <summary>Generates a PartiQL literal for a value whose runtime/source CLR type is known.</summary>
+    internal virtual string GenerateConstant(object? value, Type sourceType)
+        => DynamoRuntimeValueSerializer.GenerateLiteral(this, value, sourceType);
+
+    /// <summary>Builds the typed expression used by cached PartiQL literal serializers.</summary>
+    internal virtual Expression CreatePartiQlLiteralExpression(Expression valueExpression)
+        => ReaderWriter?.CreatePartiQlLiteralExpression(valueExpression)
+            ?? throw new NotSupportedException(
+                $"CLR type '{ClrType.Name}' is not supported for PartiQL constant generation.");
 
     /// <summary>Generates a PartiQL literal for a known non-null value.</summary>
     /// <remarks>
@@ -179,9 +185,11 @@ public class DynamoTypeMapping : CoreTypeMapping
             + "inference applied an incompatible mapping to a parameter or constant.");
     }
 
-    private bool TryFormatUnconvertedNumeric(object value, out string formatted)
+    private bool TryFormatUnconvertedNumeric(
+        object value,
+        [NotNullWhen(true)] out string? formatted)
     {
-        formatted = null!;
+        formatted = null;
 
         if (Parameters.Converter != null)
             return false;
@@ -210,7 +218,7 @@ public class DynamoTypeMapping : CoreTypeMapping
             float numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
             double numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
             decimal numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            _ => null!,
+            _ => null,
         };
 
         return formatted != null;

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
@@ -105,6 +105,8 @@ public class DynamoTypeMapping : CoreTypeMapping
         if (value == null)
             return new AttributeValue { NULL = true };
 
+        value = NormalizeRuntimeValue(value);
+
         if (TryFormatUnconvertedNumeric(value, out var numericValue))
             return new AttributeValue { N = numericValue };
 
@@ -133,6 +135,8 @@ public class DynamoTypeMapping : CoreTypeMapping
     /// </remarks>
     protected virtual string GenerateNonNullConstant(object value)
     {
+        value = NormalizeRuntimeValue(value);
+
         if (TryFormatUnconvertedNumeric(value, out var numericValue))
             return numericValue;
 
@@ -141,6 +145,21 @@ public class DynamoTypeMapping : CoreTypeMapping
         return _untypedValueWriter?.ToPartiQlLiteral(value)
             ?? throw new NotSupportedException(
                 $"CLR type '{ClrType.Name}' is not supported for PartiQL constant generation.");
+    }
+
+    private object NormalizeRuntimeValue(object value)
+    {
+        var expectedNonNullableType = Nullable.GetUnderlyingType(ClrType) ?? ClrType;
+        if (!expectedNonNullableType.IsEnum || value.GetType() == expectedNonNullableType)
+            return value;
+
+        var underlyingType = Enum.GetUnderlyingType(expectedNonNullableType);
+        var valueType = value.GetType();
+        if (valueType != underlyingType
+            && !CanRepresentEnumUnderlyingType(valueType, underlyingType))
+            return value;
+
+        return Enum.ToObject(expectedNonNullableType, value);
     }
 
     private void ValidateRuntimeValue(object value)
@@ -197,6 +216,9 @@ public class DynamoTypeMapping : CoreTypeMapping
         return formatted != null;
     }
 
+    private static bool CanRepresentEnumUnderlyingType(Type valueType, Type underlyingType)
+        => IsIntegralType(valueType) && IsIntegralType(underlyingType);
+
     private static string FormatEnum(object value)
         => Type.GetTypeCode(Enum.GetUnderlyingType(value.GetType())) switch
         {
@@ -227,6 +249,16 @@ public class DynamoTypeMapping : CoreTypeMapping
             _ => throw new InvalidOperationException(
                 $"Enum type '{value.GetType().Name}' has an unsupported underlying type."),
         };
+
+    private static bool IsIntegralType(Type type)
+        => type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong);
 
     private static bool IsNumericType(Type type)
         => type.IsEnum

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
@@ -1,6 +1,4 @@
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq.Expressions;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Storage.Internal;
@@ -37,7 +35,6 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 public class DynamoTypeMapping : CoreTypeMapping
 {
     internal DynamoValueReaderWriter? ReaderWriter { get; }
-    private readonly IDynamoUntypedValueWriter? _untypedValueWriter;
 
     private readonly ConcurrentDictionary<Type, Func<object?, AttributeValue>>
         _attributeValueSerializers = new();
@@ -52,18 +49,12 @@ public class DynamoTypeMapping : CoreTypeMapping
         new CoreTypeMappingParameters(clrType, null, comparer, keyComparer))
     {
         ReaderWriter = CreateReaderWriter(Parameters);
-        // Cache the untyped adapter once per mapping; EF reaches us with object values, but the
-        // typed codec pipeline resumes immediately behind this boundary.
-        _untypedValueWriter = ReaderWriter?.CreateUntypedValueWriter();
     }
 
     /// <summary>Creates a mapping from a fully-specified EF Core mapping parameter set.</summary>
     protected DynamoTypeMapping(CoreTypeMappingParameters parameters) : base(parameters)
     {
         ReaderWriter = CreateReaderWriter(parameters);
-        // Cache the untyped adapter once per mapping; EF reaches us with object values, but the
-        // typed codec pipeline resumes immediately behind this boundary.
-        _untypedValueWriter = ReaderWriter?.CreateUntypedValueWriter();
     }
 
     /// <summary>Clones the mapping with updated parameters.</summary>
@@ -107,14 +98,11 @@ public class DynamoTypeMapping : CoreTypeMapping
     ///     serializer is the narrow adapter back into typed expression-based conversion.
     /// </remarks>
     internal virtual AttributeValue CreateAttributeValue(object? value)
-        => DynamoRuntimeValueSerializer.CreateAttributeValue(
-            this,
-            _attributeValueSerializers,
-            value);
+        => DynamoQueryValueSerializer.CreateAttributeValue(this, _attributeValueSerializers, value);
 
     /// <summary>Serializes a value whose runtime/source CLR type is already known.</summary>
     internal virtual AttributeValue CreateAttributeValue(object? value, Type sourceType)
-        => DynamoRuntimeValueSerializer.CreateAttributeValue(
+        => DynamoQueryValueSerializer.CreateAttributeValue(
             this,
             _attributeValueSerializers,
             value,
@@ -128,21 +116,15 @@ public class DynamoTypeMapping : CoreTypeMapping
 
     /// <summary>Generates a PartiQL literal for a constant value.</summary>
     /// <remarks>
-    ///     Follows the same template method pattern as <c>RelationalTypeMapping.GenerateSqlLiteral</c>:
-    ///     this public entry point handles null, then delegates to
-    ///     <see cref="GenerateNonNullConstant" /> for non-null values. Subclasses override
-    ///     <see cref="GenerateNonNullConstant" /> rather than this method.
+    ///     EF exposes constants as boxed values. This public boundary infers the runtime source type
+    ///     once, then dispatches through a cached typed expression-tree serializer.
     /// </remarks>
     public virtual string GenerateConstant(object? value)
         => value is null ? "NULL" : GenerateNonNullConstant(value);
 
     /// <summary>Generates a PartiQL literal for a value whose runtime/source CLR type is known.</summary>
     internal virtual string GenerateConstant(object? value, Type sourceType)
-        => DynamoRuntimeValueSerializer.GenerateLiteral(
-            this,
-            _literalSerializers,
-            value,
-            sourceType);
+        => DynamoQueryValueSerializer.GenerateLiteral(this, _literalSerializers, value, sourceType);
 
     /// <summary>Builds the typed expression used by cached PartiQL literal serializers.</summary>
     internal virtual Expression CreatePartiQlLiteralExpression(Expression valueExpression)
@@ -152,96 +134,15 @@ public class DynamoTypeMapping : CoreTypeMapping
 
     /// <summary>Generates a PartiQL literal for a known non-null value.</summary>
     /// <remarks>
-    ///     This is the override point for subclasses, mirroring
-    ///     <c>RelationalTypeMapping.GenerateNonNullSqlLiteral</c>. The base implementation delegates to
-    ///     the cached typed adapter in the mapping-owned codec pipeline.
+    ///     This override point exists for compatibility with the previous template-method shape.
+    ///     The base implementation immediately resumes the typed expression-tree serializer.
     /// </remarks>
     protected virtual string GenerateNonNullConstant(object value)
-    {
-        value = NormalizeRuntimeValue(value);
-
-        if (TryFormatUnconvertedNumeric(value, out var numericValue))
-            return numericValue;
-
-        ValidateRuntimeValue(value);
-
-        return _untypedValueWriter?.ToPartiQlLiteral(value)
-            ?? throw new NotSupportedException(
-                $"CLR type '{ClrType.Name}' is not supported for PartiQL constant generation.");
-    }
-
-    private object NormalizeRuntimeValue(object value)
-    {
-        var expectedNonNullableType = Nullable.GetUnderlyingType(ClrType) ?? ClrType;
-        if (!expectedNonNullableType.IsEnum || value.GetType() == expectedNonNullableType)
-            return value;
-
-        var underlyingType = Enum.GetUnderlyingType(expectedNonNullableType);
-        var valueType = value.GetType();
-        if (valueType != underlyingType
-            && !DynamoWireValueConversion.CanRepresentEnumUnderlyingType(valueType, underlyingType))
-            return value;
-
-        return Enum.ToObject(expectedNonNullableType, value);
-    }
-
-    private void ValidateRuntimeValue(object value)
-    {
-        var expectedType = ClrType;
-        var expectedNonNullableType = Nullable.GetUnderlyingType(expectedType) ?? expectedType;
-        var valueType = value.GetType();
-
-        if (expectedType == typeof(object)
-            || expectedType.IsAssignableFrom(valueType)
-            || expectedNonNullableType.IsAssignableFrom(valueType))
-            return;
-
-        throw new InvalidOperationException(
-            $"DynamoDB type mapping for CLR type '{ClrType.Name}' cannot serialize runtime "
-            + $"value of type '{valueType.Name}'. This usually means query type-mapping "
-            + "inference applied an incompatible mapping to a parameter or constant.");
-    }
-
-    private bool TryFormatUnconvertedNumeric(
-        object value,
-        [NotNullWhen(true)] out string? formatted)
-    {
-        formatted = null;
-
-        if (Parameters.Converter != null)
-            return false;
-
-        var mappingType = Nullable.GetUnderlyingType(ClrType) ?? ClrType;
-        var valueType = value.GetType();
-        if (valueType == mappingType
-            || !DynamoWireValueConversion.IsNumericType(mappingType)
-            || !DynamoWireValueConversion.IsNumericType(valueType))
-            return false;
-
-        if (valueType.IsEnum)
-        {
-            formatted = DynamoWireValueConversion.FormatEnum(value);
-            return true;
-        }
-
-        formatted = value switch
-        {
-            byte numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            sbyte numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            short numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            ushort numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            int numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            uint numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            long numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            ulong numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            float numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
-            double numeric => numeric.ToString("R", CultureInfo.InvariantCulture),
-            decimal numeric => numeric.ToString(CultureInfo.InvariantCulture),
-            _ => null,
-        };
-
-        return formatted != null;
-    }
+        => DynamoQueryValueSerializer.GenerateLiteral(
+            this,
+            _literalSerializers,
+            value,
+            value.GetType());
 
     private static DynamoValueReaderWriter? CreateReaderWriter(CoreTypeMappingParameters parameters)
     {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMapping.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
@@ -37,6 +38,11 @@ public class DynamoTypeMapping : CoreTypeMapping
 {
     internal DynamoValueReaderWriter? ReaderWriter { get; }
     private readonly IDynamoUntypedValueWriter? _untypedValueWriter;
+
+    private readonly ConcurrentDictionary<Type, Func<object?, AttributeValue>>
+        _attributeValueSerializers = new();
+
+    private readonly ConcurrentDictionary<Type, Func<object?, string>> _literalSerializers = new();
 
     /// <summary>Creates a mapping for the given CLR type.</summary>
     public DynamoTypeMapping(
@@ -101,11 +107,18 @@ public class DynamoTypeMapping : CoreTypeMapping
     ///     serializer is the narrow adapter back into typed expression-based conversion.
     /// </remarks>
     internal virtual AttributeValue CreateAttributeValue(object? value)
-        => DynamoRuntimeValueSerializer.CreateAttributeValue(this, value);
+        => DynamoRuntimeValueSerializer.CreateAttributeValue(
+            this,
+            _attributeValueSerializers,
+            value);
 
     /// <summary>Serializes a value whose runtime/source CLR type is already known.</summary>
     internal virtual AttributeValue CreateAttributeValue(object? value, Type sourceType)
-        => DynamoRuntimeValueSerializer.CreateAttributeValue(this, value, sourceType);
+        => DynamoRuntimeValueSerializer.CreateAttributeValue(
+            this,
+            _attributeValueSerializers,
+            value,
+            sourceType);
 
     /// <summary>Builds the typed expression used by cached query/runtime serializers.</summary>
     internal virtual Expression CreateAttributeValueExpression(Expression valueExpression)
@@ -121,11 +134,15 @@ public class DynamoTypeMapping : CoreTypeMapping
     ///     <see cref="GenerateNonNullConstant" /> rather than this method.
     /// </remarks>
     public virtual string GenerateConstant(object? value)
-        => DynamoRuntimeValueSerializer.GenerateLiteral(this, value);
+        => value is null ? "NULL" : GenerateNonNullConstant(value);
 
     /// <summary>Generates a PartiQL literal for a value whose runtime/source CLR type is known.</summary>
     internal virtual string GenerateConstant(object? value, Type sourceType)
-        => DynamoRuntimeValueSerializer.GenerateLiteral(this, value, sourceType);
+        => DynamoRuntimeValueSerializer.GenerateLiteral(
+            this,
+            _literalSerializers,
+            value,
+            sourceType);
 
     /// <summary>Builds the typed expression used by cached PartiQL literal serializers.</summary>
     internal virtual Expression CreatePartiQlLiteralExpression(Expression valueExpression)
@@ -162,7 +179,7 @@ public class DynamoTypeMapping : CoreTypeMapping
         var underlyingType = Enum.GetUnderlyingType(expectedNonNullableType);
         var valueType = value.GetType();
         if (valueType != underlyingType
-            && !CanRepresentEnumUnderlyingType(valueType, underlyingType))
+            && !DynamoWireValueConversion.CanRepresentEnumUnderlyingType(valueType, underlyingType))
             return value;
 
         return Enum.ToObject(expectedNonNullableType, value);
@@ -196,12 +213,14 @@ public class DynamoTypeMapping : CoreTypeMapping
 
         var mappingType = Nullable.GetUnderlyingType(ClrType) ?? ClrType;
         var valueType = value.GetType();
-        if (valueType == mappingType || !IsNumericType(mappingType) || !IsNumericType(valueType))
+        if (valueType == mappingType
+            || !DynamoWireValueConversion.IsNumericType(mappingType)
+            || !DynamoWireValueConversion.IsNumericType(valueType))
             return false;
 
         if (valueType.IsEnum)
         {
-            formatted = FormatEnum(value);
+            formatted = DynamoWireValueConversion.FormatEnum(value);
             return true;
         }
 
@@ -223,64 +242,6 @@ public class DynamoTypeMapping : CoreTypeMapping
 
         return formatted != null;
     }
-
-    private static bool CanRepresentEnumUnderlyingType(Type valueType, Type underlyingType)
-        => IsIntegralType(valueType) && IsIntegralType(underlyingType);
-
-    private static string FormatEnum(object value)
-        => Type.GetTypeCode(Enum.GetUnderlyingType(value.GetType())) switch
-        {
-            TypeCode.Byte => Convert
-                .ToByte(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.SByte => Convert
-                .ToSByte(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.Int16 => Convert
-                .ToInt16(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.UInt16 => Convert
-                .ToUInt16(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.Int32 => Convert
-                .ToInt32(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.UInt32 => Convert
-                .ToUInt32(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.Int64 => Convert
-                .ToInt64(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            TypeCode.UInt64 => Convert
-                .ToUInt64(value, CultureInfo.InvariantCulture)
-                .ToString(CultureInfo.InvariantCulture),
-            _ => throw new InvalidOperationException(
-                $"Enum type '{value.GetType().Name}' has an unsupported underlying type."),
-        };
-
-    private static bool IsIntegralType(Type type)
-        => type == typeof(byte)
-            || type == typeof(sbyte)
-            || type == typeof(short)
-            || type == typeof(ushort)
-            || type == typeof(int)
-            || type == typeof(uint)
-            || type == typeof(long)
-            || type == typeof(ulong);
-
-    private static bool IsNumericType(Type type)
-        => type.IsEnum
-            || type == typeof(byte)
-            || type == typeof(sbyte)
-            || type == typeof(short)
-            || type == typeof(ushort)
-            || type == typeof(int)
-            || type == typeof(uint)
-            || type == typeof(long)
-            || type == typeof(ulong)
-            || type == typeof(float)
-            || type == typeof(double)
-            || type == typeof(decimal);
 
     private static DynamoValueReaderWriter? CreateReaderWriter(CoreTypeMappingParameters parameters)
     {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWireValueConversion.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWireValueConversion.cs
@@ -6,6 +6,8 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 internal static class DynamoWireValueConversion
 {
     /// <summary>Returns whether the CLR type is represented as a numeric DynamoDB value.</summary>
+    /// <param name="type">CLR type to inspect.</param>
+    /// <returns><see langword="true" /> when values of <paramref name="type" /> use DynamoDB number wire values.</returns>
     public static bool IsNumericType(Type type)
         => type.IsEnum
             || type == typeof(byte)
@@ -21,6 +23,8 @@ internal static class DynamoWireValueConversion
             || type == typeof(decimal);
 
     /// <summary>Returns whether the CLR type is an integral numeric type.</summary>
+    /// <param name="type">CLR type to inspect.</param>
+    /// <returns><see langword="true" /> when <paramref name="type" /> is an integral numeric type.</returns>
     public static bool IsIntegralType(Type type)
         => type == typeof(byte)
             || type == typeof(sbyte)
@@ -32,10 +36,16 @@ internal static class DynamoWireValueConversion
             || type == typeof(ulong);
 
     /// <summary>Returns whether an integral type can represent an enum underlying type.</summary>
+    /// <param name="valueType">Candidate value type.</param>
+    /// <param name="underlyingType">Enum underlying type.</param>
+    /// <returns><see langword="true" /> when both types are integral numeric types.</returns>
     public static bool CanRepresentEnumUnderlyingType(Type valueType, Type underlyingType)
         => IsIntegralType(valueType) && IsIntegralType(underlyingType);
 
     /// <summary>Formats an enum as its numeric DynamoDB wire value.</summary>
+    /// <param name="value">Enum value to format.</param>
+    /// <returns>Invariant-culture numeric representation of <paramref name="value" />.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the enum has an unsupported underlying type.</exception>
     public static string FormatEnum(object value)
         => Type.GetTypeCode(Enum.GetUnderlyingType(value.GetType())) switch
         {
@@ -99,6 +109,9 @@ internal static class DynamoWireValueConversion
         if (value is null)
             return new AttributeValue { NULL = true };
 
+        if (value.GetType().IsEnum)
+            return new AttributeValue { N = FormatEnum(value) };
+
         return value switch
         {
             string s => new AttributeValue { S = s },
@@ -129,6 +142,9 @@ internal static class DynamoWireValueConversion
     {
         if (value == null)
             return "NULL";
+
+        if (value.GetType().IsEnum)
+            return FormatEnum(value);
 
         return value switch
         {

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWireValueConversion.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWireValueConversion.cs
@@ -5,6 +5,68 @@ namespace EntityFrameworkCore.DynamoDb.Storage;
 
 internal static class DynamoWireValueConversion
 {
+    /// <summary>Returns whether the CLR type is represented as a numeric DynamoDB value.</summary>
+    public static bool IsNumericType(Type type)
+        => type.IsEnum
+            || type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal);
+
+    /// <summary>Returns whether the CLR type is an integral numeric type.</summary>
+    public static bool IsIntegralType(Type type)
+        => type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong);
+
+    /// <summary>Returns whether an integral type can represent an enum underlying type.</summary>
+    public static bool CanRepresentEnumUnderlyingType(Type valueType, Type underlyingType)
+        => IsIntegralType(valueType) && IsIntegralType(underlyingType);
+
+    /// <summary>Formats an enum as its numeric DynamoDB wire value.</summary>
+    public static string FormatEnum(object value)
+        => Type.GetTypeCode(Enum.GetUnderlyingType(value.GetType())) switch
+        {
+            TypeCode.Byte => Convert
+                .ToByte(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.SByte => Convert
+                .ToSByte(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int16 => Convert
+                .ToInt16(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt16 => Convert
+                .ToUInt16(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int32 => Convert
+                .ToInt32(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt32 => Convert
+                .ToUInt32(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.Int64 => Convert
+                .ToInt64(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            TypeCode.UInt64 => Convert
+                .ToUInt64(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture),
+            _ => throw new InvalidOperationException(
+                $"Enum type '{value.GetType().Name}' has an unsupported underlying type."),
+        };
+
     /// <summary>Formats numeric values for DynamoDB wire output using invariant culture.</summary>
     /// <remarks>
     ///     Uses round-trip (<c>R</c>) formatting for <see cref="float" /> and <see cref="double" />

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoQueryValueSerializer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoQueryValueSerializer.cs
@@ -14,7 +14,7 @@ namespace EntityFrameworkCore.DynamoDb.Storage.Internal;
 ///     once to the source CLR type, then resumes the mapping-owned expression pipeline so value
 ///     converters use typed expressions instead of <c>ConvertToProvider(object)</c>.
 /// </remarks>
-internal static class DynamoRuntimeValueSerializer
+internal static class DynamoQueryValueSerializer
 {
     private static readonly MethodInfo ConvertProviderValueToAttributeValueMethod =
         typeof(DynamoWireValueConversion).GetMethod(

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoRuntimeValueSerializer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoRuntimeValueSerializer.cs
@@ -16,12 +16,6 @@ namespace EntityFrameworkCore.DynamoDb.Storage.Internal;
 /// </remarks>
 internal static class DynamoRuntimeValueSerializer
 {
-    private static readonly ConcurrentDictionary<CacheKey, Func<object?, AttributeValue>>
-        AttributeValueSerializers = new();
-
-    private static readonly ConcurrentDictionary<CacheKey, Func<object?, string>>
-        LiteralSerializers = new();
-
     private static readonly MethodInfo ConvertProviderValueToAttributeValueMethod =
         typeof(DynamoWireValueConversion).GetMethod(
             nameof(DynamoWireValueConversion.ConvertProviderValueToAttributeValue))!;
@@ -30,8 +24,15 @@ internal static class DynamoRuntimeValueSerializer
         typeof(DynamoWireValueConversion).GetMethod(
             nameof(DynamoWireValueConversion.GenerateBoxedConstant))!;
 
-    public static AttributeValue CreateAttributeValue(
+    /// <summary>Serializes a boxed runtime value through a mapping-owned typed delegate cache.</summary>
+    /// <param name="mapping">DynamoDB type mapping that owns conversion metadata.</param>
+    /// <param name="serializers">Per-mapping serializer cache keyed by runtime source type.</param>
+    /// <param name="value">Boxed runtime value to serialize.</param>
+    /// <param name="sourceType">Known runtime/source CLR type, or <see langword="null" /> to infer it.</param>
+    /// <returns>DynamoDB attribute value for the runtime value.</returns>
+    internal static AttributeValue CreateAttributeValue(
         DynamoTypeMapping mapping,
+        ConcurrentDictionary<Type, Func<object?, AttributeValue>> serializers,
         object? value,
         Type? sourceType = null)
     {
@@ -39,13 +40,21 @@ internal static class DynamoRuntimeValueSerializer
             return new AttributeValue { NULL = true };
 
         sourceType ??= value.GetType();
-        return AttributeValueSerializers.GetOrAdd(
-            new CacheKey(mapping, sourceType),
-            static key => CompileAttributeValueSerializer(key.Mapping, key.SourceType))(value);
+        return serializers.GetOrAdd(
+            sourceType,
+            static (key, mapping) => CompileAttributeValueSerializer(mapping, key),
+            mapping)(value);
     }
 
-    public static string GenerateLiteral(
+    /// <summary>Generates a PartiQL literal through a mapping-owned typed delegate cache.</summary>
+    /// <param name="mapping">DynamoDB type mapping that owns conversion metadata.</param>
+    /// <param name="serializers">Per-mapping literal serializer cache keyed by runtime source type.</param>
+    /// <param name="value">Boxed runtime value to render.</param>
+    /// <param name="sourceType">Known runtime/source CLR type, or <see langword="null" /> to infer it.</param>
+    /// <returns>PartiQL literal for the runtime value.</returns>
+    internal static string GenerateLiteral(
         DynamoTypeMapping mapping,
+        ConcurrentDictionary<Type, Func<object?, string>> serializers,
         object? value,
         Type? sourceType = null)
     {
@@ -53,9 +62,10 @@ internal static class DynamoRuntimeValueSerializer
             return "NULL";
 
         sourceType ??= value.GetType();
-        return LiteralSerializers.GetOrAdd(
-            new CacheKey(mapping, sourceType),
-            static key => CompileLiteralSerializer(key.Mapping, key.SourceType))(value);
+        return serializers.GetOrAdd(
+            sourceType,
+            static (key, mapping) => CompileLiteralSerializer(mapping, key),
+            mapping)(value);
     }
 
     private static Func<object?, AttributeValue> CompileAttributeValueSerializer(
@@ -128,22 +138,7 @@ internal static class DynamoRuntimeValueSerializer
     {
         var nonNullableMappingType = Nullable.GetUnderlyingType(mappingType) ?? mappingType;
         var nonNullableSourceType = Nullable.GetUnderlyingType(sourceType) ?? sourceType;
-        return IsNumericType(nonNullableMappingType) && IsNumericType(nonNullableSourceType);
+        return DynamoWireValueConversion.IsNumericType(nonNullableMappingType)
+            && DynamoWireValueConversion.IsNumericType(nonNullableSourceType);
     }
-
-    private static bool IsNumericType(Type type)
-        => type.IsEnum
-            || type == typeof(byte)
-            || type == typeof(sbyte)
-            || type == typeof(short)
-            || type == typeof(ushort)
-            || type == typeof(int)
-            || type == typeof(uint)
-            || type == typeof(long)
-            || type == typeof(ulong)
-            || type == typeof(float)
-            || type == typeof(double)
-            || type == typeof(decimal);
-
-    private readonly record struct CacheKey(DynamoTypeMapping Mapping, Type SourceType);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoRuntimeValueSerializer.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoRuntimeValueSerializer.cs
@@ -1,0 +1,149 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.Storage.Internal;
+
+/// <summary>
+///     Compiles typed serializers for EF's object-shaped runtime value boundary.
+/// </summary>
+/// <remarks>
+///     EF hands query constants and parameters to type mappings as boxed <see cref="object" />
+///     values. This adapter is the only intended query serialization boxing boundary: it unboxes
+///     once to the source CLR type, then resumes the mapping-owned expression pipeline so value
+///     converters use typed expressions instead of <c>ConvertToProvider(object)</c>.
+/// </remarks>
+internal static class DynamoRuntimeValueSerializer
+{
+    private static readonly ConcurrentDictionary<CacheKey, Func<object?, AttributeValue>>
+        AttributeValueSerializers = new();
+
+    private static readonly ConcurrentDictionary<CacheKey, Func<object?, string>>
+        LiteralSerializers = new();
+
+    private static readonly MethodInfo ConvertProviderValueToAttributeValueMethod =
+        typeof(DynamoWireValueConversion).GetMethod(
+            nameof(DynamoWireValueConversion.ConvertProviderValueToAttributeValue))!;
+
+    private static readonly MethodInfo GenerateBoxedConstantMethod =
+        typeof(DynamoWireValueConversion).GetMethod(
+            nameof(DynamoWireValueConversion.GenerateBoxedConstant))!;
+
+    public static AttributeValue CreateAttributeValue(
+        DynamoTypeMapping mapping,
+        object? value,
+        Type? sourceType = null)
+    {
+        if (value is null)
+            return new AttributeValue { NULL = true };
+
+        sourceType ??= value.GetType();
+        return AttributeValueSerializers.GetOrAdd(
+            new CacheKey(mapping, sourceType),
+            static key => CompileAttributeValueSerializer(key.Mapping, key.SourceType))(value);
+    }
+
+    public static string GenerateLiteral(
+        DynamoTypeMapping mapping,
+        object? value,
+        Type? sourceType = null)
+    {
+        if (value is null)
+            return "NULL";
+
+        sourceType ??= value.GetType();
+        return LiteralSerializers.GetOrAdd(
+            new CacheKey(mapping, sourceType),
+            static key => CompileLiteralSerializer(key.Mapping, key.SourceType))(value);
+    }
+
+    private static Func<object?, AttributeValue> CompileAttributeValueSerializer(
+        DynamoTypeMapping mapping,
+        Type sourceType)
+    {
+        var valueParameter = Expression.Parameter(typeof(object), "value");
+        var typedValue = Expression.Convert(valueParameter, sourceType);
+        var body = CreateAttributeValueBody(mapping, typedValue, sourceType);
+        return Expression.Lambda<Func<object?, AttributeValue>>(body, valueParameter).Compile();
+    }
+
+    private static Func<object?, string> CompileLiteralSerializer(
+        DynamoTypeMapping mapping,
+        Type sourceType)
+    {
+        var valueParameter = Expression.Parameter(typeof(object), "value");
+        var typedValue = Expression.Convert(valueParameter, sourceType);
+        var body = CreateLiteralBody(mapping, typedValue, sourceType);
+        return Expression.Lambda<Func<object?, string>>(body, valueParameter).Compile();
+    }
+
+    private static Expression CreateAttributeValueBody(
+        DynamoTypeMapping mapping,
+        Expression typedValue,
+        Type sourceType)
+    {
+        if (CanUseMappingExpression(mapping, sourceType))
+            return mapping.CreateAttributeValueExpression(typedValue);
+
+        // Numeric promotions (for example short property compared to int parameter) should stay
+        // numeric DynamoDB values without unboxing the runtime value as the property's CLR type.
+        if (mapping.Converter is null && IsNumericCompatible(mapping.ClrType, sourceType))
+            return Expression.Call(
+                ConvertProviderValueToAttributeValueMethod.MakeGenericMethod(sourceType),
+                typedValue);
+
+        return mapping.CreateAttributeValueExpression(
+            Expression.Convert(typedValue, mapping.ClrType));
+    }
+
+    private static Expression CreateLiteralBody(
+        DynamoTypeMapping mapping,
+        Expression typedValue,
+        Type sourceType)
+    {
+        if (CanUseMappingExpression(mapping, sourceType))
+            return mapping.CreatePartiQlLiteralExpression(typedValue);
+
+        // Inline constants follow the same numeric-promotion rule as AttributeValue parameters.
+        if (mapping.Converter is null && IsNumericCompatible(mapping.ClrType, sourceType))
+            return Expression.Call(
+                GenerateBoxedConstantMethod,
+                Expression.Convert(typedValue, typeof(object)));
+
+        return mapping.CreatePartiQlLiteralExpression(
+            Expression.Convert(typedValue, mapping.ClrType));
+    }
+
+    private static bool CanUseMappingExpression(DynamoTypeMapping mapping, Type sourceType)
+    {
+        var targetType = mapping.ClrType;
+        return targetType == sourceType
+            || targetType.IsAssignableFrom(sourceType)
+            || (Nullable.GetUnderlyingType(targetType) is { } targetUnderlying
+                && targetUnderlying == sourceType);
+    }
+
+    private static bool IsNumericCompatible(Type mappingType, Type sourceType)
+    {
+        var nonNullableMappingType = Nullable.GetUnderlyingType(mappingType) ?? mappingType;
+        var nonNullableSourceType = Nullable.GetUnderlyingType(sourceType) ?? sourceType;
+        return IsNumericType(nonNullableMappingType) && IsNumericType(nonNullableSourceType);
+    }
+
+    private static bool IsNumericType(Type type)
+        => type.IsEnum
+            || type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal);
+
+    private readonly record struct CacheKey(DynamoTypeMapping Mapping, Type SourceType);
+}

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
@@ -35,6 +35,10 @@ internal abstract class DynamoValueReaderWriter
 
     internal abstract IDynamoUntypedValueWriter CreateUntypedValueWriter();
 
+    internal abstract Expression CreateWriteExpression(Expression typedValueExpression);
+
+    internal abstract Expression CreatePartiQlLiteralExpression(Expression typedValueExpression);
+
     protected static Expression CreatePropertyExpression(
         Expression attributeValueExpression,
         string propertyPath,
@@ -147,10 +151,10 @@ internal abstract class DynamoValueReaderWriter<TValue> : DynamoValueReaderWrite
 
     protected virtual Expression CreateConstructorExpression() => Expression.New(GetType());
 
-    internal virtual Expression CreateWriteExpression(Expression typedValueExpression)
+    internal override Expression CreateWriteExpression(Expression typedValueExpression)
         => Expression.Call(Expression.Constant(this, GetType()), WriteMethod, typedValueExpression);
 
-    internal virtual Expression CreatePartiQlLiteralExpression(Expression typedValueExpression)
+    internal override Expression CreatePartiQlLiteralExpression(Expression typedValueExpression)
         => Expression.Call(
             Expression.Constant(this, GetType()),
             ToPartiQlLiteralMethod,

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
@@ -33,8 +33,6 @@ internal abstract class DynamoValueReaderWriter
         bool required,
         IProperty? property);
 
-    internal abstract IDynamoUntypedValueWriter CreateUntypedValueWriter();
-
     internal abstract Expression CreateWriteExpression(Expression typedValueExpression);
 
     internal abstract Expression CreatePartiQlLiteralExpression(Expression typedValueExpression);
@@ -64,19 +62,6 @@ internal abstract class DynamoValueReaderWriter
         => $"Required property '{propertyPath}' did not contain a value for expected DynamoDB wire member '{WireMemberName}'.";
 }
 
-/// <summary>Bridges EF's untyped mapping boundary to the typed Dynamo serialization pipeline.</summary>
-/// <remarks>
-///     EF asks type mappings to serialize runtime values as <see cref="object" /> for query
-///     constants, parameters, and update values. The cast happens exactly once here, and the typed
-///     delegate pipeline resumes immediately after this adapter.
-/// </remarks>
-internal interface IDynamoUntypedValueWriter
-{
-    AttributeValue Write(object value);
-
-    string ToPartiQlLiteral(object value);
-}
-
 /// <summary>Strongly-typed base implementation for a DynamoDB value reader/writer.</summary>
 internal abstract class DynamoValueReaderWriter<TValue> : DynamoValueReaderWriter
 {
@@ -92,10 +77,6 @@ internal abstract class DynamoValueReaderWriter<TValue> : DynamoValueReaderWrite
         typeof(DynamoValueReaderWriter<TValue>).GetMethod(
             nameof(ToPartiQlLiteral),
             [typeof(TValue)])!;
-
-    private Func<TValue, AttributeValue>? _attributeValueFactory;
-    private Func<TValue, string>? _partiQlLiteralFactory;
-    private IDynamoUntypedValueWriter? _untypedValueWriter;
 
     public sealed override Type ValueType => typeof(TValue);
 
@@ -115,11 +96,6 @@ internal abstract class DynamoValueReaderWriter<TValue> : DynamoValueReaderWrite
             property,
             ReadMethod,
             CreateConstructorExpression());
-
-    internal sealed override IDynamoUntypedValueWriter CreateUntypedValueWriter()
-        => _untypedValueWriter ??= new DynamoUntypedValueWriter<TValue>(
-            _attributeValueFactory ??= CompileAttributeValueFactory(),
-            _partiQlLiteralFactory ??= CompilePartiQlLiteralFactory());
 
     public TValue Read(
         AttributeValue attributeValue,
@@ -159,33 +135,6 @@ internal abstract class DynamoValueReaderWriter<TValue> : DynamoValueReaderWrite
             Expression.Constant(this, GetType()),
             ToPartiQlLiteralMethod,
             typedValueExpression);
-
-    private Func<TValue, AttributeValue> CompileAttributeValueFactory()
-    {
-        var valueParameter = Expression.Parameter(typeof(TValue), "value");
-        var body = CreateWriteExpression(valueParameter);
-
-        return Expression.Lambda<Func<TValue, AttributeValue>>(body, valueParameter).Compile();
-    }
-
-    private Func<TValue, string> CompilePartiQlLiteralFactory()
-    {
-        var valueParameter = Expression.Parameter(typeof(TValue), "value");
-        var body = CreatePartiQlLiteralExpression(valueParameter);
-
-        return Expression.Lambda<Func<TValue, string>>(body, valueParameter).Compile();
-    }
-}
-
-internal sealed class DynamoUntypedValueWriter<TValue>(
-    Func<TValue, AttributeValue> write,
-    Func<TValue, string> toPartiQlLiteral) : IDynamoUntypedValueWriter
-{
-    // This is the single intentional cast site from EF's object-based mapping boundary back into
-    // the typed serialization pipeline.
-    public AttributeValue Write(object value) => write((TValue)value);
-
-    public string ToPartiQlLiteral(object value) => toPartiQlLiteral((TValue)value);
 }
 
 /// <summary>Exposes the provider-level reader/writer under a composed wrapper.</summary>
@@ -239,22 +188,8 @@ internal sealed class DynamoConvertedValueReaderWriter<TModel, TProvider>(
 
     // ── Object-based (boxed) fallback methods ──────────────────────────────────────
     //
-    // These three methods use the untyped ValueConverter API and box value types. They are NOT
-    // on any hot path:
-    //
-    //   • The query read path goes through CreateReadExpression, which inlines the converter's
-    //     ConvertFromProviderExpression directly into the compiled query expression tree —
-    //     no runtime boxing.
-    //
-    //   • The SaveChanges write path goes through DynamoEntityItemSerializerSource, which
-    //     dispatches via pre-compiled Func<IUpdateEntry, AttributeValue> delegates that call
-    //     CreateWriteExpression / CreatePartiQlLiteralExpression (expression-tree paths below)
-    //     rather than Write / ToPartiQlLiteral.
-    //
-    //   • ReadValue / Write / ToPartiQlLiteral are only reachable via the
-    //     IDynamoUntypedValueWriter.Write(object) path, which is itself already operating on a
-    //     boxed object — so the additional boxing here is in an already-boxed context and does
-    //     not regress the hot path.
+    // These methods use the untyped ValueConverter API and box value types. Query read/value
+    // binding and SaveChanges write paths use expression-tree APIs below instead.
 
     protected override TModel ReadValue(
         AttributeValue attributeValue,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -316,40 +316,34 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
         var statuses =
             new[] { MappingStatus.Active, MappingStatus.Inactive, MappingStatus.Pending };
 
-        var firstPage = await Db
-            .Items
-            .AsNoTracking()
-            .Where(item => statuses.Contains(item.StringStatus))
-            .ToPageAsync(2, null, CancellationToken);
+        string? nextToken = null;
+        var items = new List<QueryTypeMappingItem>();
 
-        firstPage.Items.Should().HaveCount(2);
-        firstPage.NextToken.Should().NotBeNull();
+        do
+        {
+            var page = await Db
+                .Items
+                .AsNoTracking()
+                .Where(item => statuses.Contains(item.StringStatus))
+                .ToPageAsync(2, nextToken, CancellationToken);
 
-        var secondPage = await Db
-            .Items
-            .AsNoTracking()
-            .Where(item => statuses.Contains(item.StringStatus))
-            .ToPageAsync(2, firstPage.NextToken, CancellationToken);
+            items.AddRange(page.Items);
+            nextToken = page.NextToken;
+        } while (nextToken is not null);
 
-        secondPage.Items.Should().HaveCount(1);
-        firstPage
-            .Items
-            .Concat(secondPage.Items)
-            .Select(item => item.Pk)
+        items.Select(item => item.Pk).Should().BeEquivalentTo(["ITEM#1", "ITEM#2", "ITEM#3"]);
+
+        SqlCapture
+            .PartiQlStatements
             .Should()
-            .BeEquivalentTo(["ITEM#1", "ITEM#2", "ITEM#3"]);
-
-        AssertSql(
-            """
-            SELECT "pk", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
-            FROM "QueryTypeMappingItems"
-            WHERE "stringStatus" IN [?, ?, ?]
-            """,
-            """
-            SELECT "pk", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
-            FROM "QueryTypeMappingItems"
-            WHERE "stringStatus" IN [?, ?, ?]
-            """);
+            .OnlyContain(statement => statement
+                == """
+                   SELECT "pk", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
+                   FROM "QueryTypeMappingItems"
+                   WHERE "stringStatus" IN [?, ?, ?]
+                   """);
+        SqlCapture.PartiQlStatements.Should().HaveCountGreaterThan(1);
+        SqlCapture.Clear();
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -99,6 +99,28 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_converted_enum_parameter_comparison_returns_expected_item()
+    {
+        MappingStatus? status = MappingStatus.Active;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.NullableStringStatus == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "nullableStringStatus" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Inline_converted_enum_constant_comparison_returns_expected_item()
     {
         var result = await Db
@@ -214,6 +236,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["shortValue"] = new() { N = "7" },
             ["nullableShortValue"] = new() { NULL = true },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Active) },
+            ["nullableStringStatus"] = new() { S = nameof(MappingStatus.Active) },
             ["profile"] =
                 new()
                 {
@@ -229,6 +252,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["shortValue"] = new() { N = "8" },
             ["nullableShortValue"] = new() { N = "8" },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Inactive) },
+            ["nullableStringStatus"] = new() { NULL = true },
             ["profile"] =
                 new()
                 {
@@ -244,6 +268,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["shortValue"] = new() { N = "9" },
             ["nullableShortValue"] = new() { N = "9" },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Pending) },
+            ["nullableStringStatus"] = new() { S = nameof(MappingStatus.Pending) },
             ["profile"] = new()
             {
                 M = new Dictionary<string, AttributeValue>
@@ -273,6 +298,10 @@ public sealed class QueryTypeMappingDbContext(DbContextOptions options) : DbCont
                 .Property(item => item.StringStatus)
                 .HasAttributeName("stringStatus")
                 .HasConversion<string>();
+            builder
+                .Property(item => item.NullableStringStatus)
+                .HasAttributeName("nullableStringStatus")
+                .HasConversion<string>();
             builder.ComplexProperty(
                 item => item.Profile,
                 profileBuilder
@@ -289,6 +318,8 @@ public sealed record QueryTypeMappingItem
     public short? NullableShortValue { get; set; }
 
     public MappingStatus StringStatus { get; set; }
+
+    public MappingStatus? NullableStringStatus { get; set; }
 
     public QueryTypeMappingProfile Profile { get; set; } = new();
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -1,0 +1,306 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.QueryTypeMappingTable;
+
+/// <summary>End-to-end coverage for query type-mapping inference and parameter binding.</summary>
+public class QueryTypeMappingTests : QueryTypeMappingTestFixture
+{
+    public QueryTypeMappingTests(DynamoContainerFixture fixture) : base(fixture) { }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Short_parameter_comparison_returns_expected_item()
+    {
+        short value = 7;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.ShortValue == value)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "shortValue" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_short_parameter_comparison_returns_expected_item()
+    {
+        short? value = 8;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.NullableShortValue == value)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#2");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "nullableShortValue" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Reversed_range_comparison_returns_expected_items()
+    {
+        short value = 8;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => value <= item.ShortValue)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().BeEquivalentTo(["ITEM#2", "ITEM#3"]);
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE ? <= "shortValue"
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Converted_enum_parameter_comparison_returns_expected_item()
+    {
+        var status = MappingStatus.Active;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.StringStatus == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "stringStatus" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Inline_converted_enum_constant_comparison_returns_expected_item()
+    {
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.StringStatus == MappingStatus.Inactive)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#2");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "stringStatus" = 'Inactive'
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Parameterized_converted_contains_returns_expected_items()
+    {
+        var statuses = new[] { MappingStatus.Active, MappingStatus.Pending };
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => statuses.Contains(item.StringStatus))
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().BeEquivalentTo(["ITEM#1", "ITEM#3"]);
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "stringStatus" IN [?, ?]
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Complex_converted_property_comparison_returns_expected_item()
+    {
+        var status = MappingStatus.Pending;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.Profile.Status == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#3");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "profile"."status" = ?
+            """);
+    }
+}
+
+public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
+{
+    private const string TableName = "QueryTypeMappingItems";
+
+    public QueryTypeMappingTestFixture(DynamoContainerFixture fixture) : base(fixture)
+        => EnsureClassTableInitialized(TableName, CreateTable);
+
+    public QueryTypeMappingDbContext Db
+    {
+        get
+        {
+            field ??= new QueryTypeMappingDbContext(
+                CreateOptions<QueryTypeMappingDbContext>(o => o.DynamoDbClient(Client)));
+            return field;
+        }
+    }
+
+    private static async Task CreateTable(
+        IAmazonDynamoDB dynamoDb,
+        CancellationToken cancellationToken)
+    {
+        await dynamoDb.CreateTableAsync(
+            new CreateTableRequest
+            {
+                TableName = TableName,
+                AttributeDefinitions =
+                [
+                    new AttributeDefinition
+                    {
+                        AttributeName = "pk", AttributeType = ScalarAttributeType.S,
+                    },
+                ],
+                KeySchema =
+                [
+                    new KeySchemaElement { AttributeName = "pk", KeyType = KeyType.HASH },
+                ],
+                BillingMode = BillingMode.PAY_PER_REQUEST,
+            },
+            cancellationToken);
+
+        await dynamoDb.SeedItemsAsync(TableName, AttributeValues, cancellationToken);
+    }
+
+    private static readonly List<Dictionary<string, AttributeValue>> AttributeValues =
+    [
+        new()
+        {
+            ["pk"] = new() { S = "ITEM#1" },
+            ["shortValue"] = new() { N = "7" },
+            ["nullableShortValue"] = new() { NULL = true },
+            ["stringStatus"] = new() { S = nameof(MappingStatus.Active) },
+            ["profile"] =
+                new()
+                {
+                    M = new Dictionary<string, AttributeValue>
+                    {
+                        ["status"] = new() { S = nameof(MappingStatus.Active) },
+                    },
+                },
+        },
+        new()
+        {
+            ["pk"] = new() { S = "ITEM#2" },
+            ["shortValue"] = new() { N = "8" },
+            ["nullableShortValue"] = new() { N = "8" },
+            ["stringStatus"] = new() { S = nameof(MappingStatus.Inactive) },
+            ["profile"] =
+                new()
+                {
+                    M = new Dictionary<string, AttributeValue>
+                    {
+                        ["status"] = new() { S = nameof(MappingStatus.Inactive) },
+                    },
+                },
+        },
+        new()
+        {
+            ["pk"] = new() { S = "ITEM#3" },
+            ["shortValue"] = new() { N = "9" },
+            ["nullableShortValue"] = new() { N = "9" },
+            ["stringStatus"] = new() { S = nameof(MappingStatus.Pending) },
+            ["profile"] = new()
+            {
+                M = new Dictionary<string, AttributeValue>
+                {
+                    ["status"] = new() { S = nameof(MappingStatus.Pending) },
+                },
+            },
+        },
+    ];
+}
+
+public sealed class QueryTypeMappingDbContext(DbContextOptions options) : DbContext(options)
+{
+    public DbSet<QueryTypeMappingItem> Items { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<QueryTypeMappingItem>(builder =>
+        {
+            builder.ToTable("QueryTypeMappingItems");
+            builder.HasPartitionKey(item => item.Pk);
+            builder.Property(item => item.Pk).HasAttributeName("pk");
+            builder.Property(item => item.ShortValue).HasAttributeName("shortValue");
+            builder
+                .Property(item => item.NullableShortValue)
+                .HasAttributeName("nullableShortValue");
+            builder
+                .Property(item => item.StringStatus)
+                .HasAttributeName("stringStatus")
+                .HasConversion<string>();
+            builder.ComplexProperty(
+                item => item.Profile,
+                profileBuilder
+                    => profileBuilder.Property(profile => profile.Status).HasConversion<string>());
+        });
+}
+
+public sealed record QueryTypeMappingItem
+{
+    public string Pk { get; set; } = null!;
+
+    public short ShortValue { get; set; }
+
+    public short? NullableShortValue { get; set; }
+
+    public MappingStatus StringStatus { get; set; }
+
+    public QueryTypeMappingProfile Profile { get; set; } = new();
+}
+
+public sealed record QueryTypeMappingProfile
+{
+    public MappingStatus Status { get; set; }
+}
+
+public enum MappingStatus
+{
+    Inactive,
+    Active,
+    Pending,
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.QueryTypeMappingTable;
 
 /// <summary>End-to-end coverage for query type-mapping inference and parameter binding.</summary>
+#pragma warning disable EF9102
 public class QueryTypeMappingTests : QueryTypeMappingTestFixture
 {
     public QueryTypeMappingTests(DynamoContainerFixture fixture) : base(fixture) { }
@@ -77,6 +78,29 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Between_comparison_returns_expected_items()
+    {
+        var low = 7;
+        var high = 8;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.ShortValue >= low && item.ShortValue <= high)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().BeEquivalentTo(["ITEM#1", "ITEM#2"]);
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "shortValue" BETWEEN ? AND ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Converted_enum_parameter_comparison_returns_expected_item()
     {
         var status = MappingStatus.Active;
@@ -111,6 +135,28 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
             .ToListAsync(CancellationToken);
 
         result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "nullableStringStatus" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_converted_enum_null_comparison_returns_expected_item()
+    {
+        MappingStatus? status = null;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.NullableStringStatus == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#2");
 
         AssertSql(
             """
@@ -157,6 +203,64 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
         AssertSql(
             """
             SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "stringStatus" IN [?, ?]
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Materialized_entity_preserves_converted_and_nullable_values()
+    {
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.Pk == "ITEM#2")
+            .ToListAsync(CancellationToken);
+
+        var item = result.Should().ContainSingle().Subject;
+        item.ShortValue.Should().Be(8);
+        item.NullableShortValue.Should().Be(8);
+        item.StringStatus.Should().Be(MappingStatus.Inactive);
+        item.NullableStringStatus.Should().BeNull();
+        item.Profile.Status.Should().Be(MappingStatus.Inactive);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Paginated_converted_parameter_query_resumes_with_next_token()
+    {
+        var statuses = new[] { MappingStatus.Active, MappingStatus.Pending };
+
+        var firstPage = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => statuses.Contains(item.StringStatus))
+            .ToPageAsync(2, null, CancellationToken);
+
+        firstPage.Items.Should().HaveCount(1);
+        firstPage.NextToken.Should().NotBeNull();
+
+        var secondPage = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => statuses.Contains(item.StringStatus))
+            .ToPageAsync(2, firstPage.NextToken, CancellationToken);
+
+        secondPage.Items.Should().HaveCount(1);
+        firstPage
+            .Items
+            .Concat(secondPage.Items)
+            .Select(item => item.Pk)
+            .Should()
+            .BeEquivalentTo(["ITEM#1", "ITEM#3"]);
+
+        AssertSql(
+            """
+            SELECT "pk", "nullableShortValue", "nullableStringStatus", "shortValue", "stringStatus", "profile"
+            FROM "QueryTypeMappingItems"
+            WHERE "stringStatus" IN [?, ?]
+            """,
+            """
+            SELECT "pk", "nullableShortValue", "nullableStringStatus", "shortValue", "stringStatus", "profile"
             FROM "QueryTypeMappingItems"
             WHERE "stringStatus" IN [?, ?]
             """);

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -34,6 +34,28 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Promoted_int_parameter_compared_to_short_property_returns_expected_item()
+    {
+        var value = 8;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.ShortValue == value)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#2");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "shortValue" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Nullable_short_parameter_comparison_returns_expected_item()
     {
         short? value = 8;
@@ -97,6 +119,28 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
             SELECT "pk"
             FROM "QueryTypeMappingItems"
             WHERE "shortValue" BETWEEN ? AND ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Numeric_enum_parameter_comparison_returns_expected_item()
+    {
+        var status = MappingStatus.Active;
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.NumericStatus == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "numericStatus" = ?
             """);
     }
 
@@ -209,6 +253,28 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Parameterized_nullable_converted_contains_returns_expected_items()
+    {
+        MappingStatus?[] statuses = [MappingStatus.Active, null];
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => statuses.Contains(item.NullableStringStatus))
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().BeEquivalentTo(["ITEM#1", "ITEM#2"]);
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "nullableStringStatus" IN [?, ?]
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Materialized_entity_preserves_converted_and_nullable_values()
     {
         var result = await Db
@@ -221,6 +287,7 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
         item.ShortValue.Should().Be(8);
         item.NullableShortValue.Should().Be(8);
         item.StringStatus.Should().Be(MappingStatus.Inactive);
+        item.NumericStatus.Should().Be(MappingStatus.Inactive);
         item.NullableStringStatus.Should().BeNull();
         item.Profile.Status.Should().Be(MappingStatus.Inactive);
     }
@@ -228,7 +295,8 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Paginated_converted_parameter_query_resumes_with_next_token()
     {
-        var statuses = new[] { MappingStatus.Active, MappingStatus.Pending };
+        var statuses =
+            new[] { MappingStatus.Active, MappingStatus.Inactive, MappingStatus.Pending };
 
         var firstPage = await Db
             .Items
@@ -236,7 +304,7 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
             .Where(item => statuses.Contains(item.StringStatus))
             .ToPageAsync(2, null, CancellationToken);
 
-        firstPage.Items.Should().HaveCount(1);
+        firstPage.Items.Should().HaveCount(2);
         firstPage.NextToken.Should().NotBeNull();
 
         var secondPage = await Db
@@ -251,18 +319,18 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
             .Concat(secondPage.Items)
             .Select(item => item.Pk)
             .Should()
-            .BeEquivalentTo(["ITEM#1", "ITEM#3"]);
+            .BeEquivalentTo(["ITEM#1", "ITEM#2", "ITEM#3"]);
 
         AssertSql(
             """
-            SELECT "pk", "nullableShortValue", "nullableStringStatus", "shortValue", "stringStatus", "profile"
+            SELECT "pk", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
             FROM "QueryTypeMappingItems"
-            WHERE "stringStatus" IN [?, ?]
+            WHERE "stringStatus" IN [?, ?, ?]
             """,
             """
-            SELECT "pk", "nullableShortValue", "nullableStringStatus", "shortValue", "stringStatus", "profile"
+            SELECT "pk", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
             FROM "QueryTypeMappingItems"
-            WHERE "stringStatus" IN [?, ?]
+            WHERE "stringStatus" IN [?, ?, ?]
             """);
     }
 
@@ -339,6 +407,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["pk"] = new() { S = "ITEM#1" },
             ["shortValue"] = new() { N = "7" },
             ["nullableShortValue"] = new() { NULL = true },
+            ["numericStatus"] = new() { N = "1" },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Active) },
             ["nullableStringStatus"] = new() { S = nameof(MappingStatus.Active) },
             ["profile"] =
@@ -355,6 +424,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["pk"] = new() { S = "ITEM#2" },
             ["shortValue"] = new() { N = "8" },
             ["nullableShortValue"] = new() { N = "8" },
+            ["numericStatus"] = new() { N = "0" },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Inactive) },
             ["nullableStringStatus"] = new() { NULL = true },
             ["profile"] =
@@ -371,6 +441,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["pk"] = new() { S = "ITEM#3" },
             ["shortValue"] = new() { N = "9" },
             ["nullableShortValue"] = new() { N = "9" },
+            ["numericStatus"] = new() { N = "2" },
             ["stringStatus"] = new() { S = nameof(MappingStatus.Pending) },
             ["nullableStringStatus"] = new() { S = nameof(MappingStatus.Pending) },
             ["profile"] = new()
@@ -398,6 +469,7 @@ public sealed class QueryTypeMappingDbContext(DbContextOptions options) : DbCont
             builder
                 .Property(item => item.NullableShortValue)
                 .HasAttributeName("nullableShortValue");
+            builder.Property(item => item.NumericStatus).HasAttributeName("numericStatus");
             builder
                 .Property(item => item.StringStatus)
                 .HasAttributeName("stringStatus")
@@ -420,6 +492,8 @@ public sealed record QueryTypeMappingItem
     public short ShortValue { get; set; }
 
     public short? NullableShortValue { get; set; }
+
+    public MappingStatus NumericStatus { get; set; }
 
     public MappingStatus StringStatus { get; set; }
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -353,6 +353,37 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task SaveChanges_writes_converted_enum_wire_values()
+    {
+        var pk = $"ITEM#WRITE#{Guid.NewGuid():N}";
+        Db.Items.Add(
+            new QueryTypeMappingItem
+            {
+                Pk = pk,
+                ShortValue = 10,
+                NullableShortValue = null,
+                NumericStatus = (MappingStatus)99,
+                StringStatus = (MappingStatus)99,
+                NullableStringStatus = null,
+                Profile = new QueryTypeMappingProfile { Status = (MappingStatus)99 },
+            });
+
+        await Db.SaveChangesAsync(CancellationToken);
+
+        var response = await Client.GetItemAsync(
+            new GetItemRequest
+            {
+                TableName = "QueryTypeMappingItems",
+                Key = new Dictionary<string, AttributeValue> { ["pk"] = new() { S = pk }, },
+            },
+            CancellationToken);
+
+        response.Item["stringStatus"].S.Should().Be("99");
+        response.Item["nullableStringStatus"].NULL.Should().BeTrue();
+        response.Item["profile"].M["status"].S.Should().Be("99");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Complex_converted_property_comparison_returns_expected_item()
     {
         var status = MappingStatus.Pending;

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -167,6 +167,24 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Converted_enum_underlying_parameter_comparison_is_rejected()
+    {
+        var status = 1;
+
+        var act = () => Db
+            .Items
+            .AsNoTracking()
+            .Where(item => (int)item.StringStatus == status)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*value-converted enum*numeric underlying type*");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Nullable_converted_enum_parameter_comparison_returns_expected_item()
     {
         MappingStatus? status = MappingStatus.Active;

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -176,6 +176,23 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Enum_underlying_cast_on_converted_property_uses_target_numeric_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var status = 1;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => (int)e.StringStatus == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" = ?");
+        captured.Single().Parameters.Single().N.Should().Be("1");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Converted_property_parameter_uses_property_converter_mapping()
     {
         var (client, captured) = CreateClient();
@@ -333,6 +350,23 @@ public class QueryTypeMappingInferenceTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         captured.Single().Parameters.Select(p => p.S).Should().Equal(nameof(StringStatus.Active));
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Parameterized_nullable_converted_contains_values_use_null_attribute_value()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        StringStatus?[] values = [StringStatus.Active, null];
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains(e.NullableStringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters[0].S.Should().Be(nameof(StringStatus.Active));
+        captured.Single().Parameters[1].NULL.Should().BeTrue();
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -196,6 +196,45 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_enum_underlying_cast_on_converted_property_is_rejected()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var status = 1;
+
+        var act = () => context
+            .Items
+            .AllowScan()
+            .Where(e => e.NullableStringStatus.HasValue
+                && (int)e.NullableStringStatus.Value == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        captured.Should().BeEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        Parameterized_contains_enum_underlying_cast_on_converted_property_is_rejected()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var values = new[] { 1 };
+
+        var act = () => context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains((int)e.StringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*value-converted enum*numeric underlying type*");
+        captured.Should().BeEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Converted_property_parameter_uses_property_converter_mapping()
     {
         var (client, captured) = CreateClient();
@@ -256,6 +295,7 @@ public class QueryTypeMappingInferenceTests
             .Where(e => e.Code == code)
             .ToListAsync(TestContext.Current.CancellationToken);
 
+        captured.Single().Statement.Should().Contain("WHERE \"code\" = ?");
         captured.Single().Parameters.Single().S.Should().Be("A-1");
     }
 
@@ -336,6 +376,7 @@ public class QueryTypeMappingInferenceTests
             .Where(e => values.Contains(e.ShortValue))
             .ToListAsync(TestContext.Current.CancellationToken);
 
+        captured.Single().Statement.Should().Contain("WHERE \"shortValue\" IN [?, ?]");
         captured.Single().Parameters.Select(p => p.N).Should().Equal("1", "2");
     }
 
@@ -352,6 +393,7 @@ public class QueryTypeMappingInferenceTests
             .Where(e => values.Contains(e.StringStatus))
             .ToListAsync(TestContext.Current.CancellationToken);
 
+        captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" IN [?]");
         captured.Single().Parameters.Select(p => p.S).Should().Equal(nameof(StringStatus.Active));
     }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -116,6 +116,49 @@ public class QueryTypeMappingInferenceTests
         captured.Single().Parameters.Single().N.Should().Be("7");
     }
 
+    [Theory(Timeout = TestConfiguration.DefaultTimeout)]
+    [InlineData("lt")]
+    [InlineData("le")]
+    [InlineData("gt")]
+    [InlineData("ge")]
+    public async Task Reversed_range_comparison_uses_property_numeric_mapping(string comparison)
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        short value = 7;
+
+        var query = comparison switch
+        {
+            "lt" => context.Items.AllowScan().Where(e => value < e.ShortValue),
+            "le" => context.Items.AllowScan().Where(e => value <= e.ShortValue),
+            "gt" => context.Items.AllowScan().Where(e => value > e.ShortValue),
+            "ge" => context.Items.AllowScan().Where(e => value >= e.ShortValue),
+            _ => throw new InvalidOperationException(),
+        };
+
+        await query.ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Between_comparison_uses_property_numeric_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var low = 7;
+        var high = 9;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.ShortValue >= low && e.ShortValue <= high)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"shortValue\" BETWEEN ? AND ?");
+        captured.Single().Parameters.Select(p => p.N).Should().Equal("7", "9");
+    }
+
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Enum_parameter_with_numeric_mapping_serializes_underlying_number()
     {
@@ -165,6 +208,38 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_converted_enum_null_parameter_uses_null_attribute_value()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        StringStatus? status = null;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.NullableStringStatus == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().NULL.Should().BeTrue();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Non_enum_converted_property_parameter_uses_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var code = new QueryTypeMappingCode("A-1");
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.Code == code)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().S.Should().Be("A-1");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Inline_converted_enum_constant_uses_property_converter_mapping()
     {
         var (client, captured) = CreateClient();
@@ -177,6 +252,22 @@ public class QueryTypeMappingInferenceTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" = 'Active'");
+        captured.Single().Parameters.Should().BeNullOrEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Inline_string_literal_escapes_single_quotes()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.Id == "O'Brien")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"id\" = 'O''Brien'");
         captured.Single().Parameters.Should().BeNullOrEmpty();
     }
 
@@ -301,7 +392,11 @@ public class QueryTypeMappingInferenceTests
         public StringStatus? NullableStringStatus { get; set; }
 
         public QueryTypeMappingProfile Profile { get; set; } = new();
+
+        public QueryTypeMappingCode Code { get; set; } = new("A-1");
     }
+
+    private sealed record QueryTypeMappingCode(string Value);
 
     private sealed class QueryTypeMappingProfile
     {
@@ -321,6 +416,10 @@ public class QueryTypeMappingInferenceTests
                 builder.Property(e => e.ShortValue).HasAttributeName("shortValue");
                 builder.Property(e => e.NullableShortValue).HasAttributeName("nullableShortValue");
                 builder.Property(e => e.NumericStatus).HasAttributeName("numericStatus");
+                builder
+                    .Property(e => e.Code)
+                    .HasAttributeName("code")
+                    .HasConversion(code => code.Value, value => new QueryTypeMappingCode(value));
                 builder
                     .Property(e => e.StringStatus)
                     .HasAttributeName("stringStatus")

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -176,20 +176,23 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public async Task Enum_underlying_cast_on_converted_property_uses_target_numeric_mapping()
+    public async Task Enum_underlying_cast_on_converted_property_is_rejected()
     {
         var (client, captured) = CreateClient();
         await using var context = QueryTypeMappingContext.Create(client);
         var status = 1;
 
-        await context
+        var act = () => context
             .Items
             .AllowScan()
             .Where(e => (int)e.StringStatus == status)
             .ToListAsync(TestContext.Current.CancellationToken);
 
-        captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" = ?");
-        captured.Single().Parameters.Single().N.Should().Be("1");
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*value-converted enum*numeric underlying type*");
+        captured.Should().BeEmpty();
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -235,6 +235,47 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task List_contains_enum_underlying_cast_on_converted_property_is_rejected()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var values = new List<int> { 1 };
+
+        var act = () => context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains((int)e.StringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*value-converted enum*numeric underlying type*");
+        captured.Should().BeEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        Read_only_list_contains_enum_underlying_cast_on_converted_property_is_rejected()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        IReadOnlyList<int> values = [1];
+
+        var act = () => context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains((int)e.StringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*value-converted enum*numeric underlying type*");
+        captured.Should().BeEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Converted_property_parameter_uses_property_converter_mapping()
     {
         var (client, captured) = CreateClient();

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -60,6 +60,63 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_short_parameter_uses_property_numeric_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        short? value = 7;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.NullableShortValue == value)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Reversed_short_parameter_comparison_uses_property_numeric_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        short value = 7;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => value == e.ShortValue)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Theory(Timeout = TestConfiguration.DefaultTimeout)]
+    [InlineData("lt")]
+    [InlineData("le")]
+    [InlineData("gt")]
+    [InlineData("ge")]
+    public async Task Range_comparison_uses_property_numeric_mapping(string comparison)
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        short value = 7;
+
+        var query = comparison switch
+        {
+            "lt" => context.Items.AllowScan().Where(e => e.ShortValue < value),
+            "le" => context.Items.AllowScan().Where(e => e.ShortValue <= value),
+            "gt" => context.Items.AllowScan().Where(e => e.ShortValue > value),
+            "ge" => context.Items.AllowScan().Where(e => e.ShortValue >= value),
+            _ => throw new InvalidOperationException(),
+        };
+
+        await query.ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Enum_parameter_with_numeric_mapping_serializes_underlying_number()
     {
         var (client, captured) = CreateClient();
@@ -92,6 +149,22 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Inline_converted_enum_constant_uses_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.StringStatus == StringStatus.Active)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" = 'Active'");
+        captured.Single().Parameters.Should().BeNullOrEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Inline_contains_values_use_item_property_mapping()
     {
         var (client, captured) = CreateClient();
@@ -104,6 +177,22 @@ public class QueryTypeMappingInferenceTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         captured.Single().Statement.Should().Contain("WHERE \"shortValue\" IN [1, 2]");
+        captured.Single().Parameters.Should().BeNullOrEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Inline_converted_contains_values_use_item_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => new[] { StringStatus.Active }.Contains(e.StringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"stringStatus\" IN ['Active']");
         captured.Single().Parameters.Should().BeNullOrEmpty();
     }
 
@@ -121,6 +210,39 @@ public class QueryTypeMappingInferenceTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         captured.Single().Parameters.Select(p => p.N).Should().Equal("1", "2");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Parameterized_converted_contains_values_use_item_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var values = new[] { StringStatus.Active };
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains(e.StringStatus))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Select(p => p.S).Should().Equal(nameof(StringStatus.Active));
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Complex_converted_property_parameter_uses_leaf_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var status = StringStatus.Active;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.Profile.Status == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"profile\".\"status\" = ?");
+        captured.Single().Parameters.Single().S.Should().Be(nameof(StringStatus.Active));
     }
 
     private static (IAmazonDynamoDB Client, List<ExecuteStatementRequest> Captured) CreateClient()
@@ -154,9 +276,18 @@ public class QueryTypeMappingInferenceTests
 
         public short ShortValue { get; set; }
 
+        public short? NullableShortValue { get; set; }
+
         public NumericStatus NumericStatus { get; set; }
 
         public StringStatus StringStatus { get; set; }
+
+        public QueryTypeMappingProfile Profile { get; set; } = new();
+    }
+
+    private sealed class QueryTypeMappingProfile
+    {
+        public StringStatus Status { get; set; }
     }
 
     private sealed class QueryTypeMappingContext(DbContextOptions options) : DbContext(options)
@@ -170,11 +301,18 @@ public class QueryTypeMappingInferenceTests
                 builder.HasPartitionKey(e => e.Id);
                 builder.Property(e => e.Id).HasAttributeName("id");
                 builder.Property(e => e.ShortValue).HasAttributeName("shortValue");
+                builder.Property(e => e.NullableShortValue).HasAttributeName("nullableShortValue");
                 builder.Property(e => e.NumericStatus).HasAttributeName("numericStatus");
                 builder
                     .Property(e => e.StringStatus)
                     .HasAttributeName("stringStatus")
                     .HasConversion<string>();
+                builder.ComplexProperty(
+                    e => e.Profile,
+                    profileBuilder =>
+                    {
+                        profileBuilder.Property(p => p.Status).HasConversion<string>();
+                    });
             });
 
         public static QueryTypeMappingContext Create(IAmazonDynamoDB client)

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -149,6 +149,22 @@ public class QueryTypeMappingInferenceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Nullable_converted_enum_parameter_uses_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        StringStatus? status = StringStatus.Active;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.NullableStringStatus == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().S.Should().Be(nameof(StringStatus.Active));
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Inline_converted_enum_constant_uses_property_converter_mapping()
     {
         var (client, captured) = CreateClient();
@@ -282,6 +298,8 @@ public class QueryTypeMappingInferenceTests
 
         public StringStatus StringStatus { get; set; }
 
+        public StringStatus? NullableStringStatus { get; set; }
+
         public QueryTypeMappingProfile Profile { get; set; } = new();
     }
 
@@ -306,6 +324,10 @@ public class QueryTypeMappingInferenceTests
                 builder
                     .Property(e => e.StringStatus)
                     .HasAttributeName("stringStatus")
+                    .HasConversion<string>();
+                builder
+                    .Property(e => e.NullableStringStatus)
+                    .HasAttributeName("nullableStringStatus")
                     .HasConversion<string>();
                 builder.ComplexProperty(
                     e => e.Profile,

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/QueryTypeMappingInferenceTests.cs
@@ -1,0 +1,188 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NSubstitute;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Query;
+
+/// <summary>Regression tests for query type-mapping inference at parameter/literal binding.</summary>
+public class QueryTypeMappingInferenceTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Captured_short_parameter_uses_property_numeric_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        short value = 7;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.ShortValue == value)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        Captured_promoted_int_parameter_compared_to_short_property_serializes_as_number()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var value = 7;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.ShortValue == value)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("7");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task
+        Inline_numeric_literal_compared_to_short_property_serializes_as_number_literal()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.ShortValue == 7)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"shortValue\" = 7");
+        captured.Single().Parameters.Should().BeNullOrEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Enum_parameter_with_numeric_mapping_serializes_underlying_number()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var status = NumericStatus.Active;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.NumericStatus == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().N.Should().Be("1");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Converted_property_parameter_uses_property_converter_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var status = StringStatus.Active;
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => e.StringStatus == status)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Single().S.Should().Be(nameof(StringStatus.Active));
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Inline_contains_values_use_item_property_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => new[] { 1, 2 }.Contains(e.ShortValue))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Statement.Should().Contain("WHERE \"shortValue\" IN [1, 2]");
+        captured.Single().Parameters.Should().BeNullOrEmpty();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Parameterized_contains_values_use_item_property_mapping()
+    {
+        var (client, captured) = CreateClient();
+        await using var context = QueryTypeMappingContext.Create(client);
+        var values = new[] { 1, 2 };
+
+        await context
+            .Items
+            .AllowScan()
+            .Where(e => values.Contains(e.ShortValue))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        captured.Single().Parameters.Select(p => p.N).Should().Equal("1", "2");
+    }
+
+    private static (IAmazonDynamoDB Client, List<ExecuteStatementRequest> Captured) CreateClient()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        var captured = new List<ExecuteStatementRequest>();
+        client
+            .ExecuteStatementAsync(
+                Arg.Do<ExecuteStatementRequest>(captured.Add),
+                Arg.Any<CancellationToken>())
+            .Returns(new ExecuteStatementResponse { Items = [] });
+
+        return (client, captured);
+    }
+
+    private enum NumericStatus
+    {
+        Inactive = 0,
+        Active = 1,
+    }
+
+    private enum StringStatus
+    {
+        Inactive,
+        Active,
+    }
+
+    private sealed class QueryTypeMappingEntity
+    {
+        public string Id { get; set; } = null!;
+
+        public short ShortValue { get; set; }
+
+        public NumericStatus NumericStatus { get; set; }
+
+        public StringStatus StringStatus { get; set; }
+    }
+
+    private sealed class QueryTypeMappingContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<QueryTypeMappingEntity> Items => Set<QueryTypeMappingEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<QueryTypeMappingEntity>(builder =>
+            {
+                builder.ToTable("QueryTypeMappingItems");
+                builder.HasPartitionKey(e => e.Id);
+                builder.Property(e => e.Id).HasAttributeName("id");
+                builder.Property(e => e.ShortValue).HasAttributeName("shortValue");
+                builder.Property(e => e.NumericStatus).HasAttributeName("numericStatus");
+                builder
+                    .Property(e => e.StringStatus)
+                    .HasAttributeName("stringStatus")
+                    .HasConversion<string>();
+            });
+
+        public static QueryTypeMappingContext Create(IAmazonDynamoDB client)
+            => new(
+                new DbContextOptionsBuilder<QueryTypeMappingContext>()
+                    .UseDynamo(options => options.DynamoDbClient(client))
+                    .ConfigureWarnings(w
+                        => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                    .Options);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
@@ -37,6 +37,66 @@ public class DynamoEntityItemSerializerSourceTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void BuildItem_EnumWithStringConverter_UsesStringAttributeValue()
+    {
+        using var db = new ConvertedEnumDbContext(
+            new DbContextOptionsBuilder<ConvertedEnumDbContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w
+                    => w
+                        .Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)
+                        .Ignore(DynamoEventId.ScanLikeQueryDetected))
+                .Options);
+
+        var entity = new ConvertedEnumEntity
+        {
+            Pk = "E#1",
+            Sk = "E1",
+            Status = ConvertedStatus.Active,
+            OptionalStatus = ConvertedStatus.Inactive,
+        };
+
+        db.Add(entity);
+
+        var serializer = db.GetService<DynamoEntityItemSerializerSource>();
+        var updateEntry = (IUpdateEntry)db.Entry(entity).GetInfrastructure();
+
+        var item = serializer.BuildItem(updateEntry);
+        item["status"].S.Should().Be(nameof(ConvertedStatus.Active));
+        item["status"].N.Should().BeNull();
+        item["optionalStatus"].S.Should().Be(nameof(ConvertedStatus.Inactive));
+        item["optionalStatus"].N.Should().BeNull();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void BuildItem_NullableEnumWithStringConverter_UsesNullAttributeValueForNull()
+    {
+        using var db = new ConvertedEnumDbContext(
+            new DbContextOptionsBuilder<ConvertedEnumDbContext>()
+                .UseDynamo()
+                .ConfigureWarnings(w
+                    => w
+                        .Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)
+                        .Ignore(DynamoEventId.ScanLikeQueryDetected))
+                .Options);
+
+        var entity = new ConvertedEnumEntity
+        {
+            Pk = "E#2", Sk = "E2", Status = ConvertedStatus.Active, OptionalStatus = null,
+        };
+
+        db.Add(entity);
+
+        var serializer = db.GetService<DynamoEntityItemSerializerSource>();
+        var updateEntry = (IUpdateEntry)db.Entry(entity).GetInfrastructure();
+
+        var item = serializer.BuildItem(updateEntry);
+        item["optionalStatus"].NULL.Should().BeTrue();
+        item["optionalStatus"].S.Should().BeNull();
+        item["optionalStatus"].N.Should().BeNull();
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public void BuildItem_ListWithNullableEnumElements_UsesNullAttributeValueForNullElement()
     {
         using var db = new NullableCollectionDbContext(
@@ -172,6 +232,20 @@ public class DynamoEntityItemSerializerSourceTests
         Inactive = 2,
     }
 
+    private enum ConvertedStatus
+    {
+        Active = 1,
+        Inactive = 2,
+    }
+
+    private sealed class ConvertedEnumEntity
+    {
+        public string Pk { get; set; } = null!;
+        public string Sk { get; set; } = null!;
+        public ConvertedStatus Status { get; set; }
+        public ConvertedStatus? OptionalStatus { get; set; }
+    }
+
     private sealed class NullableCollectionEntity
     {
         public string Pk { get; set; } = null!;
@@ -207,6 +281,24 @@ public class DynamoEntityItemSerializerSourceTests
                 b.ToTable("Bad\"TableName");
                 b.HasPartitionKey(x => x.Pk);
                 b.HasSortKey(x => x.Sk);
+            });
+    }
+
+    private sealed class ConvertedEnumDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<ConvertedEnumEntity> Items => Set<ConvertedEnumEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<ConvertedEnumEntity>(b =>
+            {
+                b.ToTable("ConvertedEnums");
+                b.HasPartitionKey(x => x.Pk);
+                b.HasSortKey(x => x.Sk);
+                b.Property(x => x.Status).HasAttributeName("status").HasConversion<string>();
+                b
+                    .Property(x => x.OptionalStatus)
+                    .HasAttributeName("optionalStatus")
+                    .HasConversion<string>();
             });
     }
 


### PR DESCRIPTION
## Summary
Fixes query value binding so constants and parameters inherit DynamoDB type mappings from the model property they are compared with. This makes LINQ predicates use the same wire representation as saved data, including numeric promotions, nullable values, complex-property leaves, and value converters.

## Changes
- Added query translation/type-mapping inference for property comparisons, `IN` lists, and scalar access expressions.
- Extended `DynamoTypeMapping`/SQL expression factory behavior so constants and parameters can be cloned with inferred mappings.
- Normalized enum constants before converter binding, including nullable enum converter scenarios.
- Documented scalar query mapping behavior and converter expectations in `docs/querying/operators.md`.
- Added unit and DynamoDB Local integration coverage for numeric, nullable, converter, enum, `IN`, and complex-property query cases.

## Validation
- `dotnet build --no-restore`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj --no-build`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj --no-build`
- `task docs:build`
