### PR TITLE
fix(query): parameterize binary constants

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoQuerySqlGenerator.cs
@@ -167,6 +167,16 @@ public sealed class DynamoQuerySqlGenerator : SqlExpressionVisitor
     /// <inheritdoc />
     protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
     {
+        if (sqlConstantExpression.Value is byte[])
+        {
+            AppendParameter(
+                sqlConstantExpression.Value,
+                sqlConstantExpression.Value.GetType(),
+                sqlConstantExpression.TypeMapping);
+
+            return sqlConstantExpression;
+        }
+
         // Use the runtime value type when available so promoted constants (short property vs int
         // literal) serialize as DynamoDB N without trying to unbox int as short.
         if (sqlConstantExpression.TypeMapping is DynamoTypeMapping dynamoTypeMapping)

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Query/ToQueryStringTests.cs
@@ -48,6 +48,28 @@ public class ToQueryStringTests
         client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!, default);
     }
 
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void ToQueryString_InlineBinaryConstant_ParameterizesValue()
+    {
+        var client = Substitute.For<IAmazonDynamoDB>();
+        using var context = ToQueryStringDbContext.Create(client);
+
+        var queryString =
+            context.BinaryItems.Where(e => e.Id == new byte[] { 1, 2, 3 }).ToQueryString();
+
+        queryString
+            .Should()
+            .Be(
+                "-- p0=<binary:3 bytes>"
+                + Environment.NewLine
+                + "SELECT \"id\", \"name\""
+                + Environment.NewLine
+                + "FROM \"ToQueryStringBinaryItems\""
+                + Environment.NewLine
+                + "WHERE \"id\" = ?");
+        client.DidNotReceiveWithAnyArgs().ExecuteStatementAsync(default!, default);
+    }
+
     [Theory(Timeout = TestConfiguration.DefaultTimeout)]
     [MemberData(nameof(AttributeValues))]
     public void ToQueryString_AttributeValueFormatting_HandlesSdkV4NullCollections(
@@ -90,16 +112,33 @@ public class ToQueryStringTests
         public string Name { get; set; } = null!;
     }
 
+    private sealed class ToQueryStringBinaryEntity
+    {
+        public byte[] Id { get; set; } = null!;
+
+        public string Name { get; set; } = null!;
+    }
+
     private sealed class ToQueryStringDbContext(DbContextOptions options) : DbContext(options)
     {
         public DbSet<ToQueryStringEntity> Items => Set<ToQueryStringEntity>();
 
+        public DbSet<ToQueryStringBinaryEntity> BinaryItems => Set<ToQueryStringBinaryEntity>();
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<ToQueryStringEntity>(builder =>
+        {
+            modelBuilder.Entity<ToQueryStringEntity>(builder =>
             {
                 builder.ToTable("ToQueryStringItems");
                 builder.HasPartitionKey(e => e.Pk);
             });
+
+            modelBuilder.Entity<ToQueryStringBinaryEntity>(builder =>
+            {
+                builder.ToTable("ToQueryStringBinaryItems");
+                builder.HasPartitionKey(e => e.Id);
+            });
+        }
 
         public static ToQueryStringDbContext Create(IAmazonDynamoDB client)
             => new(


### PR DESCRIPTION
## Summary

Inline PartiQL literal generation does not support binary values, so queries comparing a binary property to an inline `byte[]` constant could fail during SQL generation. This change emits a PartiQL parameter for binary constants instead, preserving binary query support without requiring callers to hoist values into variables.

## Changes

- Parameterize `byte[]` SQL constants in `DynamoQuerySqlGenerator` instead of attempting inline literal generation.
- Add a focused `ToQueryString` unit test that verifies inline binary constants produce `?` plus a binary parameter comment.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.Tests/EntityFrameworkCore.DynamoDb.Tests.csproj -- --filter-class EntityFrameworkCore.DynamoDb.Tests.Query.ToQueryStringTests`
