### PR TITLE
fix(metadata): keep discriminator opt-out per entity type

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -441,21 +441,24 @@ APIs can return multiple capacity entries.
 Model validation runs during `DbContext` initialization, before any queries execute. Failures
 throw exceptions — they are not emitted as EF Core log events.
 
-| Validation failure                                | Likely cause                                                                       | Fix                                                                                               |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Shared-table key shape mismatch                   | Entity types on the same table disagree on PK-only vs PK+SK                        | Ensure all entities on the table have matching key configurations                                 |
-| Shared-table key attribute name mismatch          | PK or SK attribute names differ across co-located entity types                     | Use consistent attribute name overrides across all entity types                                   |
-| Key type category mismatch                        | Same attribute is mapped as `string` on one type and `number` on another           | Align value converters so all types agree on the store type                                       |
-| Nullable key property                             | A partition key or sort key property is nullable                                   | DynamoDB key attributes must be non-null; make the property required                              |
-| Non-DynamoDB-compatible key type                  | Key property maps to `bool`, `Guid`, or another unsupported store type             | Add a `ValueConverter` to map to `string`, a number type, or `byte[]`                             |
-| Secondary-index key type incompatible             | GSI/LSI key property resolves to an unsupported type                               | Same as above; applies independently for each index key property                                  |
-| Root entity uses `HasKey(...)` or `[Key]`         | EF Core primary key was declared instead of DynamoDB key mapping                   | Replace with `HasPartitionKey(...)` and `HasSortKey(...)`                                         |
-| Local secondary index without sort key            | `HasLocalSecondaryIndex(...)` on a table that has no sort key                      | LSIs require the table to define both a partition key and a sort key                              |
-| Duplicate discriminator values                    | Two entity types on the same table share the same discriminator value              | Assign a unique discriminator value to each type                                                  |
-| Discriminator attribute name conflicts with PK/SK | The discriminator attribute name collides with the partition or sort key attribute | Change the discriminator name via `HasEmbeddedDiscriminatorName(...)` or rename the key attribute |
+| Validation failure                                | Likely cause                                                                                     | Fix                                                                                               |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Shared-table key shape mismatch                   | Entity types on the same table disagree on PK-only vs PK+SK                                      | Ensure all entities on the table have matching key configurations                                 |
+| Shared-table key attribute name mismatch          | PK or SK attribute names differ across co-located entity types                                   | Use consistent attribute name overrides across all entity types                                   |
+| Key type category mismatch                        | Same attribute is mapped as `string` on one type and `number` on another                         | Align value converters so all types agree on the store type                                       |
+| Nullable key property                             | A partition key or sort key property is nullable                                                 | DynamoDB key attributes must be non-null; make the property required                              |
+| Non-DynamoDB-compatible key type                  | Key property maps to `bool`, `Guid`, or another unsupported store type                           | Add a `ValueConverter` to map to `string`, a number type, or `byte[]`                             |
+| Secondary-index key type incompatible             | GSI/LSI key property resolves to an unsupported type                                             | Same as above; applies independently for each index key property                                  |
+| Root entity uses `HasKey(...)` or `[Key]`         | EF Core primary key was declared instead of DynamoDB key mapping                                 | Replace with `HasPartitionKey(...)` and `HasSortKey(...)`                                         |
+| Local secondary index without sort key            | `HasLocalSecondaryIndex(...)` on a table that has no sort key                                    | LSIs require the table to define both a partition key and a sort key                              |
+| Duplicate discriminator values                    | Two discriminator-enabled entity types on the same table share the same discriminator value      | Assign a unique discriminator value to each discriminator-enabled type                            |
+| Discriminator attribute name mismatch             | Discriminator-enabled entity types on the same table use different discriminator attribute names | Use one discriminator attribute name for the table group or opt specific types out intentionally  |
+| Discriminator attribute name conflicts with PK/SK | The discriminator attribute name collides with the partition or sort key attribute               | Change the discriminator name via `HasEmbeddedDiscriminatorName(...)` or rename the key attribute |
+| Unexpected missing discriminator predicate        | The queried entity type called `HasNoDiscriminator()` or has no active discriminator metadata    | Keep discriminator metadata on that type, or ensure PK/SK patterns isolate its items              |
+| Unexpected discriminator predicate remains        | Another entity type in the same table still has discriminator metadata                           | `HasNoDiscriminator()` is per type; call it on each type that should opt out                      |
 
-See [Entities and Keys](modeling/entities-keys.md) and [Secondary Indexes](modeling/secondary-indexes.md)
-for configuration details.
+See [Entities and Keys](modeling/entities-keys.md), [Secondary Indexes](modeling/secondary-indexes.md),
+and [Single-Table Design and Discriminators](modeling/single-table-design.md) for configuration details.
 
 ## Translation Failures
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -320,15 +320,18 @@ provider cannot guarantee auto-increment semantics on DynamoDB item writes.
 
 ### Shared-Table Discriminator Constraints
 
-When multiple entity types share the same DynamoDB table, a discriminator is required. The
-following constraints are validated at startup:
+When multiple entity types share the same DynamoDB table, the provider adds discriminator metadata
+by convention. For entity types that keep discriminator metadata, the following constraints are
+validated at startup:
 
 - Discriminator values must be unique within the table group.
 - All entity types in the group must use the same discriminator attribute name.
 - The discriminator attribute name must not collide with the partition key or sort key attribute
     names.
 
-The default discriminator attribute name is `$type`.
+The default discriminator attribute name is `$type`. `HasDiscriminator()` and
+`HasNoDiscriminator()` apply only to the entity type on which they are called; they do not configure
+or disable discrimination for the whole shared-table group.
 
 See [Single-Table Design](modeling/single-table-design.md).
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -324,8 +324,8 @@ When multiple entity types share the same DynamoDB table, the provider adds disc
 by convention. For entity types that keep discriminator metadata, the following constraints are
 validated at startup:
 
-- Discriminator values must be unique within the table group.
-- All entity types in the group must use the same discriminator attribute name.
+- Discriminator values must be unique among discriminator-enabled entity types within the table group.
+- Discriminator-enabled entity types in the group must use the same discriminator attribute name.
 - The discriminator attribute name must not collide with the partition key or sort key attribute
     names.
 

--- a/docs/modeling/single-table-design.md
+++ b/docs/modeling/single-table-design.md
@@ -128,6 +128,19 @@ Defaults:
 When a shared-table group resolves to exactly one concrete type, a discriminator is not persisted
 for that group.
 
