### PR TITLE
test(tests): clean up query type mapping write row

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -350,31 +350,44 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     public async Task SaveChanges_writes_converted_enum_wire_values()
     {
         var pk = $"ITEM#WRITE#{Guid.NewGuid():N}";
-        Db.Items.Add(
-            new QueryTypeMappingItem
-            {
-                Pk = pk,
-                ShortValue = 10,
-                NullableShortValue = null,
-                NumericStatus = (MappingStatus)99,
-                StringStatus = (MappingStatus)99,
-                NullableStringStatus = null,
-                Profile = new QueryTypeMappingProfile { Status = (MappingStatus)99 },
-            });
+        try
+        {
+            Db.Items.Add(
+                new QueryTypeMappingItem
+                {
+                    Pk = pk,
+                    ShortValue = 10,
+                    NullableShortValue = null,
+                    NumericStatus = (MappingStatus)99,
+                    StringStatus = (MappingStatus)99,
+                    NullableStringStatus = null,
+                    Profile = new QueryTypeMappingProfile { Status = (MappingStatus)99 },
+                });
 
-        await Db.SaveChangesAsync(CancellationToken);
+            await Db.SaveChangesAsync(CancellationToken);
 
-        var response = await Client.GetItemAsync(
-            new GetItemRequest
-            {
-                TableName = "QueryTypeMappingItems",
-                Key = new Dictionary<string, AttributeValue> { ["pk"] = new() { S = pk }, },
-            },
-            CancellationToken);
+            var response = await Client.GetItemAsync(
+                new GetItemRequest
+                {
+                    TableName = "QueryTypeMappingItems",
+                    Key = new Dictionary<string, AttributeValue> { ["pk"] = new() { S = pk }, },
+                },
+                CancellationToken);
 
-        response.Item["stringStatus"].S.Should().Be("99");
-        response.Item["nullableStringStatus"].NULL.Should().BeTrue();
-        response.Item["profile"].M["status"].S.Should().Be("99");
+            response.Item["stringStatus"].S.Should().Be("99");
+            response.Item["nullableStringStatus"].NULL.Should().BeTrue();
+            response.Item["profile"].M["status"].S.Should().Be("99");
+        }
+        finally
+        {
+            await Client.DeleteItemAsync(
+                new DeleteItemRequest
+                {
+                    TableName = "QueryTypeMappingItems",
+                    Key = new Dictionary<string, AttributeValue> { ["pk"] = new() { S = pk }, },
+                },
+                CancellationToken);
+        }
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]


### PR DESCRIPTION
## Summary

Cleans up the integration test row inserted by `SaveChanges_writes_converted_enum_wire_values`. The row previously remained in the shared `QueryTypeMappingItems` table and could pollute later query tests when execution order changed.

## Changes

- Wraps the write-row assertions in `try`/`finally`.
- Deletes the generated `ITEM#WRITE#...` row from DynamoDB Local after the test runs.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj --configuration Release --filter-class EntityFrameworkCore.DynamoDb.IntegrationTests.QueryTypeMappingTable.QueryTypeMappingTests`