### PR TITLE
test(integration): improve DynamoDB save test helpers

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/AddedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/AddedEntitiesSaveChangesTests.cs
@@ -163,14 +163,14 @@ public class AddedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
             Revoked = false,
         };
 
-        Db.Entry(session).State.Should().Be(EntityState.Detached);
+        AssertEntryState(session, EntityState.Detached);
 
         Db.Sessions.Add(session);
-        Db.Entry(session).State.Should().Be(EntityState.Added);
+        AssertEntryState(session, EntityState.Added);
 
         await Db.SaveChangesAsync(CancellationToken);
 
-        Db.Entry(session).State.Should().Be(EntityState.Unchanged);
+        AssertEntryState(session, EntityState.Unchanged);
     }
 
     /// <summary>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/AddedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/AddedEntitiesSaveChangesTests.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -30,16 +29,7 @@ public class AddedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Products.Add(product);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var item = await GetItemAsync(product.Pk, product.Sk, CancellationToken);
-        item.Should().NotBeNull();
-        item!["pk"].S.Should().Be("PROD#round-trip");
-        item["sk"].S.Should().Be("PRODUCT");
-        item["version"].N.Should().Be("1");
-        item["name"].S.Should().Be("Widget");
-        item["price"].N.Should().Be("9.99");
-        item["isActive"].BOOL.Should().BeTrue();
-        item["publishedAt"].S.Should().Be("2024-06-01 00:00:00+00:00");
-        item["$type"].S.Should().Be("ProductItem");
+        await AssertItemExistsInDynamoDbAsync(product, product.Pk, product.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -95,15 +85,14 @@ public class AddedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Sessions.Add(session);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var customerItem = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        var orderItem = await GetItemAsync(order.Pk, order.Sk, CancellationToken);
-        var productItem = await GetItemAsync(product.Pk, product.Sk, CancellationToken);
-        var sessionItem = await GetItemAsync(session.Pk, session.Sk, CancellationToken);
-
-        customerItem!["$type"].S.Should().Be("CustomerItem");
-        orderItem!["$type"].S.Should().Be("OrderItem");
-        productItem!["$type"].S.Should().Be("ProductItem");
-        sessionItem!["$type"].S.Should().Be("SessionItem");
+        await AssertItemExistsInDynamoDbAsync(
+            customer,
+            customer.Pk,
+            customer.Sk,
+            CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(order, order.Pk, order.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(product, product.Pk, product.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(session, session.Pk, session.Sk, CancellationToken);
     }
 
     /// <summary>A nullable scalar written as null is persisted as a DynamoDB NULL attribute.</summary>
@@ -124,9 +113,7 @@ public class AddedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Products.Add(product);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var item = await GetItemAsync(product.Pk, product.Sk, CancellationToken);
-        item.Should().NotBeNull();
-        item!["publishedAt"].NULL.Should().BeTrue();
+        await AssertItemExistsInDynamoDbAsync(product, product.Pk, product.Sk, CancellationToken);
     }
 
     /// <summary>A newly added entity with primitive collections persists list, map, and set wire shapes.</summary>
@@ -153,12 +140,7 @@ public class AddedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Sessions.Add(session);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var item = await GetItemAsync(session.Pk, session.Sk, CancellationToken);
-        item.Should().NotBeNull();
-        item!["scopes"].L.Select(x => x.S).Should().Equal("read", "write");
-        item["attributes"].M["device"].S.Should().Be("ios");
-        item["attributes"].M["region"].S.Should().Be("eu-west-1");
-        item["flags"].SS.Should().BeEquivalentTo("trusted", "mfa");
+        await AssertItemExistsInDynamoDbAsync(session, session.Pk, session.Sk, CancellationToken);
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ConvertedCollectionAndEscapingSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ConvertedCollectionAndEscapingSaveChangesTests.cs
@@ -16,9 +16,7 @@ public class ConvertedCollectionAndEscapingSaveChangesTests(DynamoContainerFixtu
         Db.ConvertedCollectionItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["scores"].S.Should().Be("1|2|3");
+        await AssertRawStringAsync(item.Pk, item.Sk, "scores", "1|2|3", CancellationToken);
 
         AssertSql(
             """
@@ -35,18 +33,13 @@ public class ConvertedCollectionAndEscapingSaveChangesTests(DynamoContainerFixtu
             Pk = "TENANT#CONV", Sk = "COLL#MOD-1", Version = 1, Scores = [5],
         };
 
-        Db.ConvertedCollectionItems.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Scores = [8, 13, 21];
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["scores"].S.Should().Be("8|13|21");
+        await AssertRawStringAsync(item.Pk, item.Sk, "scores", "8|13|21", CancellationToken);
 
         AssertSql(
             """
@@ -67,10 +60,7 @@ public class ConvertedCollectionAndEscapingSaveChangesTests(DynamoContainerFixtu
         Db.QuotedAttributeItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().ContainKey("O'Brien");
-        raw["O'Brien"].S.Should().Be("Ada");
+        await AssertRawStringAsync(item.Pk, item.Sk, "O'Brien", "Ada", CancellationToken);
 
         AssertSql(
             """
@@ -90,19 +80,12 @@ public class ConvertedCollectionAndEscapingSaveChangesTests(DynamoContainerFixtu
             Pk = "TENANT#ESC", Sk = "QUOTE#UPDATE-1", Version = 1, DisplayName = "Ada",
         };
 
-        Db.QuotedAttributeItems.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.DisplayName = "Grace";
-        var affected = await Db.SaveChangesAsync(CancellationToken);
+        await SaveChangesShouldAffectAsync(1);
 
-        affected.Should().Be(1);
-
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().ContainKey("O'Brien");
-        raw["O'Brien"].S.Should().Be("Grace");
+        await AssertRawStringAsync(item.Pk, item.Sk, "O'Brien", "Grace", CancellationToken);
 
         AssertSql(
             """
@@ -124,17 +107,12 @@ public class ConvertedCollectionAndEscapingSaveChangesTests(DynamoContainerFixtu
             Pk = "TENANT#ESC", Sk = "QUOTE#DELETE-1", Version = 1, DisplayName = "Ada",
         };
 
-        Db.QuotedAttributeItems.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         Db.QuotedAttributeItems.Remove(item);
-        var affected = await Db.SaveChangesAsync(CancellationToken);
+        await SaveChangesShouldAffectAsync(1);
 
-        affected.Should().Be(1);
-
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().BeNull();
+        await AssertItemDoesNotExistAsync(item.Pk, item.Sk, CancellationToken);
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/CustomTypeConverterTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/CustomTypeConverterTests.cs
@@ -26,12 +26,7 @@ public class CustomTypeConverterTests(DynamoContainerFixture fixture)
         Db.CustomConverterItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-
-        raw.Should().NotBeNull();
-        // The converter should have serialized ProductCode("PROD-42") as the string "PROD-42".
-        raw!["code"].S.Should().Be("PROD-42");
-        raw["optionalCode"].NULL.Should().BeTrue();
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -49,10 +44,6 @@ public class CustomTypeConverterTests(DynamoContainerFixture fixture)
         Db.CustomConverterItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-
-        raw.Should().NotBeNull();
-        raw!["code"].S.Should().Be("PROD-1");
-        raw["optionalCode"].S.Should().Be("OPT-7");
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -163,14 +162,12 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Entry(toModify).State.Should().Be(EntityState.Unchanged);
         Db.Entry(toDelete).State.Should().Be(EntityState.Detached);
 
-        // Raw DynamoDB verification.
-        var addedItem = await GetItemAsync(toAdd.Pk, toAdd.Sk, CancellationToken);
-        addedItem.Should().NotBeNull();
-        addedItem!["email"].S.Should().Be("new@example.com");
-
-        var modifiedItem = await GetItemAsync(toModify.Pk, toModify.Sk, CancellationToken);
-        modifiedItem.Should().NotBeNull();
-        modifiedItem!["email"].S.Should().Be("after-modify@example.com");
+        await AssertItemExistsInDynamoDbAsync(toAdd, toAdd.Pk, toAdd.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(
+            toModify,
+            toModify.Pk,
+            toModify.Sk,
+            CancellationToken);
 
         var deletedItem = await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
         deletedItem.Should().BeNull();

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/DeletedEntitiesSaveChangesTests.cs
@@ -24,17 +24,12 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         Db.Customers.Remove(customer);
-        var affected = await Db.SaveChangesAsync(CancellationToken);
+        await SaveChangesShouldAffectAsync(1);
 
-        affected.Should().Be(1);
-
-        var item = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        item.Should().BeNull();
+        await AssertItemDoesNotExistAsync(customer.Pk, customer.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -56,18 +51,16 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
+        await SeedAsync(customer);
 
-        Db.Entry(customer).State.Should().Be(EntityState.Unchanged);
+        AssertEntryState(customer, EntityState.Unchanged);
 
         Db.Customers.Remove(customer);
-        Db.Entry(customer).State.Should().Be(EntityState.Deleted);
+        AssertEntryState(customer, EntityState.Deleted);
 
-        LoggerFactory.Clear();
         await Db.SaveChangesAsync(CancellationToken);
 
-        Db.Entry(customer).State.Should().Be(EntityState.Detached);
+        AssertEntryState(customer, EntityState.Detached);
 
         AssertSql(
             """
@@ -97,14 +90,11 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         Db.Customers.Attach(stub);
         Db.Entry(stub).State = EntityState.Deleted;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-
-        affected.Should().Be(1);
-        Db.Entry(stub).State.Should().Be(EntityState.Detached);
+        await SaveChangesShouldAffectAsync(1);
+        AssertEntryState(stub, EntityState.Detached);
 
         // Confirm item is still absent (was never created).
-        var item = await GetItemAsync("TENANT#GHOST", "CUSTOMER#GHOST-1", CancellationToken);
-        item.Should().BeNull();
+        await AssertItemDoesNotExistAsync("TENANT#GHOST", "CUSTOMER#GHOST-1", CancellationToken);
     }
 
     /// <summary>
@@ -135,8 +125,7 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
         Db.Customers.AddRange(toModify, toDelete);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SaveAndClearLogAsync();
 
         // New entity to add in the mixed batch.
         var toAdd = new CustomerItem
@@ -153,14 +142,13 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
         toModify.Email = "after-modify@example.com";
         Db.Customers.Remove(toDelete);
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-
-        affected.Should().Be(3);
+        await SaveChangesShouldAffectAsync(3);
 
         // Post-save state checks.
-        Db.Entry(toAdd).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(toModify).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(toDelete).State.Should().Be(EntityState.Detached);
+        AssertEntryStates(
+            (toAdd, EntityState.Unchanged),
+            (toModify, EntityState.Unchanged),
+            (toDelete, EntityState.Detached));
 
         await AssertItemExistsInDynamoDbAsync(toAdd, toAdd.Pk, toAdd.Sk, CancellationToken);
         await AssertItemExistsInDynamoDbAsync(
@@ -169,8 +157,7 @@ public class DeletedEntitiesSaveChangesTests(DynamoContainerFixture fixture)
             toModify.Sk,
             CancellationToken);
 
-        var deletedItem = await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
-        deletedItem.Should().BeNull();
+        await AssertItemDoesNotExistAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
@@ -1,15 +1,10 @@
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 using LayeredCraft.DynamoMapper.Runtime;
 
 // ReSharper disable ClassNeverInstantiated.Global
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
-
-public interface IDynamoMapper<T>
-{
-    static abstract Dictionary<string, AttributeValue> ToItem(T source);
-    static abstract T FromItem(Dictionary<string, AttributeValue> item);
-}
 
 public static class MapperExtensions
 {

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
@@ -31,7 +31,10 @@ internal partial class SaveChangesCustomerItemMapper : IDynamoMapper<CustomerIte
     public static partial CustomerItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
-[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoMapper(
+    Convention = DynamoNamingConvention.CamelCase,
+    OmitNullValues = false,
+    DateTimeFormat = "yyyy-MM-dd HH:mm:sszzz")]
 internal partial class SaveChangesOrderItemMapper : IDynamoMapper<OrderItem>
 {
     public static partial Dictionary<string, AttributeValue> ToItem(OrderItem source);
@@ -39,7 +42,10 @@ internal partial class SaveChangesOrderItemMapper : IDynamoMapper<OrderItem>
     public static partial OrderItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
-[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoMapper(
+    Convention = DynamoNamingConvention.CamelCase,
+    OmitNullValues = false,
+    DateTimeFormat = "yyyy-MM-dd HH:mm:sszzz")]
 internal partial class SaveChangesProductItemMapper : IDynamoMapper<ProductItem>
 {
     public static partial Dictionary<string, AttributeValue> ToItem(ProductItem source);
@@ -47,7 +53,10 @@ internal partial class SaveChangesProductItemMapper : IDynamoMapper<ProductItem>
     public static partial ProductItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
-[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoMapper(
+    Convention = DynamoNamingConvention.CamelCase,
+    OmitNullValues = false,
+    DateTimeFormat = "yyyy-MM-dd HH:mm:sszzz")]
 internal partial class SaveChangesSessionItemMapper : IDynamoMapper<SessionItem>
 {
     public static partial Dictionary<string, AttributeValue> ToItem(SessionItem source);
@@ -64,4 +73,78 @@ internal partial class SaveChangesConverterCoverageItemMapper : IDynamoMapper<Co
     public static partial Dictionary<string, AttributeValue> ToItem(ConverterCoverageItem source);
 
     public static partial ConverterCoverageItem FromItem(Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoField(
+    nameof(CustomConverterItem.Code),
+    ToMethod = nameof(ToProductCode),
+    FromMethod = nameof(FromProductCode))]
+[DynamoField(
+    nameof(CustomConverterItem.OptionalCode),
+    ToMethod = nameof(ToNullableProductCode),
+    FromMethod = nameof(FromNullableProductCode))]
+internal partial class SaveChangesCustomConverterItemMapper : IDynamoMapper<CustomConverterItem>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(CustomConverterItem source);
+
+    public static partial CustomConverterItem FromItem(Dictionary<string, AttributeValue> item);
+
+    private static AttributeValue ToProductCode(CustomConverterItem source)
+        => source.Code.Value.ToAttributeValue();
+
+    private static ProductCode FromProductCode(Dictionary<string, AttributeValue> item)
+        => new(item["code"].S);
+
+    private static AttributeValue ToNullableProductCode(CustomConverterItem source)
+        => source.OptionalCode.HasValue
+            ? source.OptionalCode.Value.Value.ToAttributeValue()
+            : new AttributeValue { NULL = true };
+
+    private static ProductCode? FromNullableProductCode(Dictionary<string, AttributeValue> item)
+        => item["optionalCode"].NULL == true ? null : new ProductCode(item["optionalCode"].S);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoField(
+    nameof(ConvertedCollectionItem.Scores),
+    ToMethod = nameof(ToScores),
+    FromMethod = nameof(FromScores))]
+internal partial class SaveChangesConvertedCollectionItemMapper
+    : IDynamoMapper<ConvertedCollectionItem>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(ConvertedCollectionItem source);
+
+    public static partial ConvertedCollectionItem FromItem(Dictionary<string, AttributeValue> item);
+
+    private static AttributeValue ToScores(ConvertedCollectionItem source)
+        => string.Join('|', source.Scores).ToAttributeValue();
+
+    private static List<int> FromScores(Dictionary<string, AttributeValue> item)
+        => string.IsNullOrWhiteSpace(item["scores"].S)
+            ? []
+            : item["scores"]
+                .S
+                .Split('|', StringSplitOptions.RemoveEmptyEntries)
+                .Select(int.Parse)
+                .ToList();
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoField(nameof(QuotedAttributeItem.DisplayName), AttributeName = "O'Brien")]
+internal partial class SaveChangesQuotedAttributeItemMapper : IDynamoMapper<QuotedAttributeItem>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(QuotedAttributeItem source);
+
+    public static partial QuotedAttributeItem FromItem(Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+[DynamoField(nameof(SparseGsiItem.Gs1Pk), AttributeName = "gs1-pk")]
+[DynamoField(nameof(SparseGsiItem.Gs1Sk), AttributeName = "gs1-sk")]
+internal partial class SaveChangesSparseGsiItemMapper : IDynamoMapper<SparseGsiItem>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(SparseGsiItem source);
+
+    public static partial SparseGsiItem FromItem(Dictionary<string, AttributeValue> item);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/Mappers.cs
@@ -1,61 +1,72 @@
 using Amazon.DynamoDBv2.Model;
 using LayeredCraft.DynamoMapper.Runtime;
 
+// ReSharper disable ClassNeverInstantiated.Global
+
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
+
+public interface IDynamoMapper<T>
+{
+    static abstract Dictionary<string, AttributeValue> ToItem(T source);
+    static abstract T FromItem(Dictionary<string, AttributeValue> item);
+}
+
+public static class MapperExtensions
+{
+    public static CustomerItem ToCustomerItem(this Dictionary<string, AttributeValue> item)
+        => SaveChangesCustomerItemMapper.FromItem(item);
+
+    public static OrderItem ToOrderItem(this Dictionary<string, AttributeValue> item)
+        => SaveChangesOrderItemMapper.FromItem(item);
+
+    public static ConverterCoverageItem ToConverterCoverageItem(
+        this Dictionary<string, AttributeValue> item)
+        => SaveChangesConverterCoverageItemMapper.FromItem(item);
+}
 
 [DynamoMapper(
     Convention = DynamoNamingConvention.CamelCase,
     OmitNullValues = false,
     DateTimeFormat = "yyyy-MM-dd HH:mm:sszzz")]
 [DynamoIgnore(nameof(CustomerItem.ReferenceIds), Ignore = IgnoreMapping.ToModel)]
-internal static partial class SaveChangesCustomerItemMapper
+internal partial class SaveChangesCustomerItemMapper : IDynamoMapper<CustomerItem>
 {
-    internal static partial Dictionary<string, AttributeValue> ToItem(CustomerItem source);
+    public static partial Dictionary<string, AttributeValue> ToItem(CustomerItem source);
 
-    internal static partial CustomerItem FromItem(Dictionary<string, AttributeValue> item);
-
-    internal static CustomerItem ToCustomerItem(this Dictionary<string, AttributeValue> item)
-        => FromItem(item);
+    public static partial CustomerItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
 [DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
-internal static partial class SaveChangesOrderItemMapper
+internal partial class SaveChangesOrderItemMapper : IDynamoMapper<OrderItem>
 {
-    internal static partial Dictionary<string, AttributeValue> ToItem(OrderItem source);
+    public static partial Dictionary<string, AttributeValue> ToItem(OrderItem source);
 
-    internal static partial OrderItem FromItem(Dictionary<string, AttributeValue> item);
-
-    internal static OrderItem ToOrderItem(this Dictionary<string, AttributeValue> item)
-        => FromItem(item);
+    public static partial OrderItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
 [DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
-internal static partial class SaveChangesProductItemMapper
+internal partial class SaveChangesProductItemMapper : IDynamoMapper<ProductItem>
 {
-    internal static partial Dictionary<string, AttributeValue> ToItem(ProductItem source);
+    public static partial Dictionary<string, AttributeValue> ToItem(ProductItem source);
 
-    internal static partial ProductItem FromItem(Dictionary<string, AttributeValue> item);
+    public static partial ProductItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
 [DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
-internal static partial class SaveChangesSessionItemMapper
+internal partial class SaveChangesSessionItemMapper : IDynamoMapper<SessionItem>
 {
-    internal static partial Dictionary<string, AttributeValue> ToItem(SessionItem source);
+    public static partial Dictionary<string, AttributeValue> ToItem(SessionItem source);
 
-    internal static partial SessionItem FromItem(Dictionary<string, AttributeValue> item);
+    public static partial SessionItem FromItem(Dictionary<string, AttributeValue> item);
 }
 
 [DynamoMapper(
     Convention = DynamoNamingConvention.CamelCase,
     OmitNullValues = false,
     DateTimeFormat = "yyyy-MM-dd HH:mm:sszzz")]
-internal static partial class SaveChangesConverterCoverageItemMapper
+internal partial class SaveChangesConverterCoverageItemMapper : IDynamoMapper<ConverterCoverageItem>
 {
-    internal static partial Dictionary<string, AttributeValue> ToItem(ConverterCoverageItem source);
+    public static partial Dictionary<string, AttributeValue> ToItem(ConverterCoverageItem source);
 
-    internal static partial ConverterCoverageItem FromItem(Dictionary<string, AttributeValue> item);
-
-    internal static ConverterCoverageItem ToConverterCoverageItem(
-        this Dictionary<string, AttributeValue> item)
-        => FromItem(item);
+    public static partial ConverterCoverageItem FromItem(Dictionary<string, AttributeValue> item);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
@@ -43,6 +43,143 @@ public abstract class SaveChangesTableTestFixture : DynamoTestFixtureBase
             },
             cancellationToken);
 
+    protected async Task AssertItemDoesNotExistAsync(
+        string pk,
+        string sk,
+        CancellationToken cancellationToken)
+        => (await GetItemAsync(pk, sk, cancellationToken)).Should().BeNull();
+
+    protected async Task<Dictionary<string, AttributeValue>> GetExistingItemAsync(
+        string pk,
+        string sk,
+        CancellationToken cancellationToken)
+        => await GetItemAsync(pk, sk, cancellationToken)
+            ?? throw new InvalidOperationException($"Item {pk}/{sk} not found.");
+
+    protected async Task AssertRawItemAsync(
+        string pk,
+        string sk,
+        Action<Dictionary<string, AttributeValue>> assertion,
+        CancellationToken cancellationToken)
+        => assertion(await GetExistingItemAsync(pk, sk, cancellationToken));
+
+    protected async Task AssertRawAttributeAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        Action<AttributeValue> assertion,
+        CancellationToken cancellationToken)
+    {
+        var item = await GetExistingItemAsync(pk, sk, cancellationToken);
+        item.Should().ContainKey(attributeName);
+        assertion(item[attributeName]);
+    }
+
+    protected Task AssertRawStringAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        string expected,
+        CancellationToken cancellationToken)
+        => AssertRawAttributeAsync(
+            pk,
+            sk,
+            attributeName,
+            attribute => attribute.S.Should().Be(expected),
+            cancellationToken);
+
+    protected Task AssertRawNumberAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        string expected,
+        CancellationToken cancellationToken)
+        => AssertRawAttributeAsync(
+            pk,
+            sk,
+            attributeName,
+            attribute => attribute.N.Should().Be(expected),
+            cancellationToken);
+
+    protected Task AssertRawNullAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        CancellationToken cancellationToken)
+        => AssertRawAttributeAsync(
+            pk,
+            sk,
+            attributeName,
+            attribute => attribute.NULL.Should().BeTrue(),
+            cancellationToken);
+
+    protected async Task AssertRawMissingAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        CancellationToken cancellationToken)
+    {
+        var item = await GetExistingItemAsync(pk, sk, cancellationToken);
+        item.Should().NotContainKey(attributeName);
+    }
+
+    protected Task AssertRawStringSetAsync(
+        string pk,
+        string sk,
+        string attributeName,
+        IEnumerable<string> expected,
+        CancellationToken cancellationToken)
+        => AssertRawAttributeAsync(
+            pk,
+            sk,
+            attributeName,
+            attribute => attribute.SS.Should().BeEquivalentTo(expected),
+            cancellationToken);
+
+    protected async Task SaveAndClearLogAsync()
+    {
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+    }
+
+    protected async Task SeedAsync<T>(T entity) where T : class
+    {
+        Db.Set<T>().Add(entity);
+        await SaveAndClearLogAsync();
+    }
+
+    protected async Task SaveChangesShouldAffectAsync(int expected)
+        => (await Db.SaveChangesAsync(CancellationToken)).Should().Be(expected);
+
+    protected async Task SaveChangesShouldAffectAsync(bool acceptAllChangesOnSuccess, int expected)
+        => (await Db.SaveChangesAsync(acceptAllChangesOnSuccess, CancellationToken))
+            .Should()
+            .Be(expected);
+
+    protected void AssertEntryState<T>(T entity, EntityState expected) where T : class
+        => AssertEntryState(Db, entity, expected);
+
+    protected static void AssertEntryState<T>(DbContext context, T entity, EntityState expected)
+        where T : class
+        => context.Entry(entity).State.Should().Be(expected);
+
+    protected void AssertEntryStates(params (object Entity, EntityState Expected)[] entries)
+        => AssertEntryStates(Db, entries);
+
+    protected static void AssertEntryStates(
+        DbContext context,
+        params (object Entity, EntityState Expected)[] entries)
+    {
+        foreach (var (entity, expected) in entries)
+            context.Entry(entity).State.Should().Be(expected);
+    }
+
+    protected void AssertOriginalValue<TEntity, TProperty>(
+        TEntity entity,
+        string propertyName,
+        TProperty expected) where TEntity : class
+        => Db.Entry(entity).Property<TProperty>(propertyName).OriginalValue.Should().Be(expected);
+
     protected async Task<Dictionary<string, AttributeValue>?> GetItemAsync(
         string pk,
         string sk,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/Infra/TestFixture.cs
@@ -29,6 +29,20 @@ public abstract class SaveChangesTableTestFixture : DynamoTestFixtureBase
             new PutItemRequest { TableName = SaveChangesItemTable.TableName, Item = item },
             cancellationToken);
 
+    protected Task AssertItemExistsInDynamoDbAsync<T>(
+        T item,
+        string pk,
+        string sk,
+        CancellationToken cancellationToken)
+        => AssertItemExistsInDynamoDbAsync(
+            item,
+            SaveChangesItemTable.TableName,
+            new Dictionary<string, AttributeValue>
+            {
+                ["pk"] = pk.ToAttributeValue(), ["sk"] = sk.ToAttributeValue(),
+            },
+            cancellationToken);
+
     protected async Task<Dictionary<string, AttributeValue>?> GetItemAsync(
         string pk,
         string sk,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
@@ -18,14 +18,11 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero),
             NullableNote = "note-1",
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Email = "updated+1@example.com";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
@@ -50,15 +47,12 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 3, 2, 12, 0, 0, TimeSpan.Zero),
             NullableNote = null,
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Email = "updated+2@example.com";
         item.IsPreferred = true;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
@@ -83,14 +77,11 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 3, 3, 12, 0, 0, TimeSpan.Zero),
             NullableNote = "to-null",
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.NullableNote = null;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
@@ -115,12 +106,9 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 3, 4, 12, 0, 0, TimeSpan.Zero),
             NullableNote = null,
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(0);
+        await SaveChangesShouldAffectAsync(0);
 
         await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
@@ -141,19 +129,16 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 3, 5, 12, 0, 0, TimeSpan.Zero),
             NullableNote = null,
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Email = "post-save@example.com";
         var entry = Db.Entry(item);
         entry.State.Should().Be(EntityState.Modified);
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         entry.State.Should().Be(EntityState.Unchanged);
-        entry.Property(x => x.Email).OriginalValue.Should().Be("post-save@example.com");
+        AssertOriginalValue(item, nameof(CustomerItem.Email), "post-save@example.com");
 
         await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ModifiedScalarSaveChangesTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -28,9 +27,7 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
         var affected = await Db.SaveChangesAsync(CancellationToken);
         affected.Should().Be(1);
 
-        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(item);
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -63,9 +60,7 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
         var affected = await Db.SaveChangesAsync(CancellationToken);
         affected.Should().Be(1);
 
-        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(item);
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -97,9 +92,7 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
         var affected = await Db.SaveChangesAsync(CancellationToken);
         affected.Should().Be(1);
 
-        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(item);
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -129,9 +122,7 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
         var affected = await Db.SaveChangesAsync(CancellationToken);
         affected.Should().Be(0);
 
-        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(item);
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
         AssertSql();
     }
@@ -164,9 +155,7 @@ public class ModifiedScalarSaveChangesTests(DynamoContainerFixture fixture)
         entry.State.Should().Be(EntityState.Unchanged);
         entry.Property(x => x.Email).OriginalValue.Should().Be("post-save@example.com");
 
-        var actual = (await GetItemAsync(item.Pk, item.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(item);
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/NestedComplexCollectionSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/NestedComplexCollectionSaveChangesTests.cs
@@ -1,7 +1,6 @@
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -41,19 +40,20 @@ public class NestedComplexCollectionSaveChangesTests : DynamoTestFixtureBase
         var item = new NestedComplexCollectionItem { Pk = "ITEM#1", Profile = null };
 
         Db.Items.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SaveAndClearLogAsync();
 
         item.Profile = new NestedProfile { Badges = [new NestedBadge { Label = "vip" }] };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
-        var raw = await GetItemAsync(item.Pk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().ContainKey("profile");
-        raw["profile"].M["badges"].L.Should().HaveCount(1);
-        raw["profile"].M["badges"].L[0].M["label"].S.Should().Be("vip");
+        await AssertRawAttributeAsync(
+            item.Pk,
+            "profile",
+            profile =>
+            {
+                profile.M["badges"].L.Should().HaveCount(1);
+                profile.M["badges"].L[0].M["label"].S.Should().Be("vip");
+            });
 
         AssertSql(
             """
@@ -83,6 +83,27 @@ public class NestedComplexCollectionSaveChangesTests : DynamoTestFixtureBase
                 BillingMode = BillingMode.PAY_PER_REQUEST,
             },
             cancellationToken);
+
+    private async Task SaveAndClearLogAsync()
+    {
+        await Db.SaveChangesAsync(CancellationToken);
+        LoggerFactory.Clear();
+    }
+
+    private async Task SaveChangesShouldAffectAsync(int expected)
+        => (await Db.SaveChangesAsync(CancellationToken)).Should().Be(expected);
+
+    private async Task AssertRawAttributeAsync(
+        string pk,
+        string attributeName,
+        Action<AttributeValue> assertion)
+    {
+        var item = await GetItemAsync(pk, CancellationToken)
+            ?? throw new InvalidOperationException($"Item {pk} not found.");
+
+        item.Should().ContainKey(attributeName);
+        assertion(item[attributeName]);
+    }
 
     private async Task<Dictionary<string, AttributeValue>?> GetItemAsync(
         string pk,

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/OwnedAndNestedSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/OwnedAndNestedSaveChangesTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -33,18 +32,18 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
             Profile = new CustomerProfile { DisplayName = "Before", Nickname = null },
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Profile!.DisplayName = "After";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["profile"].M["displayName"].S.Should().Be("After");
+        await AssertRawAttributeAsync(
+            item.Pk,
+            item.Sk,
+            "profile",
+            profile => profile.M["displayName"].S.Should().Be("After"),
+            CancellationToken);
 
         // Nested-path shape — not a full map replace.
         AssertSql(
@@ -76,20 +75,14 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 2, 12, 0, 0, TimeSpan.Zero),
             Profile = new CustomerProfile { DisplayName = "Will be removed", Nickname = null },
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Profile = null;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
-
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
+        await SaveChangesShouldAffectAsync(1);
 
         // REMOVE deletes the attribute entirely — key must be absent.
-        raw!.Should().NotContainKey("profile");
+        await AssertRawMissingAsync(item.Pk, item.Sk, "profile", CancellationToken);
 
         AssertSql(
             """
@@ -121,20 +114,22 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 3, 12, 0, 0, TimeSpan.Zero),
             Profile = null,
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Profile = new CustomerProfile { DisplayName = "Newly Added", Nickname = "new" };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().ContainKey("profile");
-        raw["profile"].M["displayName"].S.Should().Be("Newly Added");
-        raw["profile"].M["nickname"].S.Should().Be("new");
+        await AssertRawAttributeAsync(
+            item.Pk,
+            item.Sk,
+            "profile",
+            profile =>
+            {
+                profile.M["displayName"].S.Should().Be("Newly Added");
+                profile.M["nickname"].S.Should().Be("new");
+            },
+            CancellationToken);
 
         AssertSql(
             """
@@ -172,14 +167,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             },
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Profile!.PreferredAddress!.City = "NewCity";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["profile"].M["preferredAddress"].M["city"].S.Should().Be("NewCity");
@@ -219,14 +211,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             ],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Contacts[0].Verified = true;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["contacts"].L.Should().HaveCount(1);
@@ -267,15 +256,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             ],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Contacts.Add(
             new CustomerContact { Kind = "phone", Value = "+15550001", Verified = false });
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["contacts"].L.Should().HaveCount(2);
@@ -313,14 +299,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 7, 12, 0, 0, TimeSpan.Zero),
             Contacts = [contact1, contact2],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Contacts.Remove(contact1);
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["contacts"].L.Should().HaveCount(1);
@@ -368,14 +351,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             ],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Contacts[0].Address!.City = "NewCity";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["contacts"].L.Should().HaveCount(1);
@@ -416,18 +396,13 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             ],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Contacts = null!;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().NotContainKey("contacts");
+        await AssertRawMissingAsync(item.Pk, item.Sk, "contacts", CancellationToken);
 
         AssertSql(
             """
@@ -458,15 +433,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             Total = 50m,
             AppliedCoupons = ["WELCOME10"],
         };
-        Db.Orders.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         // Replace the collection reference so EF Core's snapshot comparison detects the change.
         item.AppliedCoupons = [..item.AppliedCoupons, "SUMMER5"];
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["appliedCoupons"].L.Select(a => a.S).Should().Contain("SUMMER5");
@@ -501,16 +473,13 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             Total = 60m,
             ChargesByCode = new Dictionary<string, decimal> { ["shipping"] = 9.99m },
         };
-        Db.Orders.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         // Replace the dictionary reference so EF Core's snapshot comparison detects the change.
         item.ChargesByCode =
             new Dictionary<string, decimal>(item.ChargesByCode) { ["tax"] = 11.51m };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["chargesByCode"].M.Should().ContainKey("tax");
@@ -545,15 +514,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero),
             Tags = ["vip"],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         // Replace the set reference so EF Core's snapshot comparison detects the change.
         item.Tags = new HashSet<string>(item.Tags) { "beta" };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["tags"].SS.Should().Contain("beta");
@@ -590,15 +556,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 12, 12, 0, 0, TimeSpan.Zero),
             ReferenceIds = [guid1],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         // Replace the set reference so EF Core's snapshot comparison detects the change.
         item.ReferenceIds = new HashSet<Guid>(item.ReferenceIds) { guid2 };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["referenceIds"].SS.Should().Contain(guid2.ToString());
@@ -633,15 +596,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 13, 12, 0, 0, TimeSpan.Zero),
             Profile = new CustomerProfile { DisplayName = "Test", Nickname = "before-nick" },
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Email = "own13-after@example.com";
         item.Profile!.Nickname = "after-nick";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["email"].S.Should().Be("own13-after@example.com");
@@ -676,15 +636,12 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 14, 12, 0, 0, TimeSpan.Zero),
             Tags = ["original"],
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Email = "own14-after@example.com";
         item.Tags = new HashSet<string>(item.Tags) { "added" };
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["email"].S.Should().Be("own14-after@example.com");
@@ -720,14 +677,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             IsActive = true,
             Dimensions = new ProductDimensions { Height = 5m, Width = 3m, Depth = 1m },
         };
-        Db.Products.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Dimensions!.Height = 15m;
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         // Decimal stored as DynamoDB N string.
@@ -769,14 +723,11 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
                 },
             },
         };
-        Db.Orders.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Shipping!.Method = "Express";
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
         raw!["shipping"].M["method"].S.Should().Be("Express");
@@ -812,16 +763,13 @@ public class OwnedAndNestedSaveChangesTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 17, 12, 0, 0, TimeSpan.Zero),
             Profile = new CustomerProfile { DisplayName = "Before", Nickname = null },
         };
-        Db.Customers.Add(item);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(item);
 
         item.Profile!.DisplayName = "After";
         var profileEntry = Db.Entry(item).ComplexProperty("Profile");
         profileEntry.IsModified.Should().BeTrue();
 
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-        affected.Should().Be(1);
+        await SaveChangesShouldAffectAsync(1);
 
         // Consume the first write's logged statement before checking the no-op save.
         AssertSql(

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesConcurrencyTests.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -78,9 +77,7 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         // Simulate a concurrent writer bumping the version directly.
         await BumpVersionAsync(customer.Pk, customer.Sk, CancellationToken);
@@ -115,9 +112,7 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         await Client.DeleteItemAsync(
             new DeleteItemRequest
@@ -186,10 +181,12 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
         assertion.And.Should().NotBeOfType<DbUpdateConcurrencyException>();
         assertion.WithMessage("*not found for its key*");
 
-        var realItem =
-            await GetItemAsync("TENANT#CONC-WRONG-SK", "CUSTOMER#REAL", CancellationToken);
-        realItem.Should().NotBeNull();
-        realItem!["version"].N.Should().Be("1");
+        await AssertRawNumberAsync(
+            "TENANT#CONC-WRONG-SK",
+            "CUSTOMER#REAL",
+            "version",
+            "1",
+            CancellationToken);
 
         AssertSql(
             """
@@ -266,9 +263,7 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
         Db.Customers.Add(first);
-        Db.Customers.Add(second);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(second);
 
         await BumpVersionAsync(second.Pk, second.Sk, CancellationToken);
 
@@ -310,9 +305,7 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
         Db.Customers.Add(first);
-        Db.Customers.Add(second);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(second);
 
         await Client.DeleteItemAsync(
             new DeleteItemRequest
@@ -356,9 +349,7 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         // Simulate a concurrent writer bumping the version directly.
         await BumpVersionAsync(customer.Pk, customer.Sk, CancellationToken);
@@ -392,16 +383,13 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         customer.Version = 2;
         customer.Email = "updated@example.com";
         await Db.SaveChangesAsync(CancellationToken);
 
-        var itemAfterUpdate = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        itemAfterUpdate!["version"].N.Should().Be("2");
+        await AssertRawNumberAsync(customer.Pk, customer.Sk, "version", "2", CancellationToken);
 
         AssertSql(
             """
@@ -427,25 +415,21 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         // First update: Version 1 -> 2
         customer.Version = 2;
         customer.Email = "v2@example.com";
         await Db.SaveChangesAsync(CancellationToken);
 
-        var itemV2 = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        itemV2!["version"].N.Should().Be("2");
+        await AssertRawNumberAsync(customer.Pk, customer.Sk, "version", "2", CancellationToken);
 
         // Second update: Version 2 -> 3
         customer.Version = 3;
         customer.Email = "v3@example.com";
         await Db.SaveChangesAsync(CancellationToken);
 
-        var itemV3 = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        itemV3!["version"].N.Should().Be("3");
+        await AssertRawNumberAsync(customer.Pk, customer.Sk, "version", "3", CancellationToken);
 
         AssertSql(
             """
@@ -477,17 +461,19 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         customer.Version = 2;
         customer.Email = "after@example.com";
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().NotThrowAsync();
 
-        var item = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        item!["email"].S.Should().Be("after@example.com");
+        await AssertRawStringAsync(
+            customer.Pk,
+            customer.Sk,
+            "email",
+            "after@example.com",
+            CancellationToken);
 
         AssertSql(
             """
@@ -510,16 +496,13 @@ public class SaveChangesConcurrencyTests(DynamoContainerFixture fixture)
             IsPreferred = false,
             CreatedAt = new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
         };
-        Db.Customers.Add(customer);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(customer);
 
         Db.Customers.Remove(customer);
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().NotThrowAsync();
 
-        var item = await GetItemAsync(customer.Pk, customer.Sk, CancellationToken);
-        item.Should().BeNull();
+        await AssertItemDoesNotExistAsync(customer.Pk, customer.Sk, CancellationToken);
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesEdgeCasesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesEdgeCasesTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
@@ -18,9 +17,7 @@ public class SaveChangesEdgeCasesTests(DynamoContainerFixture fixture)
     public async Task ZeroChanges_ReturnsZero_AndNoWritesEmitted()
     {
         // Fresh context with nothing tracked — SaveChanges should be a no-op.
-        var affected = await Db.SaveChangesAsync(CancellationToken);
-
-        affected.Should().Be(0);
+        await SaveChangesShouldAffectAsync(0);
         AssertSql(); // No PartiQL statements should have been emitted.
     }
 
@@ -48,11 +45,10 @@ public class SaveChangesEdgeCasesTests(DynamoContainerFixture fixture)
         Db.Customers.Add(customer);
 
         // SaveChanges with acceptAllChangesOnSuccess = false.
-        var affected = await Db.SaveChangesAsync(false, CancellationToken);
+        await SaveChangesShouldAffectAsync(false, 1);
 
         // Write reached DynamoDB.
-        affected.Should().Be(1);
-        (await GetItemAsync(pk, sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(customer, pk, sk, CancellationToken);
 
         AssertSql(
             """
@@ -61,11 +57,11 @@ public class SaveChangesEdgeCasesTests(DynamoContainerFixture fixture)
             """);
 
         // Entry still in Added state — AcceptAllChanges was not called.
-        Db.Entry(customer).State.Should().Be(EntityState.Added);
+        AssertEntryState(customer, EntityState.Added);
 
         // After explicit AcceptAllChanges, entry becomes Unchanged.
         Db.ChangeTracker.AcceptAllChanges();
-        Db.Entry(customer).State.Should().Be(EntityState.Unchanged);
+        AssertEntryState(customer, EntityState.Unchanged);
     }
 
     // ── Statement-length guard ────────────────────────────────────────────────
@@ -92,7 +88,7 @@ public class SaveChangesEdgeCasesTests(DynamoContainerFixture fixture)
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*8192*");
 
         // Guard fired before the write — item must not exist in DynamoDB.
-        (await GetItemAsync(pk, sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(pk, sk, CancellationToken);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesModelValidationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SaveChangesModelValidationTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
@@ -30,7 +29,7 @@ public class SaveChangesModelValidationTests(DynamoContainerFixture fixture)
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*HasConversion*");
 
-        (await GetItemAsync(item.Pk, item.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(item.Pk, item.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -53,7 +52,7 @@ public class SaveChangesModelValidationTests(DynamoContainerFixture fixture)
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*IsRowVersion()*not currently support*");
 
-        (await GetItemAsync(item.Pk, item.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(item.Pk, item.Sk, CancellationToken);
     }
 
     private UnmappedScalarContext CreateUnmappedScalarContext()

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SparseGsiSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/SparseGsiSaveChangesTests.cs
@@ -31,10 +31,7 @@ public class SparseGsiSaveChangesTests(DynamoContainerFixture fixture)
         Db.SparseGsiItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!.Should().NotContainKey("gs1-pk");
-        raw.Should().NotContainKey("gs1-sk");
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -59,11 +56,7 @@ public class SparseGsiSaveChangesTests(DynamoContainerFixture fixture)
         Db.SparseGsiItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["optionalNote"].NULL.Should().BeTrue();
-        raw.Should().NotContainKey("gs1-pk");
-        raw.Should().NotContainKey("gs1-sk");
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -86,9 +79,6 @@ public class SparseGsiSaveChangesTests(DynamoContainerFixture fixture)
         Db.SparseGsiItems.Add(item);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(item.Pk, item.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["gs1-pk"].S.Should().Be("partition#active");
-        raw["gs1-sk"].S.Should().Be("sort#001");
+        await AssertItemExistsInDynamoDbAsync(item, item.Pk, item.Sk, CancellationToken);
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
@@ -22,8 +21,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await Db.SaveChangesAsync(CancellationToken);
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
 
         AssertSql(
             """
@@ -83,7 +82,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -136,8 +135,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         Db.Entry(second).State.Should().Be(EntityState.Unchanged);
         Db.Entry(duplicate).State.Should().Be(EntityState.Added);
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -243,8 +242,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
         Db.Entry(first).State.Should().Be(EntityState.Unchanged);
         Db.Entry(second).State.Should().Be(EntityState.Unchanged);
         Db.Entry(duplicate).State.Should().Be(EntityState.Added);
@@ -301,8 +300,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await configuredDb.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
         configuredDb.Entry(first).State.Should().Be(EntityState.Unchanged);
         configuredDb.Entry(second).State.Should().Be(EntityState.Unchanged);
         configuredDb.Entry(duplicate).State.Should().Be(EntityState.Added);
@@ -344,9 +343,13 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await Db.SaveChangesAsync(CancellationToken);
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().NotBeNull();
-        (await GetItemAsync(duplicate.Pk, duplicate.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(
+            duplicate,
+            duplicate.Pk,
+            duplicate.Sk,
+            CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -408,7 +411,11 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await Db.SaveChangesAsync(CancellationToken);
 
-        (await GetItemAsync(customer.Pk, customer.Sk, CancellationToken)).Should().NotBeNull();
+        await AssertItemExistsInDynamoDbAsync(
+            customer,
+            customer.Pk,
+            customer.Sk,
+            CancellationToken);
 
         AssertSql(
             """
@@ -471,10 +478,12 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await Db.SaveChangesAsync(CancellationToken);
 
-        (await GetItemAsync(toAdd.Pk, toAdd.Sk, CancellationToken)).Should().NotBeNull();
-        var modifiedItem = await GetItemAsync(toModify.Pk, toModify.Sk, CancellationToken);
-        modifiedItem.Should().NotBeNull();
-        modifiedItem!["email"].S.Should().Be("modified@example.com");
+        await AssertItemExistsInDynamoDbAsync(toAdd, toAdd.Pk, toAdd.Sk, CancellationToken);
+        await AssertItemExistsInDynamoDbAsync(
+            toModify,
+            toModify.Pk,
+            toModify.Sk,
+            CancellationToken);
         (await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken)).Should().BeNull();
     }
 
@@ -512,9 +521,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
 
-        // The transaction rolled back atomically: `first` must not have been persisted.
-        var firstItem = await GetItemAsync(first.Pk, first.Sk, CancellationToken);
-        firstItem!["email"].S.Should().Be("first@example.com");
+        // The transaction rolled back atomically: `first` must not have been updated.
+        first.Email = "first@example.com";
+        await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
 
         // Both entries should remain Modified so the caller can retry after resolving the conflict.
         Db.Entry(first).State.Should().Be(EntityState.Modified);

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/TransactionalSaveChangesTests.cs
@@ -58,9 +58,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
-        Db.Entry(first).State.Should().Be(EntityState.Added);
-        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+        await AssertItemDoesNotExistAsync(first.Pk, first.Sk, CancellationToken);
+        AssertEntryState(first, EntityState.Added);
+        AssertEntryState(duplicate, EntityState.Added);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -102,8 +102,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*acceptAllChangesOnSuccess is false*");
 
-        Db.Entry(first).State.Should().Be(EntityState.Added);
-        Db.Entry(second).State.Should().Be(EntityState.Added);
+        AssertEntryState(first, EntityState.Added);
+        AssertEntryState(second, EntityState.Added);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -131,9 +131,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+        AssertEntryState(first, EntityState.Unchanged);
+        AssertEntryState(second, EntityState.Unchanged);
+        AssertEntryState(duplicate, EntityState.Added);
 
         await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
         await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
@@ -185,9 +185,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(CancellationToken);
         await act.Should().ThrowAsync<DbUpdateException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
-        Db.Entry(first).State.Should().Be(EntityState.Added);
-        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+        await AssertItemDoesNotExistAsync(first.Pk, first.Sk, CancellationToken);
+        AssertEntryState(first, EntityState.Added);
+        AssertEntryState(duplicate, EntityState.Added);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -213,10 +213,10 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var act = async () => await Db.SaveChangesAsync(cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().BeNull();
-        Db.Entry(first).State.Should().Be(EntityState.Added);
-        Db.Entry(second).State.Should().Be(EntityState.Added);
+        await AssertItemDoesNotExistAsync(first.Pk, first.Sk, CancellationToken);
+        await AssertItemDoesNotExistAsync(second.Pk, second.Sk, CancellationToken);
+        AssertEntryState(first, EntityState.Added);
+        AssertEntryState(second, EntityState.Added);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -244,9 +244,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
         await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
-        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+        AssertEntryState(first, EntityState.Unchanged);
+        AssertEntryState(second, EntityState.Unchanged);
+        AssertEntryState(duplicate, EntityState.Added);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -270,7 +270,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*AutoTransactionBehavior.Always*");
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(first.Pk, first.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -302,9 +302,11 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
 
         await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
         await AssertItemExistsInDynamoDbAsync(second, second.Pk, second.Sk, CancellationToken);
-        configuredDb.Entry(first).State.Should().Be(EntityState.Unchanged);
-        configuredDb.Entry(second).State.Should().Be(EntityState.Unchanged);
-        configuredDb.Entry(duplicate).State.Should().Be(EntityState.Added);
+        AssertEntryStates(
+            configuredDb,
+            (first, EntityState.Unchanged),
+            (second, EntityState.Unchanged),
+            (duplicate, EntityState.Added));
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -334,9 +336,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var firstSave = async () => await Db.SaveChangesAsync(CancellationToken);
         await firstSave.Should().ThrowAsync<DbUpdateException>();
 
-        Db.Entry(first).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(second).State.Should().Be(EntityState.Unchanged);
-        Db.Entry(duplicate).State.Should().Be(EntityState.Added);
+        AssertEntryState(first, EntityState.Unchanged);
+        AssertEntryState(second, EntityState.Unchanged);
+        AssertEntryState(duplicate, EntityState.Added);
 
         duplicate.Sk = "CUSTOMER#CHUNK-RETRY-3";
         duplicate.Email = "third@example.com";
@@ -374,9 +376,9 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*acceptAllChangesOnSuccess is false*");
 
-        (await GetItemAsync(first.Pk, first.Sk, CancellationToken)).Should().BeNull();
-        (await GetItemAsync(second.Pk, second.Sk, CancellationToken)).Should().BeNull();
-        (await GetItemAsync(third.Pk, third.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(first.Pk, first.Sk, CancellationToken);
+        await AssertItemDoesNotExistAsync(second.Pk, second.Sk, CancellationToken);
+        await AssertItemDoesNotExistAsync(third.Pk, third.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -453,7 +455,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*multiple operations targeting the same DynamoDB item*");
 
-        (await GetItemAsync(customer.Pk, customer.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(customer.Pk, customer.Sk, CancellationToken);
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
@@ -467,9 +469,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var toDelete = CreateCustomer("TENANT#TXN", "CUSTOMER#MIXED-DELETE", "delete@example.com");
 
         Db.Customers.Add(toModify);
-        Db.Customers.Add(toDelete);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(toDelete);
 
         var toAdd = CreateCustomer("TENANT#TXN", "CUSTOMER#MIXED-ADD", "add@example.com");
         Db.Customers.Add(toAdd);
@@ -484,7 +484,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
             toModify.Pk,
             toModify.Sk,
             CancellationToken);
-        (await GetItemAsync(toDelete.Pk, toDelete.Sk, CancellationToken)).Should().BeNull();
+        await AssertItemDoesNotExistAsync(toDelete.Pk, toDelete.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -505,9 +505,7 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         var second = CreateCustomer("TENANT#TXN", "CUSTOMER#TXN-CONC-2", "second@example.com");
 
         Db.Customers.Add(first);
-        Db.Customers.Add(second);
-        await Db.SaveChangesAsync(CancellationToken);
-        LoggerFactory.Clear();
+        await SeedAsync(second);
 
         // Simulate a concurrent writer bumping `second`'s version directly in DynamoDB.
         // The EF change tracker still holds Version = 1 for `second`.
@@ -526,8 +524,8 @@ public class TransactionalSaveChangesTests(DynamoContainerFixture fixture)
         await AssertItemExistsInDynamoDbAsync(first, first.Pk, first.Sk, CancellationToken);
 
         // Both entries should remain Modified so the caller can retry after resolving the conflict.
-        Db.Entry(first).State.Should().Be(EntityState.Modified);
-        Db.Entry(second).State.Should().Be(EntityState.Modified);
+        AssertEntryState(first, EntityState.Modified);
+        AssertEntryState(second, EntityState.Modified);
     }
 
     private static CustomerItem CreateCustomer(string pk, string sk, string email)

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+using LayeredCraft.DynamoMapper.Runtime;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
@@ -416,7 +417,7 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         return response.Item is { Count: > 0 } item ? item : null;
     }
 
-    private sealed record IntKeyEntity
+    public sealed record IntKeyEntity
     {
         public int Id { get; set; }
 
@@ -442,21 +443,21 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             });
     }
 
-    private sealed record GuidKeyEntity
+    public sealed record GuidKeyEntity
     {
         public Guid Id { get; set; }
 
         public string Name { get; set; } = null!;
     }
 
-    private sealed record StringKeyEntity
+    public sealed record StringKeyEntity
     {
         public string Id { get; set; } = null!;
 
         public string Name { get; set; } = null!;
     }
 
-    private sealed record BinaryKeyEntity
+    public sealed record BinaryKeyEntity
     {
         public byte[] Id { get; set; } = null!;
 
@@ -574,7 +575,7 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             });
     }
 
-    private sealed record CompositeKeyEntity
+    public sealed record CompositeKeyEntity
     {
         public string Pk { get; set; } = null!;
 
@@ -605,7 +606,7 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             });
     }
 
-    private sealed record CompositeGuidKeyEntity
+    public sealed record CompositeGuidKeyEntity
     {
         public Guid Id { get; set; }
 
@@ -635,4 +636,70 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
                 entity.HasSortKey(x => x.Sk);
             });
     }
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class IntKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.IntKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.IntKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.IntKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class GuidKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.GuidKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.GuidKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.GuidKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class StringKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.StringKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.StringKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.StringKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class BinaryKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.BinaryKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.BinaryKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.BinaryKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class CompositeKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.CompositeKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.CompositeKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.CompositeKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
+}
+
+[DynamoMapper(Convention = DynamoNamingConvention.CamelCase, OmitNullValues = false)]
+internal partial class CompositeGuidKeyEntityMapper
+    : IDynamoMapper<ValueGenerationSaveChangesTests.CompositeGuidKeyEntity>
+{
+    public static partial Dictionary<string, AttributeValue> ToItem(
+        ValueGenerationSaveChangesTests.CompositeGuidKeyEntity source);
+
+    public static partial ValueGenerationSaveChangesTests.CompositeGuidKeyEntity FromItem(
+        Dictionary<string, AttributeValue> item);
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -27,13 +27,12 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         context.Entities.Add(entity);
         await context.SaveChangesAsync(CancellationToken);
 
-        var raw = await GetItemAsync(
+        var raw = await GetItemAsync<IntKeyEntity>(
             IntKeyContext.TableName,
-            "id",
-            new AttributeValue { N = "123" });
-        raw.Should().NotBeNull();
-        raw!["id"].N.Should().Be("123");
-        raw["name"].S.Should().Be("assigned");
+            new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
+            CancellationToken);
+
+        raw.Should().BeEquivalentTo(entity);
 
         var materialized =
             await context

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -20,27 +20,29 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_IntPartitionKey_ExplicitKey_PersistsAndMaterializes()
     {
-        await using var context = CreateContext<IntKeyContext>();
-        await ResetTable(context);
         var entity = new IntKeyEntity { Id = 123, Name = "assigned" };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<IntKeyContext>())
+        {
+            await ResetTable(context);
 
-        var raw = await GetItemAsync<IntKeyEntity>(
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
+
+        await AssertItemExistsInDynamoDbAsync<IntKeyEntity>(
+            entity,
             IntKeyContext.TableName,
             new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
             CancellationToken);
 
-        raw.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<IntKeyContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == 123).ToListAsync(CancellationToken);
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == 123)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -58,25 +60,28 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_IntPartitionKey_DefaultZero_PersistsAsExplicitKey()
     {
-        await using var context = CreateContext<IntKeyContext>();
-        await ResetTable(context);
         var entity = new IntKeyEntity { Id = 0, Name = "zero" };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<IntKeyContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         var raw = await GetItemAsync(IntKeyContext.TableName, "id", new AttributeValue { N = "0" });
         raw.Should().NotBeNull();
         raw!["id"].N.Should().Be("0");
         raw["name"].S.Should().Be("zero");
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == 0)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<IntKeyContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == 0).ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -94,12 +99,15 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_StringPartitionKey_ExplicitKey_PersistsAndMaterializes()
     {
-        await using var context = CreateContext<StringKeyContext>();
-        await ResetTable(context);
         var entity = new StringKeyEntity { Id = "SESSION#1", Name = "assigned" };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<StringKeyContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         var raw = await GetItemAsync(
             StringKeyContext.TableName,
@@ -109,13 +117,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw!["id"].S.Should().Be(entity.Id);
         raw["name"].S.Should().Be(entity.Name);
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == entity.Id)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<StringKeyContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == entity.Id).ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -153,7 +161,6 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
 
         await using (var context = CreateContext<BinaryKeyContext>())
         {
-            context.ChangeTracker.Clear();
             var materialized =
                 await context
                     .Entities
@@ -179,13 +186,16 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_IntPartitionKey_ExplicitGenerator_GeneratesPersistsAndMaterializes()
     {
-        await using var context = CreateContext<GeneratedIntKeyContext>();
-        await ResetTable(context);
         var entity = new IntKeyEntity { Name = "generated" };
 
-        entity.Id.Should().Be(0);
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<GeneratedIntKeyContext>())
+        {
+            await ResetTable(context);
+
+            entity.Id.Should().Be(0);
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         entity.Id.Should().Be(777);
         var raw = await GetItemAsync(
@@ -196,13 +206,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw!["id"].N.Should().Be("777");
         raw["name"].S.Should().Be("generated");
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == entity.Id)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<GeneratedIntKeyContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == entity.Id).ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -220,13 +230,16 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_GuidPartitionKey_DefaultGuid_GeneratesPersistsAndMaterializes()
     {
-        await using var context = CreateContext<GuidKeyContext>();
-        await ResetTable(context);
         var entity = new GuidKeyEntity { Name = "generated" };
 
-        entity.Id.Should().Be(Guid.Empty);
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<GuidKeyContext>())
+        {
+            await ResetTable(context);
+
+            entity.Id.Should().Be(Guid.Empty);
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         entity.Id.Should().NotBe(Guid.Empty);
         var raw = await GetItemAsync(
@@ -237,13 +250,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw!["id"].S.Should().Be(entity.Id.ToString());
         raw["name"].S.Should().Be("generated");
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == entity.Id)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<GuidKeyContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == entity.Id).ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -261,13 +274,16 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_GuidPartitionKey_ValueGeneratedNever_PersistsExplicitKey()
     {
-        await using var context = CreateContext<ExplicitGuidNoGenerationContext>();
-        await ResetTable(context);
         var id = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
         var entity = new GuidKeyEntity { Id = id, Name = "explicit" };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<ExplicitGuidNoGenerationContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         entity.Id.Should().Be(id);
         var raw = await GetItemAsync(
@@ -278,13 +294,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw!["id"].S.Should().Be(id.ToString());
         raw["name"].S.Should().Be("explicit");
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == id)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<ExplicitGuidNoGenerationContext>())
+        {
+            var materialized =
+                await context.Entities.Where(x => x.Id == id).ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -302,12 +318,15 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_CompositeStringKeys_ExplicitKeys_PersistsAndMaterializes()
     {
-        await using var context = CreateContext<CompositeKeyContext>();
-        await ResetTable(context);
         var entity = new CompositeKeyEntity { Pk = "TENANT#1", Sk = "ORDER#1", Name = "composite" };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<CompositeKeyContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         var raw = await GetItemAsync(
             CompositeKeyContext.TableName,
@@ -320,13 +339,16 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw["sk"].S.Should().Be(entity.Sk);
         raw["name"].S.Should().Be(entity.Name);
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Pk == entity.Pk && x.Sk == entity.Sk)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<CompositeKeyContext>())
+        {
+            var materialized =
+                await context
+                    .Entities
+                    .Where(x => x.Pk == entity.Pk && x.Sk == entity.Sk)
+                    .ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """
@@ -344,8 +366,6 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task AddAsync_CompositeGuidStringKeys_ExplicitKeys_PersistsAndMaterializes()
     {
-        await using var context = CreateContext<CompositeGuidKeyContext>();
-        await ResetTable(context);
         var entity = new CompositeGuidKeyEntity
         {
             Id = Guid.Parse("11111111-2222-3333-4444-555555555555"),
@@ -353,8 +373,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             Name = "composite-guid",
         };
 
-        context.Entities.Add(entity);
-        await context.SaveChangesAsync(CancellationToken);
+        await using (var context = CreateContext<CompositeGuidKeyContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
 
         var raw = await GetItemAsync(
             CompositeGuidKeyContext.TableName,
@@ -367,13 +392,16 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         raw["sk"].S.Should().Be(entity.Sk);
         raw["name"].S.Should().Be(entity.Name);
 
-        var materialized =
-            await context
-                .Entities
-                .AsNoTracking()
-                .Where(x => x.Id == entity.Id && x.Sk == entity.Sk)
-                .ToListAsync(CancellationToken);
-        materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        await using (var context = CreateContext<CompositeGuidKeyContext>())
+        {
+            var materialized =
+                await context
+                    .Entities
+                    .Where(x => x.Id == entity.Id && x.Sk == entity.Sk)
+                    .ToListAsync(CancellationToken);
+
+            materialized.Should().ContainSingle().Which.Should().BeEquivalentTo(entity);
+        }
 
         AssertSql(
             """

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
@@ -126,6 +125,52 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             """
             SELECT "id", "name"
             FROM "value-generation-string-keys"
+            WHERE "id" = ?
+            """);
+    }
+
+    /// <summary>Verifies binary partition keys are explicitly written and can be read back.</summary>
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task AddAsync_BinaryPartitionKey_ExplicitKey_PersistsAndMaterializes()
+    {
+        var entity = new BinaryKeyEntity { Id = [0, 1, 2, 127, 255], Name = "binary" };
+
+        await using (var context = CreateContext<BinaryKeyContext>())
+        {
+            await ResetTable(context);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync(CancellationToken);
+        }
+
+        var raw = await GetItemAsync(
+            BinaryKeyContext.TableName,
+            "id",
+            new AttributeValue { B = new MemoryStream(entity.Id, false) });
+        raw.Should().NotBeNull();
+        raw["id"].B.ToArray().Should().Equal(entity.Id);
+        raw["name"].S.Should().Be(entity.Name);
+
+        await using (var context = CreateContext<BinaryKeyContext>())
+        {
+            context.ChangeTracker.Clear();
+            var materialized =
+                await context
+                    .Entities
+                    .Where(x => x.Id == entity.Id)
+                    .FirstOrDefaultAsync(CancellationToken);
+
+            materialized.Should().BeEquivalentTo(entity);
+        }
+
+        AssertSql(
+            """
+            INSERT INTO "value-generation-binary-keys"
+            VALUE {'id': ?, 'name': ?}
+            """,
+            """
+            SELECT "id", "name"
+            FROM "value-generation-binary-keys"
             WHERE "id" = ?
             """);
     }
@@ -411,6 +456,13 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         public string Name { get; set; } = null!;
     }
 
+    private sealed record BinaryKeyEntity
+    {
+        public byte[] Id { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
     private sealed class StringKeyContext(DbContextOptions<StringKeyContext> options) : DbContext(
         options)
     {
@@ -423,6 +475,26 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<StringKeyEntity>(entity =>
+            {
+                entity.ToTable(TableName);
+                entity.Property(x => x.Id).HasAttributeName("id");
+                entity.Property(x => x.Name).HasAttributeName("name");
+                entity.HasPartitionKey(x => x.Id);
+            });
+    }
+
+    private sealed class BinaryKeyContext(DbContextOptions<BinaryKeyContext> options) : DbContext(
+        options)
+    {
+        public const string TableName = "value-generation-binary-keys";
+
+        public DbSet<BinaryKeyEntity> Entities => Set<BinaryKeyEntity>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.ConfigureWarnings(w => w.Ignore(DynamoEventId.ScanLikeQueryDetected));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<BinaryKeyEntity>(entity =>
             {
                 entity.ToTable(TableName);
                 entity.Property(x => x.Id).HasAttributeName("id");

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/ValueGenerationSaveChangesTests.cs
@@ -30,7 +30,7 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        await AssertItemExistsInDynamoDbAsync<IntKeyEntity>(
+        await AssertItemExistsInDynamoDbAsync(
             entity,
             IntKeyContext.TableName,
             new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
@@ -70,10 +70,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        var raw = await GetItemAsync(IntKeyContext.TableName, "id", new AttributeValue { N = "0" });
-        raw.Should().NotBeNull();
-        raw!["id"].N.Should().Be("0");
-        raw["name"].S.Should().Be("zero");
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
+            IntKeyContext.TableName,
+            new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
+            CancellationToken);
 
         await using (var context = CreateContext<IntKeyContext>())
         {
@@ -109,13 +110,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             StringKeyContext.TableName,
-            "id",
-            new AttributeValue { S = entity.Id });
-        raw.Should().NotBeNull();
-        raw!["id"].S.Should().Be(entity.Id);
-        raw["name"].S.Should().Be(entity.Name);
+            new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
+            CancellationToken);
 
         await using (var context = CreateContext<StringKeyContext>())
         {
@@ -151,13 +150,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             BinaryKeyContext.TableName,
-            "id",
-            new AttributeValue { B = new MemoryStream(entity.Id, false) });
-        raw.Should().NotBeNull();
-        raw["id"].B.ToArray().Should().Equal(entity.Id);
-        raw["name"].S.Should().Be(entity.Name);
+            new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
+            CancellationToken);
 
         await using (var context = CreateContext<BinaryKeyContext>())
         {
@@ -198,13 +195,11 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         }
 
         entity.Id.Should().Be(777);
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             GeneratedIntKeyContext.TableName,
-            "id",
-            new AttributeValue { N = "777" });
-        raw.Should().NotBeNull();
-        raw!["id"].N.Should().Be("777");
-        raw["name"].S.Should().Be("generated");
+            new Dictionary<string, AttributeValue> { ["id"] = entity.Id.ToAttributeValue() },
+            CancellationToken);
 
         await using (var context = CreateContext<GeneratedIntKeyContext>())
         {
@@ -242,13 +237,14 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         }
 
         entity.Id.Should().NotBe(Guid.Empty);
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             GuidKeyContext.TableName,
-            "id",
-            new AttributeValue { S = entity.Id.ToString() });
-        raw.Should().NotBeNull();
-        raw!["id"].S.Should().Be(entity.Id.ToString());
-        raw["name"].S.Should().Be("generated");
+            new Dictionary<string, AttributeValue>
+            {
+                ["id"] = entity.Id.ToString().ToAttributeValue(),
+            },
+            CancellationToken);
 
         await using (var context = CreateContext<GuidKeyContext>())
         {
@@ -286,13 +282,14 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
         }
 
         entity.Id.Should().Be(id);
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             ExplicitGuidNoGenerationContext.TableName,
-            "id",
-            new AttributeValue { S = id.ToString() });
-        raw.Should().NotBeNull();
-        raw!["id"].S.Should().Be(id.ToString());
-        raw["name"].S.Should().Be("explicit");
+            new Dictionary<string, AttributeValue>
+            {
+                ["id"] = entity.Id.ToString().ToAttributeValue(),
+            },
+            CancellationToken);
 
         await using (var context = CreateContext<ExplicitGuidNoGenerationContext>())
         {
@@ -328,16 +325,14 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             CompositeKeyContext.TableName,
-            "pk",
-            new AttributeValue { S = entity.Pk },
-            "sk",
-            new AttributeValue { S = entity.Sk });
-        raw.Should().NotBeNull();
-        raw!["pk"].S.Should().Be(entity.Pk);
-        raw["sk"].S.Should().Be(entity.Sk);
-        raw["name"].S.Should().Be(entity.Name);
+            new Dictionary<string, AttributeValue>
+            {
+                ["pk"] = entity.Pk.ToAttributeValue(), ["sk"] = entity.Sk.ToAttributeValue(),
+            },
+            CancellationToken);
 
         await using (var context = CreateContext<CompositeKeyContext>())
         {
@@ -381,16 +376,15 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
             await context.SaveChangesAsync(CancellationToken);
         }
 
-        var raw = await GetItemAsync(
+        await AssertItemExistsInDynamoDbAsync(
+            entity,
             CompositeGuidKeyContext.TableName,
-            "id",
-            new AttributeValue { S = entity.Id.ToString() },
-            "sk",
-            new AttributeValue { S = entity.Sk });
-        raw.Should().NotBeNull();
-        raw!["id"].S.Should().Be(entity.Id.ToString());
-        raw["sk"].S.Should().Be(entity.Sk);
-        raw["name"].S.Should().Be(entity.Name);
+            new Dictionary<string, AttributeValue>
+            {
+                ["id"] = entity.Id.ToString().ToAttributeValue(),
+                ["sk"] = entity.Sk.ToAttributeValue(),
+            },
+            CancellationToken);
 
         await using (var context = CreateContext<CompositeGuidKeyContext>())
         {
@@ -424,24 +418,6 @@ public sealed class ValueGenerationSaveChangesTests(DynamoContainerFixture fixtu
     {
         await context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
         await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
-    }
-
-    private async Task<Dictionary<string, AttributeValue>?> GetItemAsync(
-        string tableName,
-        string partitionKeyName,
-        AttributeValue partitionKeyValue,
-        string? sortKeyName = null,
-        AttributeValue? sortKeyValue = null)
-    {
-        var key = new Dictionary<string, AttributeValue> { [partitionKeyName] = partitionKeyValue };
-        if (sortKeyName is not null && sortKeyValue is not null)
-            key[sortKeyName] = sortKeyValue;
-
-        var response = await Client.GetItemAsync(
-            new GetItemRequest { TableName = tableName, Key = key },
-            CancellationToken);
-
-        return response.Item is { Count: > 0 } item ? item : null;
     }
 
     public sealed record IntKeyEntity

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/WriteValueSerializationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/WriteValueSerializationTests.cs
@@ -1,5 +1,4 @@
 using EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
-using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SaveChangesTable;
 
@@ -45,10 +44,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>After SaveChanges the EF Core change tracker should reflect the entity as Unchanged.</summary>
@@ -116,10 +112,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?, 'profile': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>A null OwnsOne navigation must not produce any attribute key in the item at all.</summary>
@@ -145,10 +138,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -189,10 +179,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?, 'profile': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -250,10 +237,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -286,10 +270,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -364,9 +345,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'appliedCoupons': ?, 'cancellationReason': ?, 'chargesByCode': ?, 'customerPk': ?, 'riskFlags': ?, 'status': ?, 'total': ?, 'version': ?, 'lines': ?}
             """);
 
-        var actual = (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToOrderItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -402,10 +381,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -437,9 +413,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'appliedCoupons': ?, 'cancellationReason': ?, 'chargesByCode': ?, 'customerPk': ?, 'riskFlags': ?, 'status': ?, 'total': ?, 'version': ?, 'lines': ?}
             """);
 
-        var actual = (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToOrderItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -472,10 +446,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -503,10 +474,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
         Db.Customers.Add(entity);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -530,10 +498,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
         Db.Customers.Add(entity);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     /// <summary>
@@ -557,10 +522,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
         Db.Customers.Add(entity);
         await Db.SaveChangesAsync(CancellationToken);
 
-        var actual =
-            (await GetItemAsync(entity.Pk, entity.Sk, CancellationToken))?.ToCustomerItem();
-        actual.Should().NotBeNull();
-        actual.Should().BeEquivalentTo(entity);
+        await AssertItemExistsInDynamoDbAsync(entity, entity.Pk, entity.Sk, CancellationToken);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/WriteValueSerializationTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SaveChangesTable/WriteValueSerializationTests.cs
@@ -63,7 +63,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
 
         Db.Customers.Add(entity);
 
-        Db.Entry(entity).State.Should().Be(EntityState.Added);
+        AssertEntryState(entity, EntityState.Added);
 
         await Db.SaveChangesAsync(CancellationToken);
 
@@ -73,7 +73,7 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        Db.Entry(entity).State.Should().Be(EntityState.Unchanged);
+        AssertEntryState(entity, EntityState.Unchanged);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -303,14 +303,15 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?}
             """);
 
-        var raw = await GetItemAsync(entity.Pk, entity.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["referenceIds"]
-            .SS
-            .Should()
-            .BeEquivalentTo(entity.ReferenceIds.Select(static x => x.ToString()));
+        await AssertRawStringSetAsync(
+            entity.Pk,
+            entity.Sk,
+            "referenceIds",
+            entity.ReferenceIds.Select(static x => x.ToString()),
+            CancellationToken);
 
-        var actual = raw.ToCustomerItem();
+        var actual = (await GetExistingItemAsync(entity.Pk, entity.Sk, CancellationToken))
+            .ToCustomerItem();
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(entity, options => options.Excluding(x => x.ReferenceIds));
     }
@@ -618,14 +619,15 @@ public class WriteValueSerializationTests(DynamoContainerFixture fixture)
             VALUE {'pk': ?, 'sk': ?, '$type': ?, 'createdAt': ?, 'email': ?, 'isPreferred': ?, 'notes': ?, 'nullableNote': ?, 'preferences': ?, 'referenceIds': ?, 'tags': ?, 'version': ?, 'contacts': ?, 'profile': ?}
             """);
 
-        var raw = await GetItemAsync(entity.Pk, entity.Sk, CancellationToken);
-        raw.Should().NotBeNull();
-        raw!["referenceIds"]
-            .SS
-            .Should()
-            .BeEquivalentTo(entity.ReferenceIds.Select(static x => x.ToString()));
+        await AssertRawStringSetAsync(
+            entity.Pk,
+            entity.Sk,
+            "referenceIds",
+            entity.ReferenceIds.Select(static x => x.ToString()),
+            CancellationToken);
 
-        var actual = raw.ToCustomerItem();
+        var actual = (await GetExistingItemAsync(entity.Pk, entity.Sk, CancellationToken))
+            .ToCustomerItem();
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(entity, options => options.Excluding(x => x.ReferenceIds));
     }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/AttributeValueExtensions.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/AttributeValueExtensions.cs
@@ -1,0 +1,13 @@
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+public static class AttributeValueExtensions
+{
+    public static AttributeValue ToAttributeValue(this string value) => new() { S = value };
+
+    public static AttributeValue ToAttributeValue(this int value) => new() { N = value.ToString() };
+
+    public static AttributeValue ToAttributeValue(this byte[] value)
+        => new() { B = new MemoryStream(value) };
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
@@ -11,7 +11,8 @@ namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 public sealed class DynamoContainerFixture(IMessageSink messageSink)
     : ContainerFixture<DynamoDbBuilder, DynamoDbContainer>(messageSink)
 {
-    public IReadOnlyDictionary<Type, Type> MapperTypes { get; } = DiscoverMapperTypes();
+    public DynamoMapperRegistry Mappers { get; } =
+        DynamoMapperRegistry.FromAssembly(typeof(DynamoContainerFixture).Assembly);
 
     public IAmazonDynamoDB Client
     {
@@ -25,39 +26,4 @@ public sealed class DynamoContainerFixture(IMessageSink messageSink)
     }
 
     protected override DynamoDbBuilder Configure() => new("amazon/dynamodb-local:latest");
-
-    private static IReadOnlyDictionary<Type, Type> DiscoverMapperTypes()
-    {
-        var mapperInterfaceType = typeof(IDynamoMapper<>);
-        var discovered =
-            typeof(DynamoContainerFixture)
-                .Assembly
-                .GetTypes()
-                .Where(type => type is { IsClass: true, IsAbstract: false })
-                .SelectMany(type
-                    => type
-                        .GetInterfaces()
-                        .Where(@interface => @interface.IsGenericType
-                            && @interface.GetGenericTypeDefinition() == mapperInterfaceType)
-                        .Select(@interface => new
-                        {
-                            ModelType = @interface.GetGenericArguments()[0], MapperType = type,
-                        }))
-                .ToArray();
-
-        var duplicates = discovered
-            .GroupBy(mapper => mapper.ModelType)
-            .Where(group => group.Count() > 1)
-            .Select(group => group.Key.FullName ?? group.Key.Name)
-            .ToArray();
-
-        if (duplicates.Length > 0)
-            throw new InvalidOperationException(
-                $"Multiple DynamoMapper classes found for model type(s): {string.Join(", ", duplicates)}.");
-
-        var discoveredDict =
-            discovered.ToDictionary(mapper => mapper.ModelType, mapper => mapper.MapperType);
-
-        return discoveredDict;
-    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoContainerFixture.cs
@@ -11,6 +11,8 @@ namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
 public sealed class DynamoContainerFixture(IMessageSink messageSink)
     : ContainerFixture<DynamoDbBuilder, DynamoDbContainer>(messageSink)
 {
+    public IReadOnlyDictionary<Type, Type> MapperTypes { get; } = DiscoverMapperTypes();
+
     public IAmazonDynamoDB Client
     {
         get
@@ -23,4 +25,39 @@ public sealed class DynamoContainerFixture(IMessageSink messageSink)
     }
 
     protected override DynamoDbBuilder Configure() => new("amazon/dynamodb-local:latest");
+
+    private static IReadOnlyDictionary<Type, Type> DiscoverMapperTypes()
+    {
+        var mapperInterfaceType = typeof(IDynamoMapper<>);
+        var discovered =
+            typeof(DynamoContainerFixture)
+                .Assembly
+                .GetTypes()
+                .Where(type => type is { IsClass: true, IsAbstract: false })
+                .SelectMany(type
+                    => type
+                        .GetInterfaces()
+                        .Where(@interface => @interface.IsGenericType
+                            && @interface.GetGenericTypeDefinition() == mapperInterfaceType)
+                        .Select(@interface => new
+                        {
+                            ModelType = @interface.GetGenericArguments()[0], MapperType = type,
+                        }))
+                .ToArray();
+
+        var duplicates = discovered
+            .GroupBy(mapper => mapper.ModelType)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key.FullName ?? group.Key.Name)
+            .ToArray();
+
+        if (duplicates.Length > 0)
+            throw new InvalidOperationException(
+                $"Multiple DynamoMapper classes found for model type(s): {string.Join(", ", duplicates)}.");
+
+        var discoveredDict =
+            discovered.ToDictionary(mapper => mapper.ModelType, mapper => mapper.MapperType);
+
+        return discoveredDict;
+    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoMapperRegistry.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoMapperRegistry.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+public sealed class DynamoMapperRegistry
+{
+    private DynamoMapperRegistry(IReadOnlyDictionary<Type, DynamoMapperRegistration> mappers)
+        => Mappers = mappers;
+
+    public IReadOnlyDictionary<Type, DynamoMapperRegistration> Mappers { get; }
+
+    public static DynamoMapperRegistry FromAssembly(Assembly assembly)
+    {
+        var mapperInterfaceType = typeof(IDynamoMapper<>);
+        var discovered = assembly
+            .GetTypes()
+            .Where(type => type is { IsClass: true, IsAbstract: false })
+            .SelectMany(type
+                => type
+                    .GetInterfaces()
+                    .Where(@interface => @interface.IsGenericType
+                        && @interface.GetGenericTypeDefinition() == mapperInterfaceType)
+                    .Select(@interface => new
+                    {
+                        ModelType = @interface.GetGenericArguments()[0], MapperType = type,
+                    }))
+            .ToArray();
+
+        var duplicates = discovered
+            .GroupBy(mapper => mapper.ModelType)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key.FullName ?? group.Key.Name)
+            .ToArray();
+
+        if (duplicates.Length > 0)
+            throw new InvalidOperationException(
+                $"Multiple DynamoMapper classes found for model type(s): {string.Join(", ", duplicates)}.");
+
+        return new DynamoMapperRegistry(
+            discovered.ToDictionary(
+                mapper => mapper.ModelType,
+                mapper => new DynamoMapperRegistration(mapper.ModelType, mapper.MapperType)));
+    }
+
+    public DynamoMapperRegistration Get(Type modelType)
+    {
+        if (!Mappers.TryGetValue(modelType, out var mapper))
+            throw new InvalidOperationException($"No mapper for type '{modelType}' found.");
+
+        return mapper;
+    }
+
+    public DynamoMapperRegistration Get<T>() => Get(typeof(T));
+
+    public bool TryGet(Type modelType, out DynamoMapperRegistration mapper)
+        => Mappers.TryGetValue(modelType, out mapper!);
+
+    public bool TryGet<T>(out DynamoMapperRegistration mapper) => TryGet(typeof(T), out mapper);
+}
+
+public sealed class DynamoMapperRegistration
+{
+    private readonly MethodInfo _toItemMethod;
+    private readonly MethodInfo _fromItemMethod;
+
+    public DynamoMapperRegistration(Type modelType, Type mapperType)
+    {
+        ModelType = modelType;
+        MapperType = mapperType;
+        _toItemMethod = GetStaticMapperMethod(mapperType, nameof(IDynamoMapper<object>.ToItem));
+        _fromItemMethod = GetStaticMapperMethod(mapperType, nameof(IDynamoMapper<object>.FromItem));
+    }
+
+    public Type ModelType { get; }
+
+    public Type MapperType { get; }
+
+    public Dictionary<string, AttributeValue> ToItem(object source)
+        => (Dictionary<string, AttributeValue>)_toItemMethod.Invoke(null, [source])!;
+
+    public object FromItem(Dictionary<string, AttributeValue> item)
+        => _fromItemMethod.Invoke(null, [item])!;
+
+    public T FromItem<T>(Dictionary<string, AttributeValue> item) => (T)FromItem(item);
+
+    private static MethodInfo GetStaticMapperMethod(Type mapperType, string methodName)
+        => mapperType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"Mapper {mapperType.FullName} does not define public static {methodName} method.");
+}

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
@@ -195,4 +195,15 @@ public abstract class DynamoTestFixtureBase
 
         return mapper.FromItem<T>(response.Item);
     }
+
+    public async Task AssertItemExistsInDynamoDbAsync<T>(
+        T item,
+        string tableName,
+        Dictionary<string, AttributeValue> key,
+        CancellationToken cancellationToken = default)
+        => (await GetItemAsync<T>(tableName, key, cancellationToken))
+            .Should()
+            .BeEquivalentTo(
+                item,
+                $"Item with key {key} does not match expected item in table {tableName}");
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/DynamoTestFixtureBase.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using EntityFrameworkCore.DynamoDb.Extensions;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -182,4 +181,18 @@ public abstract class DynamoTestFixtureBase
     ///     <paramref name="expected" />, then clears the capture buffer.
     /// </summary>
     protected void AssertSql(params string[] expected) => SqlCapture.AssertBaseline(expected);
+
+    protected async Task<T> GetItemAsync<T>(
+        string tableName,
+        Dictionary<string, AttributeValue> key,
+        CancellationToken cancellationToken)
+    {
+        var mapper = _container.Mappers.Get<T>();
+
+        var response = await Client.GetItemAsync(
+            new GetItemRequest { TableName = tableName, Key = key },
+            cancellationToken);
+
+        return mapper.FromItem<T>(response.Item);
+    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/IDynamoMapper.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/SharedInfra/IDynamoMapper.cs
@@ -1,0 +1,9 @@
+using Amazon.DynamoDBv2.Model;
+
+namespace EntityFrameworkCore.DynamoDb.IntegrationTests.SharedInfra;
+
+public interface IDynamoMapper<T>
+{
+    static abstract Dictionary<string, AttributeValue> ToItem(T source);
+    static abstract T FromItem(Dictionary<string, AttributeValue> item);
+}


### PR DESCRIPTION
## Summary

Cleans up DynamoDB integration test infrastructure and improves test helper information so save behavior assertions are easier to read and maintain. Adds mapper-focused helpers around DynamoDB attribute values and applies them across save/change tracking scenarios.

## Changes

- Added shared mapper interfaces, registry, and DynamoDB attribute value conversion helpers for integration tests.
- Refactored save tests to use common item assertion helpers instead of inline `GetItemAsync` checks.
- Improved value generation coverage, including binary partition key persistence.
- Simplified test entities and mapper setup to make expected DynamoDB items clearer.

## Validation

- Not run in this session; branch already contained committed changes.

## Notes for Reviewers

Focus review on test readability, helper boundaries, and whether DynamoDB item assertions now show enough context for failures.