+### Behavior reference
+
+| Scenario                                  | Convention behavior                                                              | Query behavior                                                                             |
+| ----------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| One concrete type in a table group        | No convention discriminator is persisted                                         | No discriminator predicate                                                                 |
+| Two or more concrete types share a table  | Each root type gets discriminator metadata                                       | Queries for discriminator-enabled types include a discriminator predicate                  |
+| Inheritance hierarchy                     | Discriminator is configured on the root and values are assigned to derived types | Base queries include all concrete values; derived queries include one value                |
+| `HasDiscriminator()` on one entity type   | That entity type keeps explicit discriminator metadata                           | Queries for that type use its configured discriminator                                     |
+| `HasNoDiscriminator()` on one entity type | Only that entity type opts out                                                   | Queries for that type omit discriminator predicates; other types keep their own predicates |
+
+Discriminator metadata is tracked per root entity type. For a hierarchy, the root owns the
+configured discriminator property and each concrete derived type gets a discriminator value.
+
 ### Change discriminator attribute name
 
 Use a model-level override:
@@ -136,15 +149,51 @@ Use a model-level override:
 modelBuilder.HasEmbeddedDiscriminatorName("$kind");
 ```
 
+This changes the convention discriminator attribute name for discriminator-enabled shared-table
+types. Explicit `HasDiscriminator(...)` calls keep their configured property unless changed by the
+model.
+
 ### Explicitly configured discriminators
 
 `HasDiscriminator()` and `HasNoDiscriminator()` apply only to the entity type on which they are
 called. They do not configure or disable discrimination for every other type that maps to the same
 DynamoDB table.
 
+Use `HasDiscriminator()` when you need a custom discriminator property or values:
+
+```csharp
+modelBuilder.Entity<User>(b =>
+{
+    b.ToTable("app-table");
+    b.HasPartitionKey(x => x.Pk);
+    b.HasSortKey(x => x.Sk);
+    b.HasDiscriminator<string>("Kind")
+        .HasValue<User>("user");
+});
+```
+
 Calling `HasNoDiscriminator()` on one shared-table type opts only that type out. Queries for that
 type do not include a discriminator predicate; queries for other shared-table types still use their
 own discriminator metadata.
+
+```csharp
+modelBuilder.Entity<User>().HasNoDiscriminator();
+```
+
+With `User` opted out and `Order` still discriminator-enabled, a user query omits `$type` while an
+order query still includes it:
+
+```sql
+SELECT "pk", "sk", "name"
+FROM "app-table"
+WHERE "pk" = 'TENANT#1'
+```
+
+```sql
+SELECT "pk", "sk", "$type", "description"
+FROM "app-table"
+WHERE "pk" = 'TENANT#1' AND "$type" = 'Order'
+```
 
 ## Query behavior
 
@@ -229,7 +278,10 @@ WHERE "pk" = 'TENANT#1' AND "$type" = 'Employee'
     For key-shape examples, continue with [Practical single-table pattern](#practical-single-table-pattern).
 
 Base queries materialize polymorphically (`DbSet<Person>` can return `Employee` and `Manager`).
-When discrimination is active, the discriminator attribute is included in projection.
+When discrimination is active, the discriminator attribute is written with saved items and included
+in projections that materialize entities. The materializer uses that value to choose the concrete
+CLR type. If an entity type opts out with `HasNoDiscriminator()`, queries for that type do not get
+this type-safety predicate; your PK/SK pattern must prevent cross-type reads.
 
 ### `OfType<TDerived>()` limitation
 

--- a/docs/modeling/single-table-design.md
+++ b/docs/modeling/single-table-design.md
@@ -108,10 +108,10 @@ Table-per-type (TPT) and table-per-concrete-type (TPC) are not supported.
 Use this sequence when introducing a new entity type into a shared table:
 
 1. Define the item family and sort-key prefix (for example `ORDER#`, `INVOICE#`, `USER#METADATA`)
-1. Define uniqueness at `(PK, SK)` for that family
-1. Add entity mapping to the shared `ToTable(...)` target with the same PK/SK attribute names
-1. Add query paths that include PK and the intended SK condition (`=`, `begins_with`, range)
-1. Keep discriminator enabled unless keys alone guarantee strict type isolation
+2. Define uniqueness at `(PK, SK)` for that family
+3. Add entity mapping to the shared `ToTable(...)` target with the same PK/SK attribute names
+4. Add query paths that include PK and the intended SK condition (`=`, `begins_with`, range)
+5. Keep discriminator enabled unless keys alone guarantee strict type isolation
 
 ## Discriminator behavior
 
