### PR TITLE
test(specification): improve DynamoDB test coverage details

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.6.0-preview.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.6"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.8"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Testing Libraries -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
@@ -28,8 +28,8 @@
     <PackageVersion Include="YTest.MTP.XUnit2" Version="1.0.3"/>
   </ItemGroup>
   <ItemGroup Label="Microsoft EF Core (net10.0)">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8"/>
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.6.0-preview.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.6"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Testing Libraries -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
@@ -24,9 +25,11 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.2.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageVersion Include="YTest.MTP.XUnit2" Version="1.0.3"/>
   </ItemGroup>
   <ItemGroup Label="Microsoft EF Core (net10.0)">
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6"/>
   </ItemGroup>
 </Project>

--- a/EntityFrameworkCore.DynamoDb.slnx
+++ b/EntityFrameworkCore.DynamoDb.slnx
@@ -26,6 +26,7 @@
   <Folder Name="/tests/">
     <File Path="tests\Directory.Build.props" />
     <Project Path="tests\EntityFrameworkCore.DynamoDb.IntegrationTests\EntityFrameworkCore.DynamoDb.IntegrationTests.csproj" />
+    <Project Path="tests\EntityFrameworkCore.DynamoDb.SpecificationTests\EntityFrameworkCore.DynamoDb.SpecificationTests.csproj" />
     <Project Path="tests\EntityFrameworkCore.DynamoDb.Tests\EntityFrameworkCore.DynamoDb.Tests.csproj" />
   </Folder>
 </Solution>

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -28,6 +28,14 @@
 - Put infrastructure and extension-method tests in the matching top-level folders under
   `tests/EntityFrameworkCore.DynamoDb.Tests/`.
 
+## Specification Test Placement
+
+- Use `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/` for EF Core cross-provider
+  specification tests — overrides of `*TestBase<TFixture>` classes from
+  `Microsoft.EntityFrameworkCore.Specification.Tests`.
+- See `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md` for how to add or extend
+  specification tests.
+
 ## Integration Test Placement
 
 - Group integration tests by table scenario under

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj
@@ -43,8 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 </Project>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
@@ -7,15 +7,16 @@ those tests run against a real DynamoDB Local instance.
 
 ## Shared Infrastructure
 
-| File                                                   | Role                                                                                                                     |
-|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `TestUtilities/DynamoSpecificationContainerFixture.cs` | Process-scoped DynamoDB Local container (Testcontainers). Lazily started once per process.                               |
-| `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                    |
-| `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                    |
-| `TestUtilities/TestSqlLoggerFactory.cs`                | Captures emitted PartiQL via `DynamoEventId.ExecutingPartiQlQuery` for baseline assertions.                              |
-| `TestUtilities/DynamoTestHelpers.cs`                   | `NoSyncTest()` helper — catches expected sync-query failures.                                                            |
-| `TestUtilities/DynamoSpecificationFixture.cs`          | `IDynamoSpecificationFixture` interface + `ClearSql`/`AssertSql`/`ShouldLogDynamoSql` extensions shared by all fixtures. |
-| `AssemblyFixtures.cs`                                  | Disables test parallelization assembly-wide.                                                                             |
+| File                                                   | Role                                                                                                                         |
+|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `TestUtilities/DynamoSpecificationContainerFixture.cs` | Shared DynamoDB Local container (Testcontainers). Started asynchronously by spec test infrastructure and disposed after use. |
+| `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                        |
+| `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                        |
+| `TestUtilities/TestSqlLoggerFactory.cs`                | Captures emitted PartiQL via `DynamoEventId.ExecutingPartiQlQuery` for baseline assertions.                                  |
+| `TestUtilities/DynamoTestHelpers.cs`                   | `NoSyncTest()` helper — catches expected sync-query failures.                                                                |
+| `TestUtilities/DynamoSpecificationFixture.cs`          | `IDynamoSpecificationFixture` interface + `ClearSql`/`AssertSql`/`ShouldLogDynamoSql` extensions shared by all fixtures.     |
+| `AssemblyFixtures.cs`                                  | Disables test parallelization assembly-wide.                                                                                 |
+| `DynamoSpecificationCollection`                        | xUnit collection fixture used by concrete spec test classes that need DynamoDB Local.                                        |
 
 ## Adding a New Specification Test
 
@@ -71,7 +72,15 @@ public abstract class XxxDynamoTest : XxxTestBase<XxxDynamoTest.XxxDynamoFixture
     }
 
     // xUnit only discovers non-abstract classes; this subclass is the actual test class.
