### PR TITLE
fix(metadata): allow nullable attribute name mappings

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyBuilderExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Extensions/DynamoPropertyBuilderExtensions.cs
@@ -21,6 +21,9 @@ public static class DynamoPropertyBuilderExtensions
         }
     }
 
+    // #nullable disable removes the implicit notnull constraint on TProperty so callers
+    // mapping nullable reference properties (e.g. string?) do not get CS8714.
+#nullable disable
     extension<TProperty>(PropertyBuilder<TProperty> propertyBuilder)
     {
         /// <summary>Configures the DynamoDB attribute name used to store this scalar property.</summary>
@@ -29,6 +32,7 @@ public static class DynamoPropertyBuilderExtensions
             => (PropertyBuilder<TProperty>)((PropertyBuilder)propertyBuilder)
                 .HasAttributeName(name);
     }
+#nullable restore
 
     extension(ComplexCollectionTypePropertyBuilder builder)
     {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/AttributeNameOverrideTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/AttributeNameOverrideTests.cs
@@ -2,6 +2,7 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
 using NSubstitute;
 
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
@@ -154,6 +155,21 @@ public class AttributeNameOverrideTests
             .ToListAsync(TestContext.Current.CancellationToken);
 
         results.Should().Equal("Ada Lovelace");
+    }
+
+    /// <summary>Provides functionality for this member.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    /// <summary>Provides functionality for this member.</summary>
+    public void NullableScalarProperty_HasAttributeName_AppliesAttributeName()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var ctx = RenameDbContext.Create(client);
+
+        var entityType = ctx.Model.FindEntityType(typeof(RenameEntity));
+        var property = entityType!.FindProperty(nameof(RenameEntity.FullName));
+
+        property.Should().NotBeNull();
+        property.GetAttributeName().Should().Be("display_name");
     }
 
     private sealed record RenameEntity


### PR DESCRIPTION
## 📋 Summary

Fixes nullable reference property mappings for `HasAttributeName` so calls like `builder.Property(x => x.ImageUrl).HasAttributeName("imageUrl")` no longer produce CS8714. The generic fluent extension now avoids leaking EF Core's nullable `notnull` generic constraint to consumers while preserving the existing type-preserving return shape.

## 📝 Changes

- Suppressed nullable analysis only around the generic `PropertyBuilder<TProperty>.HasAttributeName(...)` extension declaration.
- Added a regression test covering `HasAttributeName` on a nullable `string?` property and verifying the mapped DynamoDB attribute name is applied.

## 🧪 Validation

- `dotnet build EntityFrameworkCore.DynamoDb.slnx -c Release --no-restore`
- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -c Release --no-build --no-restore`

## 🧩 Related Issues

Closes #217

## 📦 Release Notes

Nullable reference properties can now use the generic `HasAttributeName` fluent API without CS8714 nullable constraint warnings.