@@ -136,28 +136,15 @@ Use a model-level override:
 modelBuilder.HasEmbeddedDiscriminatorName("$kind");
 ```
 
-### Disable discriminators for a shared table
+### Explicitly configured discriminators
 
-If your key design already guarantees type isolation, you can disable discriminator filtering:
+`HasDiscriminator()` and `HasNoDiscriminator()` apply only to the entity type on which they are
+called. They do not configure or disable discrimination for every other type that maps to the same
+DynamoDB table.
 
-```csharp
-modelBuilder.Entity<User>(b =>
-{
-    b.ToTable("app-table");
-    b.HasPartitionKey(x => x.Pk);
-    b.HasSortKey(x => x.Sk);
-    b.HasNoDiscriminator();
-});
-```
-
-Calling `HasNoDiscriminator()` on any root entity in a shared-table group disables discrimination
-for the entire group.
-
-!!! warning "Disabling discriminators removes type predicates"
-
-    Without a discriminator, the provider does not inject type-level query filtering.
-    Queries return all items matching key conditions, regardless of CLR type.
-    Only use this when your PK/SK patterns guarantee type separation.
+Calling `HasNoDiscriminator()` on one shared-table type opts only that type out. Queries for that
+type do not include a discriminator predicate; queries for other shared-table types still use their
+own discriminator metadata.
 
 ## Query behavior
 
@@ -168,8 +155,8 @@ The provider injects discriminator predicates automatically when discrimination 
 At query time, these pieces combine in order:
 
 1. DynamoDB key conditions decide which items are read (PK and optional SK conditions)
-1. Provider discriminator predicate narrows items to allowed CLR types in the shared-table group
-1. Materialization uses discriminator values to create the correct concrete CLR type
+2. Provider discriminator predicate narrows items to allowed CLR types in the shared-table group
+3. Materialization uses discriminator values to create the correct concrete CLR type
 
 This is why key design and discriminator design should be treated as one system, not separate
 features.
@@ -288,8 +275,8 @@ filtering may be redundant. Keep it enabled by default unless you have verified 
 Think about single-table modeling as three layered constraints:
 
 1. **Key constraints (PK/SK)** define where an item lives and whether `(PK, SK)` is unique
-1. **Type constraints (discriminator)** define which CLR type an item belongs to
-1. **Query constraints (LINQ shape)** define which subset of that data you read for one use case
+2. **Type constraints (discriminator)** define which CLR type an item belongs to
+3. **Query constraints (LINQ shape)** define which subset of that data you read for one use case
 
 If any layer is weak, results can be broader than intended.
 
@@ -376,13 +363,11 @@ Before finalizing keys, define invariants explicitly:
 Treat these as model-level expectations. If the application violates them, you can read wrong
 item shapes even when the EF model itself is valid.
 
-### Keep or disable discriminator?
+### Keep discriminator enabled
 
-- Keep enabled (recommended): when shared partitions can contain multiple CLR types for the same
-    query path
-- Consider disabling: only when PK/SK patterns guarantee mutually exclusive type reads and you
-    deliberately want no type predicate injection
-- Avoid disabling early: it removes a safety boundary that prevents accidental cross-type reads
+Keep discriminator metadata on shared-table types unless a type intentionally owns key patterns that
+cannot overlap other CLR types. `HasNoDiscriminator()` is a per-type opt-out; it does not remove
+predicates or metadata from other types in the table.
 
 ## Common mistakes to avoid
 
@@ -391,17 +376,16 @@ item shapes even when the EF model itself is valid.
 - Letting multiple writers generate inconsistent SK formats for the same item family
 - Using ambiguous prefixes that overlap across types (`USER#` vs `USER_METADATA#` without a clear
     convention)
-- Disabling discriminator filtering before key invariants and query shapes are validated in real
-    traffic
+- Calling `HasNoDiscriminator()` on one type and expecting it to opt out the entire shared table
 
 ## Recommended workflow
 
 1. Start from access patterns (what must be fetched together)
-1. Design PK/SK values to satisfy those patterns
-1. Map all participating entity types to one table
-1. Keep discriminators enabled unless key design alone guarantees safe isolation
-1. Validate query shapes on base and derived sets
-1. Inspect generated query text/logs to confirm key-focused predicates (`PK`, `SK`, `begins_with`)
+2. Design PK/SK values to satisfy those patterns
+3. Map all participating entity types to one table
+4. Keep discriminator metadata on each shared-table entity type unless that type intentionally opts out
+5. Validate query shapes on base and derived sets
+6. Inspect generated query text/logs to confirm key-focused predicates (`PK`, `SK`, `begins_with`)
 
 ## See also
 

--- a/docs/modeling/single-table-design.md
+++ b/docs/modeling/single-table-design.md
@@ -159,41 +159,60 @@ model.
 called. They do not configure or disable discrimination for every other type that maps to the same
 DynamoDB table.
 
-Use `HasDiscriminator()` when you need a custom discriminator property or values:
+Use a model-level discriminator name override when every discriminator-enabled type in the shared
+DynamoDB table should use the same custom attribute:
 
 ```csharp
+modelBuilder.HasEmbeddedDiscriminatorName("Kind");
+
 modelBuilder.Entity<User>(b =>
 {
     b.ToTable("app-table");
     b.HasPartitionKey(x => x.Pk);
     b.HasSortKey(x => x.Sk);
-    b.HasDiscriminator<string>("Kind")
-        .HasValue<User>("user");
+});
+
+modelBuilder.Entity<Order>(b =>
+{
+    b.ToTable("app-table");
+    b.HasPartitionKey(x => x.Pk);
+    b.HasSortKey(x => x.Sk);
 });
 ```
 
+Use `HasDiscriminator()` directly only when every discriminator-enabled type that maps to the same
+DynamoDB table is configured with the same discriminator attribute name.
+
 Calling `HasNoDiscriminator()` on one shared-table type opts only that type out. Queries for that
 type do not include a discriminator predicate; queries for other shared-table types still use their
-own discriminator metadata.
+own discriminator metadata. You can call it before or after `ToTable(...)`; explicit opt-out is
+preserved during model finalization.
 
 ```csharp
 modelBuilder.Entity<User>().HasNoDiscriminator();
 ```
 
 With `User` opted out and `Order` still discriminator-enabled, a user query omits `$type` while an
-order query still includes it:
+order query still includes it. Because the user query has no discriminator predicate, include PK/SK
+conditions that isolate the user item family:
 
 ```sql
 SELECT "pk", "sk", "name"
 FROM "app-table"
-WHERE "pk" = 'TENANT#1'
+WHERE "pk" = 'TENANT#1' AND begins_with("sk", 'USER#')
 ```
 
 ```sql
 SELECT "pk", "sk", "$type", "description"
 FROM "app-table"
-WHERE "pk" = 'TENANT#1' AND "$type" = 'Order'
+WHERE "pk" = 'TENANT#1' AND begins_with("sk", 'ORDER#') AND "$type" = 'Order'
 ```
+
+!!! warning "Opted-out types rely on key isolation"
+
+    A query for an opted-out entity type does not include a discriminator predicate. If its PK/SK
+    conditions can match multiple item shapes, the provider can read rows that belong to other CLR
+    types. Only use per-type opt-out when your key pattern isolates that entity's items.
 
 ## Query behavior
 

--- a/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Infrastructure/Internal/DynamoModelValidator.cs
@@ -511,21 +511,7 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
             .ToList();
 
         if (concreteTypesWithDiscriminator.Count == 0)
-        {
-            if (rootEntityTypes.All(IsDiscriminatorDisabled))
-                return;
-
-            throw new InvalidOperationException(
-                $"Entity types mapped to shared DynamoDB table '{tableName}' do not define a discriminator property. "
-                + "Shared-table mappings with multiple entity types require a discriminator by default. "
-                + "Call HasNoDiscriminator() for the table group to explicitly opt out.");
-        }
-
-        // Mixed state (some with discriminator, some without) is normalized by
-        // DynamoDiscriminatorConvention before finalization — if any root in the group has an
-        // explicit no-discriminator signal, the convention propagates HasNoDiscriminator() to the
-        // entire group. By the time validation runs, all concrete types either have a discriminator
-        // property or none do, so concreteTypesWithDiscriminator.Count == concreteTypes.Count here.
+            return;
 
         var first = concreteTypesWithDiscriminator[0];
         var expectedDiscriminatorProperty = first.FindDiscriminatorProperty()