-    public class XxxDynamoTestDefault(XxxDynamoFixture fixture) : XxxDynamoTest(fixture);
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class XxxDynamoTestDefault : XxxDynamoTest
+    {
+        public XxxDynamoTestDefault(
+            XxxDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
 }
 ```
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
@@ -1,0 +1,129 @@
+# Specification Tests
+
+EF Core ships a cross-provider test suite in `Microsoft.EntityFrameworkCore.Specification.Tests`
+(source: `efcore/test/EFCore.Specification.Tests/`). Each `*TestBase<TFixture>` class defines the
+full test surface for a feature area. This project provides DynamoDB fixtures and overrides so
+those tests run against a real DynamoDB Local instance.
+
+## Shared Infrastructure
+
+| File                                                   | Role                                                                                                                     |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `TestUtilities/DynamoSpecificationContainerFixture.cs` | Process-scoped DynamoDB Local container (Testcontainers). Lazily started once per process.                               |
+| `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                    |
+| `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                    |
+| `TestUtilities/TestSqlLoggerFactory.cs`                | Captures emitted PartiQL via `DynamoEventId.ExecutingPartiQlQuery` for baseline assertions.                              |
+| `TestUtilities/DynamoTestHelpers.cs`                   | `NoSyncTest()` helper — catches expected sync-query failures.                                                            |
+| `TestUtilities/DynamoSpecificationFixture.cs`          | `IDynamoSpecificationFixture` interface + `ClearSql`/`AssertSql`/`ShouldLogDynamoSql` extensions shared by all fixtures. |
+| `AssemblyFixtures.cs`                                  | Disables test parallelization assembly-wide.                                                                             |
+
+## Adding a New Specification Test
+
+### 1. Find the base class
+
+Browse `efcore/test/EFCore.Specification.Tests/` for the relevant `*TestBase.cs`. It defines all
+virtual test methods to override. It also contains an inner `*FixtureBase` abstract class (e.g.
+`FindTestBase<TFixture>.FindFixtureBase`) — that is the parent your fixture must extend, not any
+external class.
+
+### 2. Create the test class and fixture
+
+```csharp
+public abstract class XxxDynamoTest : XxxTestBase<XxxDynamoTest.XxxDynamoFixture>
+{
+    protected XxxDynamoTest(XxxDynamoFixture fixture) : base(fixture) => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(XxxDynamoTest));
+
+    // overrides go here ...
+
+    public class XxxDynamoFixture : XxxFixtureBase, IDynamoSpecificationFixture
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder)
+                .UseDynamo(o => o.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            // Set table name and partition key for each entity type.
+        }
+
+        protected override Task SeedAsync(PoolableDbContext context)
+        {
+            context.AddRange(/* ... */);
+            return context.SaveChangesAsync();
+        }
+    }
+
+    // xUnit only discovers non-abstract classes; this subclass is the actual test class.
+    public class XxxDynamoTestDefault(XxxDynamoFixture fixture) : XxxDynamoTest(fixture);
+}
+```
+
+### 3. Handle overrides
+
+Every specification test class must include `Check_all_tests_overridden` and call
+`DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(CurrentDynamoTestBase))`. Use the provider
+spec-test base type, not `GetType()`, because concrete nested xUnit classes inherit from the
+abstract provider base class.
+
+Explicitly override every inherited spec test method. Each override must run the base test, skip
+with a provider limitation reason, expect provider-specific failure, or assert provider-specific
+behavior.
+
+**Sync methods** — DynamoDB has no sync query path:
+
+```csharp
+public override void Some_sync_test()
+    => NoSyncTest(() => base.Some_sync_test());
+```
+
+**Unsupported scenarios** — skip with an empty body:
+
+```csharp
+[ConditionalFact(Skip = "DynamoDB does not support composite keys.")]
+public override void Some_unsupported_test() { }
+
+[ConditionalTheory(Skip = "DynamoDB does not support composite keys.")]
+public override Task Some_unsupported_test_async(CancellationType ct) => Task.CompletedTask;
+```
+
+**Assert emitted PartiQL** — call `AssertSql(...)` after the base call. Pass no arguments for
+tests expected to produce no SQL (e.g. cache hits):
+
+```csharp
+public override async Task Some_async_test(CancellationType ct)
+{
+    await base.Some_async_test(ct);
+    AssertSql("""
+        SELECT ...
+        FROM ...
+        WHERE ...
+        """);
+}
+```
+
+## Known DynamoDB Limitations
+
+| Feature        | Skip reason                                   |
+|----------------|-----------------------------------------------|
+| Composite keys | `"DynamoDB does not support composite keys."` |
+| Nullable keys  | `"DynamoDB does not support nullable keys."`  |
+| Shadow keys    | `"DynamoDB does not support shadow keys."`    |
+
+Define skip-reason constants at the top of each test class.

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AssemblyFixtures.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AssemblyFixtures.cs
@@ -1,0 +1,1 @@
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -2,7 +2,6 @@ using EntityFrameworkCore.DynamoDb.Diagnostics;
 using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
@@ -55,7 +54,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_data_type_shadow();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_nullable_data_type()
         => base.Can_query_using_any_nullable_data_type();
 
@@ -209,6 +207,13 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
+            modelBuilder.Ignore<BuiltInNullableDataTypesShadow>();
+
+            // TODO: remove and add better discriminator support
+            modelBuilder.Entity<BuiltInDataTypesShadow>(b =>
+            {
+                b.Ignore("$type");
+            });
         }
 
         /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -51,7 +51,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type_shadow()
         => base.Can_query_using_any_data_type_shadow();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -58,7 +58,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_nullable_data_type();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type_nullable_shadow()
         => base.Can_query_using_any_data_type_nullable_shadow();
 
@@ -207,7 +206,6 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
-            modelBuilder.Ignore<BuiltInNullableDataTypesShadow>();
 
             // TODO: remove and add better discriminator support
             modelBuilder.Entity<BuiltInDataTypesShadow>(b =>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -62,7 +62,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_data_type_nullable_shadow();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_nullable_data_type_as_literal()
         => base.Can_query_using_any_nullable_data_type_as_literal();
 
@@ -87,9 +86,56 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_with_max_length_set();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
-    public override Task Can_insert_and_read_back_with_binary_key()
-        => base.Can_insert_and_read_back_with_binary_key();
+    public override async Task Can_insert_and_read_back_with_binary_key()
+    {
+        await using (var context = CreateContext())
+        {
+            context
+                .Set<DynamoBinaryKeyDataType>()
+                .AddRange(
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3], Ex = "X1" },
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4], Ex = "X3" },
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4, 5], Ex = "X2" });
+
+            Assert.Equal(3, await context.SaveChangesAsync());
+        }
+
+        async Task<BinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
+            => (await context.Set<BinaryKeyDataType>().Where(e => e.Id == bytes).ToListAsync())
+                .Single();
+
+        await using (var context = CreateContext())
+        {
+            var items = await context.Set<DynamoBinaryKeyDataType>().ToListAsync();
+
+            var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
+            Assert.Equal(new byte[] { 1, 2, 3 }, entity1.Id);
+
+            var entity2 = await QueryByBinaryKey(context, [1, 2, 3, 4]);
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, entity2.Id);
+
+            var entity3 = await QueryByBinaryKey(context, [1, 2, 3, 4, 5]);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, entity3.Id);
+
+            entity3.Ex = "Xx1";
+            entity2.Ex = "Xx3";
+            entity1.Ex = "Xx7";
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = CreateContext())
+        {
+            var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
+            Assert.Equal("Xx7", entity1.Ex);
+
+            var entity2 = await QueryByBinaryKey(context, [1, 2, 3, 4]);
+            Assert.Equal("Xx3", entity2.Ex);
+
+            var entity3 = await QueryByBinaryKey(context, [1, 2, 3, 4, 5]);
+            Assert.Equal("Xx1", entity3.Ex);
+        }
+    }
 
     /// <inheritdoc />
     [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
@@ -97,7 +143,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_null_binary_foreign_key();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
     public override Task Can_insert_and_read_back_with_string_key()
         => base.Can_insert_and_read_back_with_string_key();
 
@@ -201,6 +246,8 @@ public class BuiltInDataTypesDynamoTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
+            modelBuilder.Entity<DynamoBinaryKeyDataType>();
+
             modelBuilder.Ignore<Animal>();
             modelBuilder.Ignore<AnimalDetails>();
             modelBuilder.Ignore<AnimalIdentification>();
@@ -242,8 +289,10 @@ public class BuiltInDataTypesDynamoTest(
         public override bool PreservesDateTimeKind => false;
     }
 
-    protected class DynamoAnimal : Animal
+    protected class DynamoBinaryKeyDataType
     {
-        public new List<AnimalIdentification> IdentificationMethods { get; set; } = [];
+        public required byte[] Id { get; set; }
+
+        public required string Ex { get; set; }
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -204,6 +204,12 @@ public class BuiltInDataTypesDynamoTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
+            modelBuilder.Ignore<Animal>();
+            modelBuilder.Ignore<AnimalDetails>();
+            modelBuilder.Ignore<AnimalIdentification>();
+            modelBuilder.Ignore<StringForeignKeyDataType>();
+            modelBuilder.Ignore<BinaryForeignKeyDataType>();
+
             ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
             ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
             ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
@@ -214,46 +220,22 @@ public class BuiltInDataTypesDynamoTest(
             ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
             ConfigureIdKey<EmailTemplate>(modelBuilder);
             ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<Animal>(modelBuilder);
-            ConfigureIdKey<AnimalDetails>(modelBuilder);
-            ConfigureIdKey<AnimalIdentification>(modelBuilder);
+            // ConfigureIdKey<Animal>(modelBuilder);
+            // ConfigureIdKey<AnimalDetails>(modelBuilder);
+            // ConfigureIdKey<AnimalIdentification>(modelBuilder);
             ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
             ConfigureIdKey<StringEnclosure>(modelBuilder);
             ConfigureIdKey<StringKeyDataType>(modelBuilder);
-            ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
+            // ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
             ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
-            ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
-
-            modelBuilder
-                .Entity<Animal>()
-                .HasMany(e => e.IdentificationMethods)
-                .WithOne()
-                .HasForeignKey(e => e.AnimalId);
-
-            modelBuilder
-                .Entity<Animal>()
-                .HasOne(e => e.Details)
-                .WithOne()
-                .HasForeignKey<AnimalDetails>(e => e.AnimalId);
-
-            modelBuilder
-                .Entity<StringKeyDataType>()
-                .HasMany(e => e.Dependents)
-                .WithOne(e => e.Principal)
-                .HasForeignKey(e => e.StringKeyDataTypeId);
-
-            modelBuilder
-                .Entity<BinaryKeyDataType>()
-                .HasMany(e => e.Dependents)
-                .WithOne(e => e.Principal)
-                .HasForeignKey(e => e.BinaryKeyDataTypeId);
+            // ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
         }
 
         private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
             where TEntity : class
         {
             var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
-            entityTypeBuilder.Property("Id").ValueGeneratedNever();
+
             return entityTypeBuilder;
         }
 
@@ -283,5 +265,10 @@ public class BuiltInDataTypesDynamoTest(
 
         /// <inheritdoc />
         public override bool PreservesDateTimeKind => false;
+    }
+
+    protected class DynamoAnimal : Animal
+    {
+        public new List<AnimalIdentification> IdentificationMethods { get; set; } = [];
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -211,34 +211,6 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
-
-            ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
-            ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
-            ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
-            ConfigureIdKey<BuiltInNullableDataTypesShadow>(modelBuilder);
-            ConfigureIdKey<NonNullableBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<NullableBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<MaxLengthDataTypes>(modelBuilder);
-            ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
-            ConfigureIdKey<EmailTemplate>(modelBuilder);
-            ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
-            // ConfigureIdKey<Animal>(modelBuilder);
-            // ConfigureIdKey<AnimalDetails>(modelBuilder);
-            // ConfigureIdKey<AnimalIdentification>(modelBuilder);
-            ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
-            ConfigureIdKey<StringEnclosure>(modelBuilder);
-            ConfigureIdKey<StringKeyDataType>(modelBuilder);
-            // ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
-            ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
-            // ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
-        }
-
-        private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
-            where TEntity : class
-        {
-            var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
-
-            return entityTypeBuilder;
         }
 
         /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -1,0 +1,295 @@
+using EntityFrameworkCore.DynamoDb.Diagnostics;
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+/// <summary>Built-in data type specification tests for the DynamoDB provider.</summary>
+public class BuiltInDataTypesDynamoTest(
+    BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture fixture)
+    : BuiltInDataTypesTestBase<BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture>(fixture)
+{
+    private const string NonEmbeddedNavigationsNotSupported =
+        "DynamoDB does not support non-embedded navigation queries in this test shape.";
+
+    private const string ObjectToStringProjectionNotSupported =
+        "DynamoDB does not translate object ToString projection for built-in data type coverage yet.";
+
+    private const string DateTimeOffsetMemberProjectionNotSupported =
+        "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
+
+    private const string ProviderTypeMappingGaps =
+        "DynamoDB provider does not fully support this built-in type mapping query shape yet.";
+
+    /// <summary>Ensures all inherited specification tests are reviewed by this provider.</summary>
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(BuiltInDataTypesDynamoTest));
+
+    /// <inheritdoc />
+    public override async Task Can_filter_projection_with_captured_enum_variable(bool async)
+    {
+        if (!async)
+        {
+            await AssertNoSync(() => base.Can_filter_projection_with_captured_enum_variable(async));
+            return;
+        }
+
+        await base.Can_filter_projection_with_captured_enum_variable(async);
+    }
+
+    /// <inheritdoc />
+    public override async Task Can_filter_projection_with_inline_enum_variable(bool async)
+    {
+        if (!async)
+        {
+            await AssertNoSync(() => base.Can_filter_projection_with_inline_enum_variable(async));
+            return;
+        }
+
+        await base.Can_filter_projection_with_inline_enum_variable(async);
+    }
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type_shadow()
+        => base.Can_query_using_any_data_type_shadow();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_nullable_data_type()
+        => base.Can_query_using_any_nullable_data_type();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type_nullable_shadow()
+        => base.Can_query_using_any_data_type_nullable_shadow();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_nullable_data_type_as_literal()
+        => base.Can_query_using_any_nullable_data_type_as_literal();
+
+    /// <inheritdoc />
+    public override Task Can_query_with_null_parameters_using_any_nullable_data_type()
+        => base.Can_query_with_null_parameters_using_any_nullable_data_type();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_all_non_nullable_data_types()
+        => base.Can_insert_and_read_back_all_non_nullable_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_perform_query_with_max_length()
+        => base.Can_perform_query_with_max_length();
+
+    /// <inheritdoc />
+    public override Task Can_perform_query_with_ansi_strings_test()
+        => base.Can_perform_query_with_ansi_strings_test();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_with_max_length_set()
+        => base.Can_insert_and_read_with_max_length_set();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_insert_and_read_back_with_binary_key()
+        => base.Can_insert_and_read_back_with_binary_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_with_null_binary_foreign_key()
+        => base.Can_insert_and_read_back_with_null_binary_foreign_key();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_insert_and_read_back_with_string_key()
+        => base.Can_insert_and_read_back_with_string_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_with_null_string_foreign_key()
+        => base.Can_insert_and_read_back_with_null_string_foreign_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null()
+        => base.Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null();
+
+    /// <inheritdoc />
+    public override Task
+        Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null()
+        => base.Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_object_backed_data_types()
+        => base.Can_insert_and_read_back_object_backed_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_nullable_backed_data_types()
+        => base.Can_insert_and_read_back_nullable_backed_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_non_nullable_backed_data_types()
+        => base.Can_insert_and_read_back_non_nullable_backed_data_types();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_read_back_mapped_enum_from_collection_first_or_default()
+        => base.Can_read_back_mapped_enum_from_collection_first_or_default();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_read_back_bool_mapped_as_int_through_navigation()
+        => base.Can_read_back_bool_mapped_as_int_through_navigation();
+
+    /// <inheritdoc />
+    public override Task Can_compare_enum_to_constant() => base.Can_compare_enum_to_constant();
+
+    /// <inheritdoc />
+    public override Task Can_compare_enum_to_parameter() => base.Can_compare_enum_to_parameter();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ObjectToStringProjectionNotSupported)]
+    public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = DateTimeOffsetMemberProjectionNotSupported)]
+    public override Task Optional_datetime_reading_null_from_database()
+        => base.Optional_datetime_reading_null_from_database();
+
+    /// <inheritdoc />
+    public override Task Can_insert_query_multiline_string()
+        => base.Can_insert_query_multiline_string();
+
+    private static async Task AssertNoSync(Func<Task> testCode)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(testCode);
+
+        Assert.Contains("Sync enumerating", exception.Message);
+        Assert.Contains("DynamoDB", exception.Message);
+    }
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    /// <summary>Fixture for built-in data type specification tests.</summary>
+    public class BuiltInDataTypesDynamoFixture
+        : BuiltInDataTypesFixtureBase, IDynamoSpecificationFixture
+    {
+        /// <inheritdoc />
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        /// <inheritdoc />
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        /// <inheritdoc />
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        /// <inheritdoc />
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base
+                .AddOptions(builder)
+                .ConfigureWarnings(warnings => warnings.Ignore(
+                    CoreEventId.ManyServiceProvidersCreatedWarning,
+                    DynamoEventId.NoCompatibleSecondaryIndexFound,
+                    DynamoEventId.ScanLikeQueryDetected))
+                .UseDynamo(options
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        /// <inheritdoc />
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync().ConfigureAwait(false);
+            await context.Database.EnsureCreatedAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
+            ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
+            ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
+            ConfigureIdKey<BuiltInNullableDataTypesShadow>(modelBuilder);
+            ConfigureIdKey<NonNullableBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<NullableBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<MaxLengthDataTypes>(modelBuilder);
+            ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
+            ConfigureIdKey<EmailTemplate>(modelBuilder);
+            ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<Animal>(modelBuilder);
+            ConfigureIdKey<AnimalDetails>(modelBuilder);
+            ConfigureIdKey<AnimalIdentification>(modelBuilder);
+            ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
+            ConfigureIdKey<StringEnclosure>(modelBuilder);
+            ConfigureIdKey<StringKeyDataType>(modelBuilder);
+            ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
+            ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
+            ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
+
+            modelBuilder
+                .Entity<Animal>()
+                .HasMany(e => e.IdentificationMethods)
+                .WithOne()
+                .HasForeignKey(e => e.AnimalId);
+
+            modelBuilder
+                .Entity<Animal>()
+                .HasOne(e => e.Details)
+                .WithOne()
+                .HasForeignKey<AnimalDetails>(e => e.AnimalId);
+
+            modelBuilder
+                .Entity<StringKeyDataType>()
+                .HasMany(e => e.Dependents)
+                .WithOne(e => e.Principal)
+                .HasForeignKey(e => e.StringKeyDataTypeId);
+
+            modelBuilder
+                .Entity<BinaryKeyDataType>()
+                .HasMany(e => e.Dependents)
+                .WithOne(e => e.Principal)
+                .HasForeignKey(e => e.BinaryKeyDataTypeId);
+        }
+
+        private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
+            where TEntity : class
+        {
+            var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
+            entityTypeBuilder.Property("Id").ValueGeneratedNever();
+            return entityTypeBuilder;
+        }
+
+        /// <inheritdoc />
+        public override bool StrictEquality => true;
+
+        /// <inheritdoc />
+        public override int IntegerPrecision => 64;
+
+        /// <inheritdoc />
+        public override bool SupportsAnsi => false;
+
+        /// <inheritdoc />
+        public override bool SupportsUnicodeToAnsiConversion => false;
+
+        /// <inheritdoc />
+        public override bool SupportsLargeStringComparisons => true;
+
+        /// <inheritdoc />
+        public override bool SupportsBinaryKeys => true;
+
+        /// <inheritdoc />
+        public override bool SupportsDecimalComparisons => true;
+
+        /// <inheritdoc />
+        public override DateTime DefaultDateTime => new();
+
+        /// <inheritdoc />
+        public override bool PreservesDateTimeKind => false;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -97,6 +97,7 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_binary_key();
 
     /// <inheritdoc />
+    [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
     public override Task Can_insert_and_read_back_with_null_binary_foreign_key()
         => base.Can_insert_and_read_back_with_null_binary_foreign_key();
 
@@ -106,6 +107,7 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_string_key();
 
     /// <inheritdoc />
+    [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
     public override Task Can_insert_and_read_back_with_null_string_foreign_key()
         => base.Can_insert_and_read_back_with_null_string_foreign_key();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -48,7 +48,6 @@ public class BuiltInDataTypesDynamoTest(
     }
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
 
     /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -15,9 +15,6 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-    private const string DateTimeOffsetMemberProjectionNotSupported =
-        "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
-
     private const string ProviderTypeMappingGaps =
         "DynamoDB provider does not fully support this built-in type mapping query shape yet.";
 
@@ -153,7 +150,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = DateTimeOffsetMemberProjectionNotSupported)]
     public override Task Optional_datetime_reading_null_from_database()
         => base.Optional_datetime_reading_null_from_database();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -15,9 +15,6 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-    private const string ObjectToStringProjectionNotSupported =
-        "DynamoDB does not translate object ToString projection for built-in data type coverage yet.";
-
     private const string DateTimeOffsetMemberProjectionNotSupported =
         "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
 
@@ -153,7 +150,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Can_compare_enum_to_parameter() => base.Can_compare_enum_to_parameter();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ObjectToStringProjectionNotSupported)]
     public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
 
     /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/CLAUDE.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/DynamoApiConsistencyTest.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using EntityFrameworkCore.DynamoDb.Extensions;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.Metadata.Builders;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+public class DynamoApiConsistencyTest(DynamoApiConsistencyTest.DynamoApiConsistencyFixture fixture)
+    : ApiConsistencyTestBase<DynamoApiConsistencyTest.DynamoApiConsistencyFixture>(fixture)
+{
+    protected override void AddServices(ServiceCollection serviceCollection)
+        => serviceCollection.AddEntityFrameworkDynamo();
+
+    protected override Assembly TargetAssembly => typeof(DynamoDatabaseWrapper).Assembly;
+
+    public override void Fluent_api_methods_should_not_return_void()
+    {
+        var voidMethods =
+            GetAllTypes(Fixture.FluentApiTypes)
+                .Where(type
+                    => type.IsVisible && !type.Name.StartsWith("<M>$", StringComparison.Ordinal))
+                .SelectMany(
+                    type => type.GetMethods(
+                        PublicInstance | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    (type, method) => new { type, method })
+                .Where(t => t.method.ReturnType == typeof(void))
+                .Select(t => t.type.Name + "." + t.method.Name)
+                .ToList();
+
+        Assert.False(
+            voidMethods.Count > 0,
+            "\r\n-- Missing fluent returns --\r\n" + string.Join(Environment.NewLine, voidMethods));
+    }
+
+    public class DynamoApiConsistencyFixture : ApiConsistencyFixtureBase
+    {
+        public override HashSet<Type> FluentApiTypes { get; } =
+        [
+            typeof(DynamoDbContextOptionsBuilder),
+            typeof(DynamoDbContextOptionsExtensions),
+            typeof(DynamoServiceCollectionExtensions),
+            typeof(DynamoDbQueryableExtensions),
+            typeof(DynamoEntityTypeBuilderExtensions),
+            typeof(DynamoPropertyBuilderExtensions),
+            typeof(DynamoIndexBuilderExtensions),
+            typeof(DynamoSecondaryIndexBuilder),
+            typeof(DynamoSecondaryIndexBuilder<>),
+        ];
+
+        public DynamoApiConsistencyFixture()
+            => GenericFluentApiTypes.Add(
+                typeof(DynamoSecondaryIndexBuilder),
+                typeof(DynamoSecondaryIndexBuilder<>));
+
+        public override
+            Dictionary<Type, (Type ReadonlyExtensions, Type MutableExtensions, Type
+                ConventionExtensions, Type ConventionBuilderExtensions, Type RuntimeExtensions)>
+            MetadataExtensionTypes { get; } = new()
+        {
+            {
+                typeof(IReadOnlyEntityType),
+                (typeof(DynamoEntityTypeExtensions), typeof(DynamoEntityTypeExtensions),
+                    typeof(DynamoEntityTypeExtensions), typeof(DynamoEntityTypeBuilderExtensions),
+                    typeof(DynamoEntityTypeExtensions))
+            },
+            {
+                typeof(IReadOnlyProperty),
+                (typeof(DynamoPropertyExtensions), typeof(DynamoPropertyExtensions),
+                    typeof(DynamoPropertyExtensions), typeof(DynamoPropertyBuilderExtensions),
+                    null!)
+            },
+            {
+                typeof(IReadOnlyComplexProperty),
+                (typeof(DynamoPropertyExtensions), typeof(DynamoPropertyExtensions),
+                    typeof(DynamoPropertyExtensions), null!, null!)
+            },
+            {
+                typeof(IReadOnlyIndex),
+                (typeof(DynamoIndexExtensions), typeof(DynamoIndexExtensions),
+                    typeof(DynamoIndexExtensions), typeof(DynamoIndexBuilderExtensions), null!)
+            },
+        };
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Aliases="EFCoreRelational"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="Testcontainers.DynamoDb"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
@@ -27,5 +27,9 @@
   <ItemGroup>
     <ProjectReference
       Include="..\..\src\EntityFrameworkCore.DynamoDb\EntityFrameworkCore.DynamoDb.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 </Project>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Aliases="EFCoreRelational"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.DynamoDb"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="YTest.MTP.XUnit2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\..\src\EntityFrameworkCore.DynamoDb\EntityFrameworkCore.DynamoDb.csproj"/>
+  </ItemGroup>
+</Project>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -8,7 +8,6 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 /// <summary>Specification find tests for the DynamoDB provider.</summary>
 public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFixture>
 {
-    private const string CompositeKeysNotSupported = "DynamoDB does not support composite keys.";
     private const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
     private const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
 
@@ -39,14 +38,18 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     public override void Returns_null_for_string_key_not_in_store()
         => NoSyncTest(() => base.Returns_null_for_string_key_not_in_store());
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Find_composite_key_tracked() { }
+    public override void Find_composite_key_tracked()
+    {
+        base.Find_composite_key_tracked();
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Find_composite_key_from_store() { }
+        AssertSql();
+    }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_composite_key_not_in_store() { }
+    public override void Find_composite_key_from_store()
+        => NoSyncTest(() => base.Find_composite_key_from_store());
+
+    public override void Returns_null_for_composite_key_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_composite_key_not_in_store());
 
     public override void Find_base_type_from_store()
         => NoSyncTest(() => base.Find_base_type_from_store());
@@ -141,20 +144,36 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     [ConditionalFact(Skip = ShadowKeysNotSupported)]
     public override void Returns_null_for_shadow_key_not_in_store() { }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_null_key_values_array() { }
+    public override void Returns_null_for_null_key_values_array()
+    {
+        base.Returns_null_for_null_key_values_array();
+
+        AssertSql();
+    }
 
     [ConditionalFact(Skip = NullableKeysNotSupported)]
     public override void Returns_null_for_null_nullable_key() { }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Returns_null_for_null_in_composite_key() { }
+    public override void Returns_null_for_null_in_composite_key()
+    {
+        base.Returns_null_for_null_in_composite_key();
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Throws_for_wrong_number_of_values_for_composite_key() { }
+        AssertSql();
+    }
 
-    [ConditionalFact(Skip = CompositeKeysNotSupported)]
-    public override void Throws_for_bad_type_for_composite_key() { }
+    public override void Throws_for_wrong_number_of_values_for_composite_key()
+    {
+        base.Throws_for_wrong_number_of_values_for_composite_key();
+
+        AssertSql();
+    }
+
+    public override void Throws_for_bad_type_for_composite_key()
+    {
+        base.Throws_for_bad_type_for_composite_key();
+
+        AssertSql();
+    }
 
     [ConditionalFact(Skip = ShadowKeysNotSupported)]
     public override void Throws_for_bad_entity_type_with_different_namespace() { }
@@ -172,19 +191,6 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Find_composite_key_tracked_async(CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Find_composite_key_from_store_async(CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_composite_key_not_in_store_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
     [ConditionalTheory(Skip = ShadowKeysNotSupported)]
     public override Task Find_shadow_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
@@ -195,26 +201,6 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
     [ConditionalTheory(Skip = ShadowKeysNotSupported)]
     public override Task Returns_null_for_shadow_key_not_in_store_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_null_key_values_array_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Returns_null_for_null_in_composite_key_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Throws_for_wrong_number_of_values_for_composite_key_async(
-        CancellationType cancellationType)
-        => Task.CompletedTask;
-
-    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
-    public override Task Throws_for_bad_type_for_composite_key_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
@@ -270,6 +256,39 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
             SELECT "id", "foo"
             FROM "strings"
             WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Find_composite_key_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_composite_key_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_composite_key_from_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_composite_key_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id1", "id2", "foo"
+            FROM "composite"
+            WHERE "id1" = ? AND "id2" = ?
+            """);
+    }
+
+    public override async Task Returns_null_for_composite_key_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_composite_key_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id1", "id2", "foo"
+            FROM "composite"
+            WHERE "id1" = ? AND "id2" = ?
             """);
     }
 
@@ -421,6 +440,38 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
+    public override async Task Returns_null_for_null_key_values_array_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_null_key_values_array_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Returns_null_for_null_in_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_null_in_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_wrong_number_of_values_for_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_wrong_number_of_values_for_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_bad_type_for_composite_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_bad_type_for_composite_key_async(cancellationType);
+
+        AssertSql();
+    }
+
     public override async Task Throws_for_bad_entity_type_async(CancellationType cancellationType)
     {
         await base.Throws_for_bad_entity_type_async(cancellationType);
@@ -504,6 +555,12 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
             modelBuilder.Entity<StringKey>().ToTable("strings").HasPartitionKey(x => x.Id);
 
+            modelBuilder
+                .Entity<CompositeKey>()
+                .ToTable("composite")
+                .HasPartitionKey(x => x.Id1)
+                .HasSortKey(x => x.Id2);
+
             modelBuilder.Entity<BaseType>().ToTable("base").HasPartitionKey(x => x.Id);
 
             modelBuilder.Entity<DerivedType>();
@@ -529,6 +586,7 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
                     OwnedCollection = [new Owned1 { Prop = 71 }, new Owned1 { Prop = 72 }],
                 },
                 new StringKey { Id = "Cat", Foo = "Alice" },
+                new CompositeKey { Id1 = 77, Id2 = "Dog", Foo = "Olive" },
                 new BaseType { Id = 77, Foo = "Baxter" },
                 new DerivedType { Id = 78, Foo = "Strawberry", Boo = "Cheesecake" });
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -8,9 +8,6 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 /// <summary>Specification find tests for the DynamoDB provider.</summary>
 public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFixture>
 {
-    private const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
-    private const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
-
     protected FindDynamoTest(FindDynamoFixture fixture) : base(fixture) => fixture.ClearSql();
 
     [ConditionalFact]
@@ -23,13 +20,13 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     public override void Returns_null_for_int_key_not_in_store()
         => NoSyncTest(() => base.Returns_null_for_int_key_not_in_store());
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Find_nullable_int_key_tracked() { }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Find_nullable_int_key_from_store() { }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Returns_null_for_nullable_int_key_not_in_store() { }
 
     public override void Find_string_key_from_store()
@@ -135,13 +132,13 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Find_shadow_key_tracked() { }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Find_shadow_key_from_store() { }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Returns_null_for_shadow_key_not_in_store() { }
 
     public override void Returns_null_for_null_key_values_array()
@@ -151,7 +148,7 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Returns_null_for_null_nullable_key() { }
 
     public override void Returns_null_for_null_in_composite_key()
@@ -175,36 +172,36 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Throws_for_bad_entity_type_with_different_namespace() { }
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Find_nullable_int_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Find_nullable_int_key_from_store_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Returns_null_for_nullable_int_key_not_in_store_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Find_shadow_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Find_shadow_key_from_store_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Returns_null_for_shadow_key_not_in_store_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Throws_for_bad_entity_type_with_different_namespace_async(
         CancellationType cancellationType)
         => Task.CompletedTask;

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -1,0 +1,504 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+/// <summary>Specification find tests for the DynamoDB provider.</summary>
+public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFixture>
+{
+    private const string CompositeKeysNotSupported = "DynamoDB does not support composite keys.";
+    private const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
+    private const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
+
+    protected FindDynamoTest(FindDynamoFixture fixture) : base(fixture) => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(FindDynamoTest));
+
+    public override void Find_int_key_from_store()
+        => NoSyncTest(() => base.Find_int_key_from_store());
+
+    public override void Returns_null_for_int_key_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_int_key_not_in_store());
+
+    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    public override void Find_nullable_int_key_tracked() { }
+
+    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    public override void Find_nullable_int_key_from_store() { }
+
+    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    public override void Returns_null_for_nullable_int_key_not_in_store() { }
+
+    public override void Find_string_key_from_store()
+        => NoSyncTest(() => base.Find_string_key_from_store());
+
+    public override void Returns_null_for_string_key_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_string_key_not_in_store());
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Find_composite_key_tracked() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Find_composite_key_from_store() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Returns_null_for_composite_key_not_in_store() { }
+
+    public override void Find_base_type_from_store()
+        => NoSyncTest(() => base.Find_base_type_from_store());
+
+    public override void Returns_null_for_base_type_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_base_type_not_in_store());
+
+    public override void Find_derived_type_from_store()
+        => NoSyncTest(() => base.Find_derived_type_from_store());
+
+    public override void Returns_null_for_derived_type_not_in_store()
+        => NoSyncTest(() => base.Returns_null_for_derived_type_not_in_store());
+
+    public override void Find_base_type_using_derived_set_tracked()
+        => NoSyncTest(() => base.Find_base_type_using_derived_set_tracked());
+
+    public override void Find_base_type_using_derived_set_from_store()
+        => NoSyncTest(() => base.Find_base_type_using_derived_set_from_store());
+
+    public override void Find_derived_using_base_set_type_from_store()
+        => NoSyncTest(() => base.Find_derived_using_base_set_type_from_store());
+
+    public override void Find_int_key_tracked()
+    {
+        base.Find_int_key_tracked();
+
+        AssertSql();
+    }
+
+    public override void Find_string_key_tracked()
+    {
+        base.Find_string_key_tracked();
+
+        AssertSql();
+    }
+
+    public override void Find_base_type_tracked()
+    {
+        base.Find_base_type_tracked();
+
+        AssertSql();
+    }
+
+    public override void Find_derived_type_tracked()
+    {
+        base.Find_derived_type_tracked();
+
+        AssertSql();
+    }
+
+    public override void Find_derived_type_using_base_set_tracked()
+    {
+        base.Find_derived_type_using_base_set_tracked();
+
+        AssertSql();
+    }
+
+    public override void Returns_null_for_null_key()
+    {
+        base.Returns_null_for_null_key();
+
+        AssertSql();
+    }
+
+    public override void Throws_for_multiple_values_passed_for_simple_key()
+    {
+        base.Throws_for_multiple_values_passed_for_simple_key();
+
+        AssertSql();
+    }
+
+    public override void Throws_for_bad_type_for_simple_key()
+    {
+        base.Throws_for_bad_type_for_simple_key();
+
+        AssertSql();
+    }
+
+    public override void Throws_for_bad_entity_type()
+    {
+        base.Throws_for_bad_entity_type();
+
+        AssertSql();
+    }
+
+    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    public override void Find_shadow_key_tracked() { }
+
+    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    public override void Find_shadow_key_from_store() { }
+
+    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    public override void Returns_null_for_shadow_key_not_in_store() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Returns_null_for_null_key_values_array() { }
+
+    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    public override void Returns_null_for_null_nullable_key() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Returns_null_for_null_in_composite_key() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Throws_for_wrong_number_of_values_for_composite_key() { }
+
+    [ConditionalFact(Skip = CompositeKeysNotSupported)]
+    public override void Throws_for_bad_type_for_composite_key() { }
+
+    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    public override void Throws_for_bad_entity_type_with_different_namespace() { }
+
+    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    public override Task Find_nullable_int_key_tracked_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    public override Task Find_nullable_int_key_from_store_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    public override Task Returns_null_for_nullable_int_key_not_in_store_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Find_composite_key_tracked_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Find_composite_key_from_store_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Returns_null_for_composite_key_not_in_store_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    public override Task Find_shadow_key_tracked_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    public override Task Find_shadow_key_from_store_async(CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    public override Task Returns_null_for_shadow_key_not_in_store_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Returns_null_for_null_key_values_array_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Returns_null_for_null_in_composite_key_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Throws_for_wrong_number_of_values_for_composite_key_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = CompositeKeysNotSupported)]
+    public override Task Throws_for_bad_type_for_composite_key_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    public override Task Throws_for_bad_entity_type_with_different_namespace_async(
+        CancellationType cancellationType)
+        => Task.CompletedTask;
+
+    public override async Task Find_int_key_from_store_async(CancellationType cancellationType)
+    {
+        await base.Find_int_key_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "foo", "ownedCollection", "ownedReference"
+            FROM "ints"
+            WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Returns_null_for_int_key_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_int_key_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "foo", "ownedCollection", "ownedReference"
+            FROM "ints"
+            WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Find_string_key_from_store_async(CancellationType cancellationType)
+    {
+        await base.Find_string_key_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "foo"
+            FROM "strings"
+            WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Returns_null_for_string_key_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_string_key_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "foo"
+            FROM "strings"
+            WHERE "id" = ?
+            """);
+    }
+
+    public override async Task Find_base_type_from_store_async(CancellationType cancellationType)
+    {
+        await base.Find_base_type_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND ("$type" = 'BaseType' OR "$type" = 'DerivedType')
+            """);
+    }
+
+    public override async Task Returns_null_for_base_type_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_base_type_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND ("$type" = 'BaseType' OR "$type" = 'DerivedType')
+            """);
+    }
+
+    public override async Task Find_derived_type_from_store_async(CancellationType cancellationType)
+    {
+        await base.Find_derived_type_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND "$type" = 'DerivedType'
+            """);
+    }
+
+    public override async Task Returns_null_for_derived_type_not_in_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Returns_null_for_derived_type_not_in_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND "$type" = 'DerivedType'
+            """);
+    }
+
+    public override async Task Find_base_type_using_derived_set_tracked_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_base_type_using_derived_set_tracked_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND "$type" = 'DerivedType'
+            """);
+    }
+
+    public override async Task Find_base_type_using_derived_set_from_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_base_type_using_derived_set_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND "$type" = 'DerivedType'
+            """);
+    }
+
+    public override async Task Find_derived_using_base_set_type_from_store_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_derived_using_base_set_type_from_store_async(cancellationType);
+
+        AssertSql(
+            """
+            SELECT "id", "$type", "foo", "boo"
+            FROM "base"
+            WHERE "id" = ? AND ("$type" = 'BaseType' OR "$type" = 'DerivedType')
+            """);
+    }
+
+    public override async Task Find_int_key_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_int_key_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_string_key_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_string_key_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_base_type_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_base_type_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_derived_type_tracked_async(CancellationType cancellationType)
+    {
+        await base.Find_derived_type_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Find_derived_type_using_base_set_tracked_async(
+        CancellationType cancellationType)
+    {
+        await base.Find_derived_type_using_base_set_tracked_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Returns_null_for_null_key_async(CancellationType cancellationType)
+    {
+        await base.Returns_null_for_null_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_multiple_values_passed_for_simple_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_multiple_values_passed_for_simple_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_bad_type_for_simple_key_async(
+        CancellationType cancellationType)
+    {
+        await base.Throws_for_bad_type_for_simple_key_async(cancellationType);
+
+        AssertSql();
+    }
+
+    public override async Task Throws_for_bad_entity_type_async(CancellationType cancellationType)
+    {
+        await base.Throws_for_bad_entity_type_async(cancellationType);
+
+        AssertSql();
+    }
+
+    //      ╭──────────────────────────────────────────────────────────╮
+    //      │                        Test Infra                        │
+    //      ╰──────────────────────────────────────────────────────────╯
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    private void NoSyncTest(Action testCode) => DynamoTestHelpers.Instance.NoSyncTest(testCode);
+
+    public class FindDynamoTestSet(FindDynamoFixture fixture) : FindDynamoTest(fixture)
+    {
+        protected override TestFinder Finder { get; } = new FindViaSetFinder();
+    }
+
+    public class FindDynamoFixture : FindFixtureBase, IDynamoSpecificationFixture
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base
+                .AddOptions(builder)
+                .ConfigureWarnings(warnings
+                    => warnings.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .UseDynamo(options
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync().ConfigureAwait(false);
+            await context.Database.EnsureCreatedAsync().ConfigureAwait(false);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            modelBuilder.Entity<IntKey>().ToTable("ints").HasPartitionKey(x => x.Id);
+
+            modelBuilder.Entity<StringKey>().ToTable("strings").HasPartitionKey(x => x.Id);
+
+            modelBuilder.Entity<BaseType>().ToTable("base").HasPartitionKey(x => x.Id);
+
+            modelBuilder.Entity<DerivedType>();
+        }
+
+        protected override Task SeedAsync(PoolableDbContext context)
+        {
+            context.AddRange(
+                new IntKey
+                {
+                    Id = 77,
+                    Foo = "Smokey",
+                    OwnedReference =
+                        new Owned1
+                        {
+                            Prop = 7,
+                            NestedOwned = new Owned2 { Prop = "7" },
+                            NestedOwnedCollection =
+                            [
+                                new Owned2 { Prop = "71" }, new Owned2 { Prop = "72" },
+                            ],
+                        },
+                    OwnedCollection = [new Owned1 { Prop = 71 }, new Owned1 { Prop = 72 }],
+                },
+                new StringKey { Id = "Cat", Foo = "Alice" },
+                new BaseType { Id = 77, Foo = "Baxter" },
+                new DerivedType { Id = 78, Foo = "Strawberry", Boo = "Cheesecake" });
+
+            return context.SaveChangesAsync();
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -436,9 +436,43 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
 
     private void NoSyncTest(Action testCode) => DynamoTestHelpers.Instance.NoSyncTest(testCode);
 
-    public class FindDynamoTestSet(FindDynamoFixture fixture) : FindDynamoTest(fixture)
+    /// <summary>Find tests that use <see cref="DbSet{TEntity}.Find(object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestSet : FindDynamoTest
     {
+        /// <summary>Creates set-based find tests.</summary>
+        public FindDynamoTestSet(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
         protected override TestFinder Finder { get; } = new FindViaSetFinder();
+    }
+
+    /// <summary>Find tests that use generic <see cref="DbContext.Find{TEntity}(object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestContext : FindDynamoTest
+    {
+        /// <summary>Creates context-based find tests.</summary>
+        public FindDynamoTestContext(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
+        protected override TestFinder Finder { get; } = new FindViaContextFinder();
+    }
+
+    /// <summary>Find tests that use non-generic <see cref="DbContext.Find(Type, object[])" />.</summary>
+    [Collection(DynamoSpecificationCollection.Name)]
+    public class FindDynamoTestNonGeneric : FindDynamoTest
+    {
+        /// <summary>Creates non-generic context-based find tests.</summary>
+        public FindDynamoTestNonGeneric(
+            FindDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+
+        protected override TestFinder Finder { get; } = new FindViaNonGenericContextFinder();
     }
 
     public class FindDynamoFixture : FindFixtureBase, IDynamoSpecificationFixture

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -1,6 +1,6 @@
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 
-public static class SkipReasons
+public static class SkipReason
 {
     public const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
     public const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReasons.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReasons.cs
@@ -1,0 +1,8 @@
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+public static class SkipReasons
+{
+    public const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
+    public const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
+    public const string ForeignKeysNotSupported = "DynamoDB does not support foreign keys.";
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
@@ -1,0 +1,47 @@
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using Testcontainers.DynamoDb;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>Process-scoped DynamoDB Local container for specification tests.</summary>
+public static class DynamoSpecificationContainerFixture
+{
+    private static readonly SemaphoreSlim StartLock = new(1, 1);
+    private static DynamoDbContainer? _container;
+    private static IAmazonDynamoDB? _client;
+
+    /// <summary>Gets the shared DynamoDB client for specification tests.</summary>
+    public static IAmazonDynamoDB Client
+    {
+        get
+        {
+            EnsureStartedAsync().GetAwaiter().GetResult();
+            return _client!;
+        }
+    }
+
+    private static async Task EnsureStartedAsync()
+    {
+        if (_client is not null)
+            return;
+
+        await StartLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_client is not null)
+                return;
+
+            _container = new DynamoDbBuilder("amazon/dynamodb-local:latest").Build();
+            await _container.StartAsync().ConfigureAwait(false);
+
+            _client = new AmazonDynamoDBClient(
+                new BasicAWSCredentials("test", "test"),
+                new AmazonDynamoDBConfig { ServiceURL = _container.GetConnectionString() });
+        }
+        finally
+        {
+            StartLock.Release();
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationContainerFixture.cs
@@ -4,44 +4,74 @@ using Testcontainers.DynamoDb;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 
-/// <summary>Process-scoped DynamoDB Local container for specification tests.</summary>
-public static class DynamoSpecificationContainerFixture
+/// <summary>Collection fixture that owns the shared DynamoDB Local container.</summary>
+public sealed class DynamoSpecificationContainerFixture : IAsyncLifetime
 {
+    private const string DynamoDbLocalImage = "amazon/dynamodb-local:2.6.1";
+
     private static readonly SemaphoreSlim StartLock = new(1, 1);
     private static DynamoDbContainer? _container;
-    private static IAmazonDynamoDB? _client;
+    private static AmazonDynamoDBClient? _client;
 
     /// <summary>Gets the shared DynamoDB client for specification tests.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the fixture has not been initialized.</exception>
     public static IAmazonDynamoDB Client
-    {
-        get
-        {
-            EnsureStartedAsync().GetAwaiter().GetResult();
-            return _client!;
-        }
-    }
+        => _client
+            ?? throw new InvalidOperationException(
+                "DynamoDB specification fixture has not been initialized.");
 
-    private static async Task EnsureStartedAsync()
+    /// <summary>Starts the shared DynamoDB Local container if needed.</summary>
+    public static async Task<IAmazonDynamoDB> GetClientAsync()
     {
         if (_client is not null)
-            return;
+            return _client;
 
         await StartLock.WaitAsync().ConfigureAwait(false);
         try
         {
             if (_client is not null)
-                return;
+                return _client;
 
-            _container = new DynamoDbBuilder("amazon/dynamodb-local:latest").Build();
+            _container = new DynamoDbBuilder(DynamoDbLocalImage).Build();
             await _container.StartAsync().ConfigureAwait(false);
 
             _client = new AmazonDynamoDBClient(
                 new BasicAWSCredentials("test", "test"),
                 new AmazonDynamoDBConfig { ServiceURL = _container.GetConnectionString() });
+
+            return _client;
         }
         finally
         {
             StartLock.Release();
         }
     }
+
+    /// <summary>Starts the shared DynamoDB Local container.</summary>
+    public async Task InitializeAsync() => await GetClientAsync().ConfigureAwait(false);
+
+    /// <summary>Stops the shared DynamoDB Local container and disposes the client.</summary>
+    public static async Task DisposeContainerAsync()
+    {
+        _client?.Dispose();
+        _client = null;
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+            _container = null;
+        }
+    }
+
+    /// <summary>Stops the shared DynamoDB Local container and disposes the client.</summary>
+    public async Task DisposeAsync() => await DisposeContainerAsync().ConfigureAwait(false);
+}
+
+/// <summary>Collection definition for DynamoDB specification tests.</summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DynamoSpecificationCollection
+    : ICollectionFixture<DynamoSpecificationContainerFixture>
+{
+    /// <summary>Collection name for DynamoDB specification tests.</summary>
+    public const string Name = "DynamoDB specification tests";
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoSpecificationFixture.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>Shared SQL-capture contract for DynamoDB specification fixtures.</summary>
+public interface IDynamoSpecificationFixture
+{
+    /// <summary>Gets the PartiQL logger used by the fixture.</summary>
+    TestSqlLoggerFactory TestSqlLoggerFactory { get; }
+}
+
+/// <summary>Helpers for DynamoDB specification fixtures.</summary>
+public static class DynamoSpecificationFixtureExtensions
+{
+    /// <summary>Clears captured PartiQL statements.</summary>
+    public static void ClearSql(this IDynamoSpecificationFixture fixture)
+        => fixture.TestSqlLoggerFactory.Clear();
+
+    /// <summary>Asserts captured PartiQL statements against a baseline.</summary>
+    public static void AssertSql(this IDynamoSpecificationFixture fixture, params string[] expected)
+        => fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    /// <summary>Returns whether the logging category should be captured for DynamoDB SQL baselines.</summary>
+    public static bool ShouldLogDynamoSql(string logCategory)
+        => logCategory.StartsWith(DbLoggerCategory.Database.Command.Name, StringComparison.Ordinal)
+            || logCategory.StartsWith(DbLoggerCategory.Query.Name, StringComparison.Ordinal);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
@@ -25,6 +25,7 @@ public class DynamoTestHelpers : TestHelpers
     public static void AssertAllTestMethodsOverridden(Type testClass)
         => AssertAllMethodsOverridden(testClass);
 
+    /// <summary>Runs a sync test and verifies that DynamoDB sync query execution fails.</summary>
     public void NoSyncTest(Action testCode)
     {
         try

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestHelpers.cs
@@ -1,0 +1,44 @@
+using EntityFrameworkCore.DynamoDb.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>Provider test helpers for DynamoDB specification tests.</summary>
+public class DynamoTestHelpers : TestHelpers
+{
+    protected DynamoTestHelpers() { }
+
+    public static DynamoTestHelpers Instance { get; } = new();
+
+    public override ModelAsserter ModelAsserter => ModelAsserter.Instance;
+
+    public override IServiceCollection AddProviderServices(IServiceCollection services)
+        => services.AddEntityFrameworkDynamo();
+
+    public override DbContextOptionsBuilder UseProviderOptions(
+        DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseDynamo();
+
+    /// <summary>Asserts that provider specification tests explicitly override inherited test methods.</summary>
+    public static void AssertAllTestMethodsOverridden(Type testClass)
+        => AssertAllMethodsOverridden(testClass);
+
+    public void NoSyncTest(Action testCode)
+    {
+        try
+        {
+            testCode();
+        }
+        catch (InvalidOperationException exception) when (exception.Message.Contains(
+                "Sync enumerating",
+                StringComparison.Ordinal)
+            && exception.Message.Contains("DynamoDB", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Assert.Fail("Expected DynamoDB sync query failure.");
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStore.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStore.cs
@@ -1,0 +1,25 @@
+using Amazon.DynamoDBv2;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>Test store for DynamoDB specification tests.</summary>
+public class DynamoTestStore(string name, bool shared, DynamoTestStoreFactory factory) : TestStore(
+    name,
+    shared)
+{
+    private IAmazonDynamoDB Client => factory.Client;
+
+    public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
+        => builder.UseDynamo(options => options.DynamoDbClient(Client));
+
+    protected override async Task InitializeAsync(
+        Func<DbContext> createContext,
+        Func<DbContext, Task>? seed,
+        Func<DbContext, Task>? clean)
+    {
+        await factory.GetClientAsync().ConfigureAwait(false);
+        await base.InitializeAsync(createContext, seed, clean).ConfigureAwait(false);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
@@ -1,0 +1,30 @@
+using Amazon.DynamoDBv2;
+using EntityFrameworkCore.DynamoDb.Extensions;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>Test store factory for DynamoDB specification tests.</summary>
+public class DynamoTestStoreFactory : ITestStoreFactory
+{
+    public static DynamoTestStoreFactory Instance { get; } = new();
+
+    public IAmazonDynamoDB Client => DynamoSpecificationContainerFixture.Client;
+
+    public IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
+        => serviceCollection
+            .AddEntityFrameworkDynamo()
+            .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory());
+
+    public TestStore Create(string storeName) => new DynamoTestStore(storeName, false, this);
+
+    public virtual TestStore GetOrCreate(string storeName)
+        => new DynamoTestStore(storeName, true, this);
+
+    public virtual ListLoggerFactory CreateListLoggerFactory(Func<string, bool> shouldLogCategory)
+        => new TestSqlLoggerFactory(shouldLogCategory);
+
+    internal Task<IAmazonDynamoDB> GetClientAsync() => Task.FromResult(Client);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/DynamoTestStoreFactory.cs
@@ -9,22 +9,29 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 /// <summary>Test store factory for DynamoDB specification tests.</summary>
 public class DynamoTestStoreFactory : ITestStoreFactory
 {
+    /// <summary>Gets the singleton DynamoDB test store factory.</summary>
     public static DynamoTestStoreFactory Instance { get; } = new();
 
+    /// <summary>Gets the shared DynamoDB client from the active specification fixture.</summary>
     public IAmazonDynamoDB Client => DynamoSpecificationContainerFixture.Client;
 
+    /// <summary>Adds DynamoDB provider services to the test service collection.</summary>
     public IServiceCollection AddProviderServices(IServiceCollection serviceCollection)
         => serviceCollection
             .AddEntityFrameworkDynamo()
             .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory());
 
+    /// <summary>Creates a non-shared DynamoDB test store.</summary>
     public TestStore Create(string storeName) => new DynamoTestStore(storeName, false, this);
 
+    /// <summary>Gets or creates a shared DynamoDB test store.</summary>
     public virtual TestStore GetOrCreate(string storeName)
         => new DynamoTestStore(storeName, true, this);
 
+    /// <summary>Creates the list logger factory used to capture emitted PartiQL.</summary>
     public virtual ListLoggerFactory CreateListLoggerFactory(Func<string, bool> shouldLogCategory)
         => new TestSqlLoggerFactory(shouldLogCategory);
 
-    internal Task<IAmazonDynamoDB> GetClientAsync() => Task.FromResult(Client);
+    internal Task<IAmazonDynamoDB> GetClientAsync()
+        => DynamoSpecificationContainerFixture.GetClientAsync();
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/TestUtilities/TestSqlLoggerFactory.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using EntityFrameworkCore.DynamoDb.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+
+/// <summary>PartiQL assertion helper for DynamoDB specification tests.</summary>
+public class TestSqlLoggerFactory(Func<string, bool> shouldLogCategory)
+    : ListLoggerFactory(shouldLogCategory)
+{
+    public TestSqlLoggerFactory() : this(_ => true) { }
+
+    public IReadOnlyList<string> SqlStatements
+        => Log
+            .Where(e => e.Id.Id is var id && id == DynamoEventId.ExecutingPartiQlQuery.Id)
+            .Select(e => GetCommandText(e.State))
+            .ToArray();
+
+    public void AssertBaseline(params string[] expected)
+    {
+        try
+        {
+            var actual = SqlStatements.Select(sql => sql.ReplaceLineEndings()).ToArray();
+            var normalizedExpected = expected.Select(sql => sql.ReplaceLineEndings()).ToArray();
+
+            if (!actual.SequenceEqual(normalizedExpected))
+                throw new InvalidOperationException(
+                    BuildBaselineFailureMessage(normalizedExpected, actual));
+        }
+        finally
+        {
+            Clear();
+        }
+    }
+
+    private static string BuildBaselineFailureMessage(
+        IReadOnlyList<string> expected,
+        IReadOnlyList<string> actual)
+    {
+        var builder = new StringBuilder()
+            .AppendLine("PartiQL baseline mismatch.")
+            .AppendLine($"Expected statement count: {expected.Count}")
+            .AppendLine($"Actual statement count:   {actual.Count}");
+
+        var compareCount = Math.Min(expected.Count, actual.Count);
+        for (var i = 0; i < compareCount; i++)
+        {
+            if (expected[i] == actual[i])
+                continue;
+
+            AppendStatementDiff(builder, i, expected[i], actual[i]);
+            break;
+        }
+
+        if (expected.Count != actual.Count)
+        {
+            builder.AppendLine();
+            builder.AppendLine("All statements:");
+            AppendStatementList(builder, "Expected", expected);
+            AppendStatementList(builder, "Actual", actual);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendStatementDiff(
+        StringBuilder builder,
+        int index,
+        string expected,
+        string actual)
+    {
+        builder.AppendLine();
+        builder.AppendLine($"First mismatch at statement index {index}:");
+        builder.AppendLine("Expected:");
+        AppendIndented(builder, expected);
+        builder.AppendLine("Actual:");
+        AppendIndented(builder, actual.Length == 0 ? "<empty>" : actual);
+
+        var mismatchIndex = FirstMismatchIndex(expected, actual);
+        builder.AppendLine($"First differing character: {mismatchIndex}");
+        builder.AppendLine($"Expected from there: {Snippet(expected, mismatchIndex)}");
+        builder.AppendLine($"Actual from there:   {Snippet(actual, mismatchIndex)}");
+    }
+
+    private static void AppendStatementList(
+        StringBuilder builder,
+        string title,
+        IReadOnlyList<string> statements)
+    {
+        builder.AppendLine($"{title}:");
+
+        if (statements.Count == 0)
+        {
+            builder.AppendLine("  <none>");
+            return;
+        }
+
+        for (var i = 0; i < statements.Count; i++)
+        {
+            builder.AppendLine($"  [{i}]");
+            AppendIndented(builder, statements[i], "    ");
+        }
+    }
+
+    private static void AppendIndented(StringBuilder builder, string value, string indent = "  ")
+    {
+        foreach (var line in value.Split('\n'))
+            builder.Append(indent).AppendLine(line);
+    }
+
+    private static int FirstMismatchIndex(string expected, string actual)
+    {
+        var length = Math.Min(expected.Length, actual.Length);
+        for (var i = 0; i < length; i++)
+            if (expected[i] != actual[i])
+                return i;
+
+        return length;
+    }
+
+    private static string Snippet(string value, int start)
+    {
+        if (start >= value.Length)
+            return "<end>";
+
+        var length = Math.Min(80, value.Length - start);
+        return value.Substring(start, length).Replace("\n", "\\n");
+    }
+
+    private static string GetCommandText(object? state)
+        => state is IReadOnlyList<KeyValuePair<string, object?>> structure
+            ? structure
+                .Where(item => item.Key == "commandText")
+                .Select(item => (string?)item.Value)
+                .FirstOrDefault()
+            ?? string.Empty
+            : string.Empty;
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/xunit.runner.json
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
## Summary

Cleans up DynamoDB specification test setup and improves test metadata so unsupported cases are easier to understand. Adds provider-specific specification coverage and shared test utilities needed to run those tests against DynamoDB Local.

## Changes

- Added DynamoDB specification test project wiring, fixtures, and xUnit config.
- Added provider-specific built-in data type, find, and API consistency coverage.
- Improved skip reason organization and test configuration for unsupported DynamoDB scenarios.
- Updated package/project references needed by specification tests.

## Validation

- Not run in this session; branch already contained committed changes.

## Notes for Reviewers

Focus review on test coverage shape, skip reason clarity, and whether unsupported cases are documented with useful context.