@@ -580,9 +566,6 @@ internal sealed class DynamoModelValidator(ModelValidatorDependencies dependenci
             rootEntityTypes,
             expectedDiscriminatorAttributeName);
     }
-
-    private static bool IsDiscriminatorDisabled(IEntityType entityType)
-        => entityType[DynamoAnnotationNames.DiscriminatorDisabled] as bool? == true;
 
     /// <summary>
     ///     Validates that the shared-table discriminator attribute does not collide with PK/SK

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
@@ -24,7 +24,7 @@ public sealed class DynamoDiscriminatorConvention(
     public void ProcessEntityTypeAdded(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionContext<IConventionEntityTypeBuilder> context)
-        => ProcessModel(entityTypeBuilder.Metadata.Model);
+        => ProcessModel(entityTypeBuilder.Metadata.Model, false);
 
     /// <inheritdoc />
     public void ProcessEntityTypeAnnotationChanged(
@@ -42,7 +42,7 @@ public sealed class DynamoDiscriminatorConvention(
         if (string.Equals(newTableName, oldTableName, StringComparison.Ordinal))
             return;
 
-        ProcessModel(entityTypeBuilder.Metadata.Model);
+        ProcessModel(entityTypeBuilder.Metadata.Model, false);
     }
 
     /// <inheritdoc />
@@ -54,7 +54,7 @@ public sealed class DynamoDiscriminatorConvention(
     {
         base.ProcessEntityTypeBaseTypeChanged(entityTypeBuilder, newBaseType, oldBaseType, context);
 
-        ProcessModel(entityTypeBuilder.Metadata.Model);
+        ProcessModel(entityTypeBuilder.Metadata.Model, false);
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public sealed class DynamoDiscriminatorConvention(
     {
         base.ProcessEntityTypeRemoved(modelBuilder, entityType, context);
 
-        ProcessModel(modelBuilder.Metadata);
+        ProcessModel(modelBuilder.Metadata, false);
     }
 
     /// <inheritdoc />
@@ -82,7 +82,7 @@ public sealed class DynamoDiscriminatorConvention(
         if (name is not null)
         {
             SetDiscriminatorDisabledAnnotation(entityType, false);
-            ProcessModel(entityType.Model);
+            ProcessModel(entityType.Model, false);
             return;
         }
 
@@ -91,7 +91,7 @@ public sealed class DynamoDiscriminatorConvention(
             return;
 
         SetDiscriminatorDisabledAnnotation(entityType, true);
-        ProcessModel(entityType.Model);
+        ProcessModel(entityType.Model, false);
     }
 
     /// <inheritdoc />
@@ -104,16 +104,16 @@ public sealed class DynamoDiscriminatorConvention(
         if (string.Equals(newName, oldName, StringComparison.Ordinal))
             return;
 
-        ProcessModel(modelBuilder.Metadata);
+        ProcessModel(modelBuilder.Metadata, false);
     }
 
     /// <summary>Applies discriminator conventions to table groups that map multiple concrete entity types.</summary>
     public void ProcessModelFinalizing(
         IConventionModelBuilder modelBuilder,
         IConventionContext<IConventionModelBuilder> context)
-        => ProcessModel(modelBuilder.Metadata);
+        => ProcessModel(modelBuilder.Metadata, true);
 
-    private void ProcessModel(IConventionModel model)
+    private void ProcessModel(IConventionModel model, bool finalizing)
     {
         var rootEntityTypes = model
             .GetEntityTypes()
@@ -134,7 +134,23 @@ public sealed class DynamoDiscriminatorConvention(
             if (concreteEntityTypes.Count <= 1 && !hasHierarchy)
             {
                 foreach (var rootEntityType in tableGroup)
-                    RemoveConventionDiscriminator(rootEntityType);
+                {
+                    if (IsDiscriminatorDisabled(rootEntityType)
+                        || HasExplicitNoDiscriminator(rootEntityType))
+                    {
+                        RemoveConventionDiscriminator(rootEntityType);
+                        SetDiscriminatorDisabledAnnotation(rootEntityType, true);
+                        continue;
+                    }
+
+                    if (finalizing)
+                    {
+                        RemoveConventionDiscriminator(rootEntityType);
+                        continue;
+                    }
+
+                    ConfigureDiscriminator(rootEntityType);
+                }
 
                 continue;
             }
@@ -150,26 +166,7 @@ public sealed class DynamoDiscriminatorConvention(
                 }
 
                 SetDiscriminatorDisabledAnnotation(rootEntityType, false);
-
-                var discriminatorProperty = rootEntityType.FindDiscriminatorProperty();
-                var preserveExistingDiscriminator = discriminatorProperty is not null
-                    && rootEntityType.GetDiscriminatorPropertyConfigurationSource()
-                    != ConfigurationSource.Convention;
-
-                var discriminatorBuilder = preserveExistingDiscriminator
-                    ? rootEntityType.Builder.HasDiscriminator(
-                        discriminatorProperty!.Name,
-                        discriminatorProperty.ClrType)
-                    : rootEntityType.Builder.HasDiscriminator(
-                        rootEntityType.Model.GetEmbeddedDiscriminatorName(),
-                        typeof(string));
-
-                if (discriminatorBuilder is null)
-                    continue;
-
-                SetDefaultDiscriminatorValues(
-                    rootEntityType.GetDerivedTypesInclusive(),
-                    discriminatorBuilder);
+                ConfigureDiscriminator(rootEntityType);
             }
         }
     }
@@ -187,6 +184,31 @@ public sealed class DynamoDiscriminatorConvention(
         entityType.Builder.HasNoDiscriminator();
     }
 
+    /// <summary>Configures discriminator metadata for an entity type that should be discriminated.</summary>
+    private void ConfigureDiscriminator(IConventionEntityType rootEntityType)
+    {
+        var discriminatorProperty = rootEntityType.FindDiscriminatorProperty();
+        var preserveExistingDiscriminator = discriminatorProperty is not null
+            && rootEntityType.GetDiscriminatorPropertyConfigurationSource()
+            != ConfigurationSource.Convention;
+
+        var discriminatorBuilder = preserveExistingDiscriminator
+            ? rootEntityType.Builder.HasDiscriminator(
+                discriminatorProperty!.Name,
+                discriminatorProperty.ClrType)
+            : rootEntityType.Builder.HasDiscriminator(
+                rootEntityType.Model.GetEmbeddedDiscriminatorName(),
+                typeof(string));
+
+        if (discriminatorBuilder is null)
+            return;
+
+        SetDefaultDiscriminatorValues(
+            rootEntityType.GetDerivedTypesInclusive(),
+            discriminatorBuilder);
+    }
+
+    /// <summary>Stores or clears the provider annotation that preserves explicit discriminator opt-out.</summary>
     private static void SetDiscriminatorDisabledAnnotation(
         IConventionEntityType entityType,
         bool disabled)
@@ -194,9 +216,11 @@ public sealed class DynamoDiscriminatorConvention(
             DynamoAnnotationNames.DiscriminatorDisabled,
             disabled ? true : null);
 
+    /// <summary>Returns whether the entity type has explicitly opted out of discriminator metadata.</summary>
     private static bool IsDiscriminatorDisabled(IConventionEntityType entityType)
         => entityType[DynamoAnnotationNames.DiscriminatorDisabled] as bool? == true;
 
+    /// <summary>Returns whether EF Core metadata records an explicit discriminator removal.</summary>
     private static bool HasExplicitNoDiscriminator(IConventionEntityType entityType)
         => entityType.FindDiscriminatorProperty() is null
             && entityType.GetDiscriminatorPropertyConfigurationSource() is { } source

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Conventions/DynamoDiscriminatorConvention.cs
@@ -24,7 +24,7 @@ public sealed class DynamoDiscriminatorConvention(
     public void ProcessEntityTypeAdded(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionContext<IConventionEntityTypeBuilder> context)
-        => ProcessModel(entityTypeBuilder.Metadata.Model, false);
+        => ProcessModel(entityTypeBuilder.Metadata.Model);
 
     /// <inheritdoc />
     public void ProcessEntityTypeAnnotationChanged(
@@ -42,7 +42,7 @@ public sealed class DynamoDiscriminatorConvention(
         if (string.Equals(newTableName, oldTableName, StringComparison.Ordinal))
             return;
 
-        ProcessModel(entityTypeBuilder.Metadata.Model, false);
+        ProcessModel(entityTypeBuilder.Metadata.Model);
     }
 
     /// <inheritdoc />
@@ -54,7 +54,7 @@ public sealed class DynamoDiscriminatorConvention(
     {
         base.ProcessEntityTypeBaseTypeChanged(entityTypeBuilder, newBaseType, oldBaseType, context);
 
-        ProcessModel(entityTypeBuilder.Metadata.Model, false);
+        ProcessModel(entityTypeBuilder.Metadata.Model);
     }
 
     /// <inheritdoc />
@@ -65,7 +65,7 @@ public sealed class DynamoDiscriminatorConvention(
     {
         base.ProcessEntityTypeRemoved(modelBuilder, entityType, context);
 
-        ProcessModel(modelBuilder.Metadata, false);
+        ProcessModel(modelBuilder.Metadata);
     }
 
     /// <inheritdoc />
@@ -82,7 +82,7 @@ public sealed class DynamoDiscriminatorConvention(
         if (name is not null)
         {
             SetDiscriminatorDisabledAnnotation(entityType, false);
-            ProcessModel(entityType.Model, false);
+            ProcessModel(entityType.Model);
             return;
         }
 
@@ -91,7 +91,7 @@ public sealed class DynamoDiscriminatorConvention(
             return;
 
         SetDiscriminatorDisabledAnnotation(entityType, true);
-        ProcessModel(entityType.Model, false);
+        ProcessModel(entityType.Model);
     }
 
     /// <inheritdoc />
@@ -104,16 +104,16 @@ public sealed class DynamoDiscriminatorConvention(
         if (string.Equals(newName, oldName, StringComparison.Ordinal))
             return;
 
-        ProcessModel(modelBuilder.Metadata, false);
+        ProcessModel(modelBuilder.Metadata);
     }
 
     /// <summary>Applies discriminator conventions to table groups that map multiple concrete entity types.</summary>
     public void ProcessModelFinalizing(
         IConventionModelBuilder modelBuilder,
         IConventionContext<IConventionModelBuilder> context)
-        => ProcessModel(modelBuilder.Metadata, true);
+        => ProcessModel(modelBuilder.Metadata);
 
-    private void ProcessModel(IConventionModel model, bool removeSingleTypeConventionDiscriminators)
+    private void ProcessModel(IConventionModel model)
     {
         var rootEntityTypes = model
             .GetEntityTypes()
@@ -131,43 +131,8 @@ public sealed class DynamoDiscriminatorConvention(
                 .Distinct()
                 .ToList();
 
-            if (tableGroup.Any(static rootEntityType
-                => IsDiscriminatorDisabled(rootEntityType)
-                || HasExplicitNoDiscriminator(rootEntityType)))
-            {
-                foreach (var rootEntityType in tableGroup)
-                {
-                    rootEntityType.Builder.HasNoDiscriminator();
-                    SetDiscriminatorDisabledAnnotation(rootEntityType, true);
-                }
-
-                continue;
-            }
-
-            foreach (var rootEntityType in tableGroup)
-                SetDiscriminatorDisabledAnnotation(rootEntityType, false);
-
             if (concreteEntityTypes.Count <= 1 && !hasHierarchy)
             {
-                if (!removeSingleTypeConventionDiscriminators)
-                {
-                    foreach (var rootEntityType in tableGroup)
-                    {
-                        var discriminatorBuilder = rootEntityType.Builder.HasDiscriminator(
-                            rootEntityType.Model.GetEmbeddedDiscriminatorName(),
-                            typeof(string));
-
-                        if (discriminatorBuilder is null)
-                            continue;
-
-                        SetDefaultDiscriminatorValues(
-                            rootEntityType.GetDerivedTypesInclusive(),
-                            discriminatorBuilder);
-                    }
-
-                    continue;
-                }
-
                 foreach (var rootEntityType in tableGroup)
                     RemoveConventionDiscriminator(rootEntityType);
 
@@ -176,9 +141,28 @@ public sealed class DynamoDiscriminatorConvention(
 
             foreach (var rootEntityType in tableGroup)
             {
-                var discriminatorBuilder = rootEntityType.Builder.HasDiscriminator(
-                    rootEntityType.Model.GetEmbeddedDiscriminatorName(),
-                    typeof(string));
+                if (IsDiscriminatorDisabled(rootEntityType)
+                    || HasExplicitNoDiscriminator(rootEntityType))
+                {
+                    RemoveConventionDiscriminator(rootEntityType);
+                    SetDiscriminatorDisabledAnnotation(rootEntityType, true);
+                    continue;
+                }
+
+                SetDiscriminatorDisabledAnnotation(rootEntityType, false);
+
+                var discriminatorProperty = rootEntityType.FindDiscriminatorProperty();
+                var preserveExistingDiscriminator = discriminatorProperty is not null
+                    && rootEntityType.GetDiscriminatorPropertyConfigurationSource()
+                    != ConfigurationSource.Convention;
+
+                var discriminatorBuilder = preserveExistingDiscriminator
+                    ? rootEntityType.Builder.HasDiscriminator(
+                        discriminatorProperty!.Name,
+                        discriminatorProperty.ClrType)
+                    : rootEntityType.Builder.HasDiscriminator(
+                        rootEntityType.Model.GetEmbeddedDiscriminatorName(),
+                        typeof(string));
 
                 if (discriminatorBuilder is null)
                     continue;

--- a/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Metadata/Internal/DynamoAnnotationNames.cs
@@ -23,7 +23,7 @@ public static class DynamoAnnotationNames
     /// <summary>Annotation key for the discriminator strategy applied to a shared-table entity type.</summary>
     public const string DiscriminatorStrategy = Prefix + "DiscriminatorStrategy";
 
-    /// <summary>Marks a shared-table mapping group as explicitly opting out of discriminator metadata.</summary>
+    /// <summary>Marks a shared-table entity type as explicitly opting out of discriminator metadata.</summary>
     public const string DiscriminatorDisabled = Prefix + "DiscriminatorDisabled";
 
     /// <summary>Annotation key for the secondary index name on an entity type or property.</summary>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/DiscriminatorQueryTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/DiscriminatorQueryTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedTable;
 
@@ -98,25 +97,27 @@ public class DiscriminatorQuerySingleTypeTests(DynamoContainerFixture fixture)
 public class DiscriminatorQueryHasNoDiscriminatorTests(DynamoContainerFixture fixture)
     : SharedTableTestFixture(fixture)
 {
-    private SharedTableHasNoDiscriminatorDbContext HasNoDiscriminatorDb
+    private SharedTableEarlyHasNoDiscriminatorDbContext HasNoDiscriminatorDb
         => new(
-            CreateOptions<SharedTableHasNoDiscriminatorDbContext>(o => o.DynamoDbClient(Client)));
+            CreateOptions<SharedTableEarlyHasNoDiscriminatorDbContext>(o
+                => o.DynamoDbClient(Client)));
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task SharedTableWithHasNoDiscriminator_DoesNotInjectDiscriminatorPredicate()
     {
         var results = await HasNoDiscriminatorDb
             .Users
-            .Where(user => user.Pk == "TENANT#U")
+            .Where(user => user.Pk == "TENANT#U" && user.Sk.StartsWith("USER#"))
             .ToListAsync(CancellationToken);
 
         results.Should().HaveCount(2);
+        results.Select(user => user.Name).Should().Equal("Ada", "Lin");
 
         AssertSql(
             """
             SELECT "pk", "sk", "name"
             FROM "app-table"
-            WHERE "pk" = 'TENANT#U'
+            WHERE "pk" = 'TENANT#U' AND begins_with("sk", 'USER#')
             """);
     }
 
@@ -126,16 +127,17 @@ public class DiscriminatorQueryHasNoDiscriminatorTests(DynamoContainerFixture fi
     {
         var results = await HasNoDiscriminatorDb
             .Orders
-            .Where(order => order.Pk == "TENANT#O")
+            .Where(order => order.Pk == "TENANT#O" && order.Sk.StartsWith("ORDER#"))
             .ToListAsync(CancellationToken);
 
         results.Should().HaveCount(2);
+        results.Select(order => order.Description).Should().Equal("order-one", "order-two");
 
         AssertSql(
             """
             SELECT "pk", "sk", "$type", "description"
             FROM "app-table"
-            WHERE "pk" = 'TENANT#O' AND "$type" = 'OrderEntity'
+            WHERE "pk" = 'TENANT#O' AND begins_with("sk", 'ORDER#') AND "$type" = 'OrderEntity'
             """);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/DiscriminatorQueryTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/DiscriminatorQueryTests.cs
@@ -122,7 +122,7 @@ public class DiscriminatorQueryHasNoDiscriminatorTests(DynamoContainerFixture fi
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task
-        SharedTableWithHasNoDiscriminator_DoesNotInjectDiscriminatorPredicate_ForOrders()
+        SharedTableWithHasNoDiscriminator_StillInjectsDiscriminatorPredicate_ForOrders()
     {
         var results = await HasNoDiscriminatorDb
             .Orders
@@ -133,9 +133,9 @@ public class DiscriminatorQueryHasNoDiscriminatorTests(DynamoContainerFixture fi
 
         AssertSql(
             """
-            SELECT "pk", "sk", "description"
+            SELECT "pk", "sk", "$type", "description"
             FROM "app-table"
-            WHERE "pk" = 'TENANT#O'
+            WHERE "pk" = 'TENANT#O' AND "$type" = 'OrderEntity'
             """);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/DbContext.cs
@@ -1,5 +1,4 @@
 using Amazon.DynamoDBv2;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedTable;
 
@@ -91,17 +90,65 @@ public class SharedTableSingleTypeDbContext(DbContextOptions options) : DbContex
 
 /// <summary>
 ///     Context with two unrelated entity types sharing the same table while explicitly removing
-///     discriminator metadata from one type via <c>HasNoDiscriminator()</c>.
+///     discriminator metadata from one type via an early <c>HasNoDiscriminator()</c> call.
 /// </summary>
-public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : DbContext(options)
+public class SharedTableEarlyHasNoDiscriminatorDbContext(DbContextOptions options) : DbContext(
+    options)
 {
     public DbSet<UserEntity> Users => Set<UserEntity>();
     public DbSet<OrderEntity> Orders => Set<OrderEntity>();
 
     /// <summary>Creates a context configured to use the provided DynamoDB client instance.</summary>
-    public static SharedTableHasNoDiscriminatorDbContext Create(IAmazonDynamoDB client)
+    public static SharedTableEarlyHasNoDiscriminatorDbContext Create(IAmazonDynamoDB client)
         => new(
-            new DbContextOptionsBuilder<SharedTableHasNoDiscriminatorDbContext>()
+            is there a
+
+    private hybrid option
+
+    private where
+        we're using both we can sacrifice ordering and stuff like that for using HasnoDiscriminator? But I think it'
+    private s good
+    private to keep
+    private that option
+    private because I
+    private think people
+    private still will
+    private use that if
+    private unintentionally.I think
+    private having a
+    private hybrid approach
+    private where we're adding stuff but we'
+    private re also
+    private exclusively removing
+    private it or something else.
+    private I want
+    private you to
+    private think this
+    private through but
+    private also validate
+    private against Mongo and Dynamo.Sorry, I'm not talking Mongo and Cosmos to see if there'
+    private s lessons
+    private learned from
+    private how they
+    private handle it
+    private because I
+    private know they
+    private have different
+    private types of discriminators too.So
+    private we need
+    private to figure out
+    private a better
+    private holistic solution
+    private here that is user-
+    private friendly and it's
+    private not doing
+    private weird stuff
+    private like shadows
+    private because that
+    private will lead
+    private to the
+    private bug we had originally. new
+        DbContextOptionsBuilder<SharedTableEarlyHasNoDiscriminatorDbContext>()
                 .UseDynamo(o => o.DynamoDbClient(client))
                 .Options);
 
@@ -109,6 +156,7 @@ public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : 
     {
         modelBuilder.Entity<UserEntity>(builder =>
         {
+            builder.HasNoDiscriminator();
             builder.ToTable(SharedItemTable.TableName);
             builder.HasPartitionKey(x => x.Pk);
             builder.HasSortKey(x => x.Sk);
@@ -120,8 +168,6 @@ public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : 
             builder.HasPartitionKey(x => x.Pk);
             builder.HasSortKey(x => x.Sk);
         });
-
-        modelBuilder.Entity<UserEntity>().HasNoDiscriminator();
     }
 }
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/DbContext.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedTable/Infra/DbContext.cs
@@ -91,7 +91,7 @@ public class SharedTableSingleTypeDbContext(DbContextOptions options) : DbContex
 
 /// <summary>
 ///     Context with two unrelated entity types sharing the same table while explicitly removing
-///     the discriminator metadata via <c>HasNoDiscriminator()</c>.
+///     discriminator metadata from one type via <c>HasNoDiscriminator()</c>.
 /// </summary>
 public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : DbContext(options)
 {
@@ -112,7 +112,6 @@ public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : 
             builder.ToTable(SharedItemTable.TableName);
             builder.HasPartitionKey(x => x.Pk);
             builder.HasSortKey(x => x.Sk);
-            builder.HasNoDiscriminator();
         });
 
         modelBuilder.Entity<OrderEntity>(builder =>
@@ -121,6 +120,8 @@ public class SharedTableHasNoDiscriminatorDbContext(DbContextOptions options) : 
             builder.HasPartitionKey(x => x.Pk);
             builder.HasSortKey(x => x.Sk);
         });
+
+        modelBuilder.Entity<UserEntity>().HasNoDiscriminator();
     }
 }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorMetadataTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorMetadataTests.cs
@@ -1,5 +1,4 @@
 using Amazon.DynamoDBv2;
-using EntityFrameworkCore.DynamoDb.Metadata.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using NSubstitute;
@@ -171,6 +170,32 @@ public class DiscriminatorMetadataTests
             => new(BuildOptions<SharedTableHasNoDiscriminatorEarlyContext>(client));
     }
 
+    private sealed class SharedTableHasNoDiscriminatorLateContext(DbContextOptions options)
+        : DbContext(options)
+    {
+        /// <summary>Provides functionality for this member.</summary>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<UserEntity>(b =>
+            {
+                b.ToTable("App");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+            modelBuilder.Entity<OrderEntity>(b =>
+            {
+                b.ToTable("App");
+                b.HasPartitionKey(x => x.Id);
+            });
+
+            modelBuilder.Entity<UserEntity>().HasNoDiscriminator();
+        }
+
+        /// <summary>Provides functionality for this member.</summary>
+        public static SharedTableHasNoDiscriminatorLateContext Create(IAmazonDynamoDB client)
+            => new(BuildOptions<SharedTableHasNoDiscriminatorLateContext>(client));
+    }
+
     private sealed class SplitThenSharedTableContext(DbContextOptions options) : DbContext(options)
     {
         /// <summary>Provides functionality for this member.</summary>
@@ -287,7 +312,7 @@ public class DiscriminatorMetadataTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void SharedTableHasNoDiscriminator_EarlyCall_DisablesDiscriminatorForGroup()
+    public void SharedTableHasNoDiscriminator_EarlyCall_DoesNotDisableDiscriminatorForGroup()
     {
         var client = Substitute.For<IAmazonDynamoDB>();
         using var context = SharedTableHasNoDiscriminatorEarlyContext.Create(client);
@@ -295,9 +320,20 @@ public class DiscriminatorMetadataTests
         var userEntityType = context.Model.FindEntityType(typeof(UserEntity))!;
         var orderEntityType = context.Model.FindEntityType(typeof(OrderEntity))!;
 
+        userEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
+        orderEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void SharedTableHasNoDiscriminator_LateCall_DisablesOnlyThatType()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = SharedTableHasNoDiscriminatorLateContext.Create(client);
+
+        var userEntityType = context.Model.FindEntityType(typeof(UserEntity))!;
+        var orderEntityType = context.Model.FindEntityType(typeof(OrderEntity))!;
+
         userEntityType.FindDiscriminatorProperty().Should().BeNull();
-        orderEntityType.FindDiscriminatorProperty().Should().BeNull();
-        userEntityType[DynamoAnnotationNames.DiscriminatorDisabled].Should().Be(true);
-        orderEntityType[DynamoAnnotationNames.DiscriminatorDisabled].Should().Be(true);
+        orderEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorMetadataTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorMetadataTests.cs
@@ -312,7 +312,7 @@ public class DiscriminatorMetadataTests
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void SharedTableHasNoDiscriminator_EarlyCall_DoesNotDisableDiscriminatorForGroup()
+    public void SharedTableHasNoDiscriminator_EarlyCall_DisablesOnlyThatType()
     {
         var client = Substitute.For<IAmazonDynamoDB>();
         using var context = SharedTableHasNoDiscriminatorEarlyContext.Create(client);
@@ -320,7 +320,7 @@ public class DiscriminatorMetadataTests
         var userEntityType = context.Model.FindEntityType(typeof(UserEntity))!;
         var orderEntityType = context.Model.FindEntityType(typeof(OrderEntity))!;
 
-        userEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
+        userEntityType.FindDiscriminatorProperty().Should().BeNull();
         orderEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
     }
 
@@ -335,5 +335,29 @@ public class DiscriminatorMetadataTests
 
         userEntityType.FindDiscriminatorProperty().Should().BeNull();
         orderEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void SharedTableHasNoDiscriminator_EarlyAndLateCalls_ProduceSameModelShape()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var earlyContext = SharedTableHasNoDiscriminatorEarlyContext.Create(client);
+        using var lateContext = SharedTableHasNoDiscriminatorLateContext.Create(client);
+
+        var earlyUserEntityType = earlyContext.Model.FindEntityType(typeof(UserEntity))!;
+        var earlyOrderEntityType = earlyContext.Model.FindEntityType(typeof(OrderEntity))!;
+        var lateUserEntityType = lateContext.Model.FindEntityType(typeof(UserEntity))!;
+        var lateOrderEntityType = lateContext.Model.FindEntityType(typeof(OrderEntity))!;
+
+        earlyUserEntityType.FindDiscriminatorProperty().Should().BeNull();
+        lateUserEntityType.FindDiscriminatorProperty().Should().BeNull();
+        earlyOrderEntityType.FindDiscriminatorProperty()!
+            .Name
+            .Should()
+            .Be(lateOrderEntityType.FindDiscriminatorProperty()!.Name);
+        earlyOrderEntityType
+            .GetDiscriminatorValue()
+            .Should()
+            .Be(lateOrderEntityType.GetDiscriminatorValue());
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorValidationTests.cs
@@ -128,7 +128,6 @@ public class DiscriminatorValidationTests
                 b.ToTable("App");
                 b.HasPartitionKey(x => x.PK);
                 b.HasSortKey(x => x.SK);
-                b.HasNoDiscriminator();
             });
 
             modelBuilder.Entity<OrderEntity>(b =>
@@ -137,6 +136,8 @@ public class DiscriminatorValidationTests
                 b.HasPartitionKey(x => x.PK);
                 b.HasSortKey(x => x.SK);
             });
+
+            modelBuilder.Entity<UserEntity>().HasNoDiscriminator();
         }
 
         /// <summary>Provides functionality for this member.</summary>
@@ -155,7 +156,6 @@ public class DiscriminatorValidationTests
                 b.ToTable("App");
                 b.HasPartitionKey(x => x.PK);
                 b.HasSortKey(x => x.SK);
-                b.HasNoDiscriminator();
             });
 
             modelBuilder.Entity<OrderEntity>(b =>
@@ -163,8 +163,10 @@ public class DiscriminatorValidationTests
                 b.ToTable("App");
                 b.HasPartitionKey(x => x.PK);
                 b.HasSortKey(x => x.SK);
-                b.HasNoDiscriminator();
             });
+
+            modelBuilder.Entity<UserEntity>().HasNoDiscriminator();
+            modelBuilder.Entity<OrderEntity>().HasNoDiscriminator();
         }
 
         /// <summary>Provides functionality for this member.</summary>
@@ -300,10 +302,6 @@ public class DiscriminatorValidationTests
         act.Should().NotThrow();
     }
 
-    // MissingDiscriminatorPropertyContext calls HasDiscriminator() explicitly then nulls the
-    // property via SetDiscriminatorProperty(null). Because HasDiscriminator() was called with an
-    // explicit configuration source, HasExplicitNoDiscriminator() returns true and the convention
-    // treats the whole group as opted out — no throw is expected.
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public void SharedTableMultipleTypes_WithMissingDiscriminatorProperty_RemainsValid()
     {

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Metadata/DiscriminatorValidationTests.cs
@@ -319,9 +319,13 @@ public class DiscriminatorValidationTests
         var client = MockClient();
         using var context = HasNoDiscriminatorContext.Create(client);
 
-        var act = () => context.Model;
+        var model = context.Model;
+        var userEntityType = model.FindEntityType(typeof(UserEntity))!;
+        var orderEntityType = model.FindEntityType(typeof(OrderEntity))!;
 
-        act.Should().NotThrow();
+        userEntityType.FindDiscriminatorProperty().Should().BeNull();
+        orderEntityType.FindDiscriminatorProperty()!.Name.Should().Be("$type");
+        orderEntityType.GetDiscriminatorValue().Should().Be("OrderEntity");
     }
 
     /// <summary>Provides functionality for this member.</summary>
@@ -332,9 +336,12 @@ public class DiscriminatorValidationTests
         var client = MockClient();
         using var context = HasNoDiscriminatorOnEveryTypeContext.Create(client);
 
-        var act = () => context.Model;
+        var model = context.Model;
+        var userEntityType = model.FindEntityType(typeof(UserEntity))!;
+        var orderEntityType = model.FindEntityType(typeof(OrderEntity))!;
 
-        act.Should().NotThrow();
+        userEntityType.FindDiscriminatorProperty().Should().BeNull();
+        orderEntityType.FindDiscriminatorProperty().Should().BeNull();
     }
 
     /// <summary>Provides functionality for this member.</summary>


### PR DESCRIPTION
## Summary

Updates shared-table discriminator convention behavior so `HasNoDiscriminator()` remains scoped to the entity type it is called on instead of disabling discriminator metadata across the full table group. This lets mixed shared-table mappings keep discriminator predicates for types that still rely on them while allowing explicit per-type opt-out.

## Changes

- Keep discriminator removal localized to explicitly opted-out entity types.
- Preserve discriminator metadata and query predicates for other shared-table entity types.
- Add unit and integration coverage for early/late `HasNoDiscriminator()` calls and mixed table groups.
- Update modeling and limitations docs to describe per-type opt-out behavior.

## Validation

- Tests not run locally.

## Release Notes

- `HasNoDiscriminator()` now applies only to the configured entity type in shared-table mappings; other entity types in the same table can continue using discriminator metadata.

## Notes for Reviewers

Opened as draft because local validation was not run.