### PR TITLE
test(specification): add DynamoDB built-in data type coverage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.6.0-preview.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.6"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.8"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Testing Libraries -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
@@ -28,8 +28,8 @@
     <PackageVersion Include="YTest.MTP.XUnit2" Version="1.0.3"/>
   </ItemGroup>
   <ItemGroup Label="Microsoft EF Core (net10.0)">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8"/>
   </ItemGroup>
 </Project>

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/EntityFrameworkCore.DynamoDb.IntegrationTests.csproj
@@ -43,8 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 </Project>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -2,7 +2,6 @@ using EntityFrameworkCore.DynamoDb.Diagnostics;
 using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
@@ -55,7 +54,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_data_type_shadow();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_nullable_data_type()
         => base.Can_query_using_any_nullable_data_type();
 
@@ -209,6 +207,13 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
+            modelBuilder.Ignore<BuiltInNullableDataTypesShadow>();
+
+            // TODO: remove and add better discriminator support
+            modelBuilder.Entity<BuiltInDataTypesShadow>(b =>
+            {
+                b.Ignore("$type");
+            });
         }
 
         /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -51,7 +51,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type_shadow()
         => base.Can_query_using_any_data_type_shadow();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -58,7 +58,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_nullable_data_type();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type_nullable_shadow()
         => base.Can_query_using_any_data_type_nullable_shadow();
 
@@ -207,7 +206,6 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
-            modelBuilder.Ignore<BuiltInNullableDataTypesShadow>();
 
             // TODO: remove and add better discriminator support
             modelBuilder.Entity<BuiltInDataTypesShadow>(b =>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -14,8 +14,6 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-
-
     /// <summary>Ensures all inherited specification tests are reviewed by this provider.</summary>
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
@@ -195,9 +193,16 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_non_nullable_backed_data_types();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
-    public override Task Can_read_back_mapped_enum_from_collection_first_or_default()
-        => base.Can_read_back_mapped_enum_from_collection_first_or_default();
+    public override async Task Can_read_back_mapped_enum_from_collection_first_or_default()
+    {
+        await using var context = CreateContext();
+        var query =
+            from animal in context.Set<DynamoAnimal>()
+            select new { animal.Id, animal.IdentificationMethods.FirstOrDefault()!.Method };
+
+        var result = await query.AsAsyncEnumerable().FirstOrDefaultAsync();
+        Assert.Equal(IdentificationMethod.EarTag, result?.Method);
+    }
 
     /// <inheritdoc />
     [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
@@ -254,7 +259,37 @@ public class BuiltInDataTypesDynamoTest(
                     DynamoEventId.NoCompatibleSecondaryIndexFound,
                     DynamoEventId.ScanLikeQueryDetected))
                 .UseDynamo(options
-                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client))
+                .UseAsyncSeeding(async (context, _, cancellationToken) =>
+                {
+                    if (await context
+                        .FindAsync<DynamoAnimal>([1], cancellationToken)
+                        .ConfigureAwait(false) is not null)
+                        return;
+
+                    context
+                        .Set<DynamoAnimal>()
+                        .Add(
+                            new DynamoAnimal
+                            {
+                                Id = 1,
+                                IdentificationMethods =
+                                [
+                                    new AnimalIdentification
+                                    {
+                                        Id = 1,
+                                        AnimalId = 1,
+                                        Method = IdentificationMethod.EarTag,
+                                    },
+                                ],
+                                Details = new AnimalDetails
+                                {
+                                    Id = 1, AnimalId = 1, BoolField = true,
+                                },
+                            });
+
+                    await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                });
 
         /// <inheritdoc />
         protected override async Task CleanAsync(DbContext context)
@@ -270,6 +305,12 @@ public class BuiltInDataTypesDynamoTest(
 
             modelBuilder.Entity<DynamoBinaryKeyDataType>();
             modelBuilder.Entity<StringKeyDataType>(b => b.Ignore(e => e.Dependents));
+
+            modelBuilder.Entity<DynamoAnimal>(b =>
+            {
+                b.ComplexCollection(e => e.IdentificationMethods);
+                b.ComplexProperty(e => e.Details);
+            });
 
             modelBuilder.Ignore<Animal>();
             modelBuilder.Ignore<AnimalDetails>();
@@ -317,5 +358,12 @@ public class BuiltInDataTypesDynamoTest(
         public required byte[] Id { get; set; }
 
         public required string Ex { get; set; }
+    }
+
+    protected class DynamoAnimal
+    {
+        public int Id { get; set; }
+        public List<AnimalIdentification> IdentificationMethods { get; set; } = [];
+        public required AnimalDetails Details { get; set; }
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -62,7 +62,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_query_using_any_data_type_nullable_shadow();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_nullable_data_type_as_literal()
         => base.Can_query_using_any_nullable_data_type_as_literal();
 
@@ -87,9 +86,56 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_with_max_length_set();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
-    public override Task Can_insert_and_read_back_with_binary_key()
-        => base.Can_insert_and_read_back_with_binary_key();
+    public override async Task Can_insert_and_read_back_with_binary_key()
+    {
+        await using (var context = CreateContext())
+        {
+            context
+                .Set<DynamoBinaryKeyDataType>()
+                .AddRange(
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3], Ex = "X1" },
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4], Ex = "X3" },
+                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4, 5], Ex = "X2" });
+
+            Assert.Equal(3, await context.SaveChangesAsync());
+        }
+
+        async Task<BinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
+            => (await context.Set<BinaryKeyDataType>().Where(e => e.Id == bytes).ToListAsync())
+                .Single();
+
+        await using (var context = CreateContext())
+        {
+            var items = await context.Set<DynamoBinaryKeyDataType>().ToListAsync();
+
+            var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
+            Assert.Equal(new byte[] { 1, 2, 3 }, entity1.Id);
+
+            var entity2 = await QueryByBinaryKey(context, [1, 2, 3, 4]);
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, entity2.Id);
+
+            var entity3 = await QueryByBinaryKey(context, [1, 2, 3, 4, 5]);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, entity3.Id);
+
+            entity3.Ex = "Xx1";
+            entity2.Ex = "Xx3";
+            entity1.Ex = "Xx7";
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = CreateContext())
+        {
+            var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
+            Assert.Equal("Xx7", entity1.Ex);
+
+            var entity2 = await QueryByBinaryKey(context, [1, 2, 3, 4]);
+            Assert.Equal("Xx3", entity2.Ex);
+
+            var entity3 = await QueryByBinaryKey(context, [1, 2, 3, 4, 5]);
+            Assert.Equal("Xx1", entity3.Ex);
+        }
+    }
 
     /// <inheritdoc />
     [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
@@ -97,7 +143,6 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_null_binary_foreign_key();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
     public override Task Can_insert_and_read_back_with_string_key()
         => base.Can_insert_and_read_back_with_string_key();
 
@@ -201,6 +246,8 @@ public class BuiltInDataTypesDynamoTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
+            modelBuilder.Entity<DynamoBinaryKeyDataType>();
+
             modelBuilder.Ignore<Animal>();
             modelBuilder.Ignore<AnimalDetails>();
             modelBuilder.Ignore<AnimalIdentification>();
@@ -242,8 +289,10 @@ public class BuiltInDataTypesDynamoTest(
         public override bool PreservesDateTimeKind => false;
     }
 
-    protected class DynamoAnimal : Animal
+    protected class DynamoBinaryKeyDataType
     {
-        public new List<AnimalIdentification> IdentificationMethods { get; set; } = [];
+        public required byte[] Id { get; set; }
+
+        public required string Ex { get; set; }
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -204,6 +204,12 @@ public class BuiltInDataTypesDynamoTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
+            modelBuilder.Ignore<Animal>();
+            modelBuilder.Ignore<AnimalDetails>();
+            modelBuilder.Ignore<AnimalIdentification>();
+            modelBuilder.Ignore<StringForeignKeyDataType>();
+            modelBuilder.Ignore<BinaryForeignKeyDataType>();
+
             ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
             ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
             ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
@@ -214,46 +220,22 @@ public class BuiltInDataTypesDynamoTest(
             ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
             ConfigureIdKey<EmailTemplate>(modelBuilder);
             ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<Animal>(modelBuilder);
-            ConfigureIdKey<AnimalDetails>(modelBuilder);
-            ConfigureIdKey<AnimalIdentification>(modelBuilder);
+            // ConfigureIdKey<Animal>(modelBuilder);
+            // ConfigureIdKey<AnimalDetails>(modelBuilder);
+            // ConfigureIdKey<AnimalIdentification>(modelBuilder);
             ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
             ConfigureIdKey<StringEnclosure>(modelBuilder);
             ConfigureIdKey<StringKeyDataType>(modelBuilder);
-            ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
+            // ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
             ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
-            ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
-
-            modelBuilder
-                .Entity<Animal>()
-                .HasMany(e => e.IdentificationMethods)
-                .WithOne()
-                .HasForeignKey(e => e.AnimalId);
-
-            modelBuilder
-                .Entity<Animal>()
-                .HasOne(e => e.Details)
-                .WithOne()
-                .HasForeignKey<AnimalDetails>(e => e.AnimalId);
-
-            modelBuilder
-                .Entity<StringKeyDataType>()
-                .HasMany(e => e.Dependents)
-                .WithOne(e => e.Principal)
-                .HasForeignKey(e => e.StringKeyDataTypeId);
-
-            modelBuilder
-                .Entity<BinaryKeyDataType>()
-                .HasMany(e => e.Dependents)
-                .WithOne(e => e.Principal)
-                .HasForeignKey(e => e.BinaryKeyDataTypeId);
+            // ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
         }
 
         private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
             where TEntity : class
         {
             var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
-            entityTypeBuilder.Property("Id").ValueGeneratedNever();
+
             return entityTypeBuilder;
         }
 
@@ -283,5 +265,10 @@ public class BuiltInDataTypesDynamoTest(
 
         /// <inheritdoc />
         public override bool PreservesDateTimeKind => false;
+    }
+
+    protected class DynamoAnimal : Animal
+    {
+        public new List<AnimalIdentification> IdentificationMethods { get; set; } = [];
     }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -211,34 +211,6 @@ public class BuiltInDataTypesDynamoTest(
             modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
-
-            ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
-            ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
-            ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
-            ConfigureIdKey<BuiltInNullableDataTypesShadow>(modelBuilder);
-            ConfigureIdKey<NonNullableBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<NullableBackedDataTypes>(modelBuilder);
-            ConfigureIdKey<MaxLengthDataTypes>(modelBuilder);
-            ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
-            ConfigureIdKey<EmailTemplate>(modelBuilder);
-            ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
-            // ConfigureIdKey<Animal>(modelBuilder);
-            // ConfigureIdKey<AnimalDetails>(modelBuilder);
-            // ConfigureIdKey<AnimalIdentification>(modelBuilder);
-            ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
-            ConfigureIdKey<StringEnclosure>(modelBuilder);
-            ConfigureIdKey<StringKeyDataType>(modelBuilder);
-            // ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
-            ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
-            // ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
-        }
-
-        private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
-            where TEntity : class
-        {
-            var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
-
-            return entityTypeBuilder;
         }
 
         /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -88,18 +88,18 @@ public class BuiltInDataTypesDynamoTest(
         await using (var context = CreateContext())
         {
             context
-                .Set<DynamoBinaryKeyDataType>()
+                .Set<BinaryKeyDataType>()
                 .AddRange(
-                    new DynamoBinaryKeyDataType { Id = [1, 2, 3], Ex = "X1" },
-                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4], Ex = "X3" },
-                    new DynamoBinaryKeyDataType { Id = [1, 2, 3, 4, 5], Ex = "X2" });
+                    new BinaryKeyDataType { Id = [1, 2, 3], Ex = "X1" },
+                    new BinaryKeyDataType { Id = [1, 2, 3, 4], Ex = "X3" },
+                    new BinaryKeyDataType { Id = [1, 2, 3, 4, 5], Ex = "X2" });
 
             Assert.Equal(3, await context.SaveChangesAsync());
         }
 
-        async Task<DynamoBinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
+        async Task<BinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
             => (await context
-                .Set<DynamoBinaryKeyDataType>()
+                .Set<BinaryKeyDataType>()
                 .Where(e => e.Id == bytes)
                 .ToListAsync()).Single();
 
@@ -107,7 +107,7 @@ public class BuiltInDataTypesDynamoTest(
         {
             var items =
                 await context
-                    .Set<DynamoBinaryKeyDataType>()
+                    .Set<BinaryKeyDataType>()
                     .Where(x => x.Id == new byte[] { 1, 2, 3 })
                     .ToListAsync();
 
@@ -303,7 +303,7 @@ public class BuiltInDataTypesDynamoTest(
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.Entity<DynamoBinaryKeyDataType>();
+            modelBuilder.Entity<StringKeyDataType>(b => b.Ignore(e => e.Dependents));
             modelBuilder.Entity<StringKeyDataType>(b => b.Ignore(e => e.Dependents));
 
             modelBuilder.Entity<DynamoAnimal>(b =>
@@ -353,12 +353,7 @@ public class BuiltInDataTypesDynamoTest(
         public override bool PreservesDateTimeKind => false;
     }
 
-    protected class DynamoBinaryKeyDataType
-    {
-        public required byte[] Id { get; set; }
 
-        public required string Ex { get; set; }
-    }
 
     protected class DynamoAnimal
     {

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -303,7 +303,7 @@ public class BuiltInDataTypesDynamoTest(
 
             modelBuilder.Ignore<Animal>();
             modelBuilder.Ignore<AnimalDetails>();
-            modelBuilder.Ignore<AnimalIdentification>();
+            // modelBuilder.Ignore<AnimalIdentification>();
             modelBuilder.Ignore<StringForeignKeyDataType>();
             modelBuilder.Ignore<BinaryForeignKeyDataType>();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -105,12 +105,6 @@ public class BuiltInDataTypesDynamoTest(
 
         await using (var context = CreateContext())
         {
-            var items =
-                await context
-                    .Set<BinaryKeyDataType>()
-                    .Where(x => x.Id == new byte[] { 1, 2, 3 })
-                    .ToListAsync();
-
             var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
             Assert.Equal(new byte[] { 1, 2, 3 }, entity1.Id);
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -1,0 +1,295 @@
+using EntityFrameworkCore.DynamoDb.Diagnostics;
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+/// <summary>Built-in data type specification tests for the DynamoDB provider.</summary>
+public class BuiltInDataTypesDynamoTest(
+    BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture fixture)
+    : BuiltInDataTypesTestBase<BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture>(fixture)
+{
+    private const string NonEmbeddedNavigationsNotSupported =
+        "DynamoDB does not support non-embedded navigation queries in this test shape.";
+
+    private const string ObjectToStringProjectionNotSupported =
+        "DynamoDB does not translate object ToString projection for built-in data type coverage yet.";
+
+    private const string DateTimeOffsetMemberProjectionNotSupported =
+        "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
+
+    private const string ProviderTypeMappingGaps =
+        "DynamoDB provider does not fully support this built-in type mapping query shape yet.";
+
+    /// <summary>Ensures all inherited specification tests are reviewed by this provider.</summary>
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(BuiltInDataTypesDynamoTest));
+
+    /// <inheritdoc />
+    public override async Task Can_filter_projection_with_captured_enum_variable(bool async)
+    {
+        if (!async)
+        {
+            await AssertNoSync(() => base.Can_filter_projection_with_captured_enum_variable(async));
+            return;
+        }
+
+        await base.Can_filter_projection_with_captured_enum_variable(async);
+    }
+
+    /// <inheritdoc />
+    public override async Task Can_filter_projection_with_inline_enum_variable(bool async)
+    {
+        if (!async)
+        {
+            await AssertNoSync(() => base.Can_filter_projection_with_inline_enum_variable(async));
+            return;
+        }
+
+        await base.Can_filter_projection_with_inline_enum_variable(async);
+    }
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type_shadow()
+        => base.Can_query_using_any_data_type_shadow();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_nullable_data_type()
+        => base.Can_query_using_any_nullable_data_type();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_data_type_nullable_shadow()
+        => base.Can_query_using_any_data_type_nullable_shadow();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
+    public override Task Can_query_using_any_nullable_data_type_as_literal()
+        => base.Can_query_using_any_nullable_data_type_as_literal();
+
+    /// <inheritdoc />
+    public override Task Can_query_with_null_parameters_using_any_nullable_data_type()
+        => base.Can_query_with_null_parameters_using_any_nullable_data_type();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_all_non_nullable_data_types()
+        => base.Can_insert_and_read_back_all_non_nullable_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_perform_query_with_max_length()
+        => base.Can_perform_query_with_max_length();
+
+    /// <inheritdoc />
+    public override Task Can_perform_query_with_ansi_strings_test()
+        => base.Can_perform_query_with_ansi_strings_test();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_with_max_length_set()
+        => base.Can_insert_and_read_with_max_length_set();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_insert_and_read_back_with_binary_key()
+        => base.Can_insert_and_read_back_with_binary_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_with_null_binary_foreign_key()
+        => base.Can_insert_and_read_back_with_null_binary_foreign_key();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_insert_and_read_back_with_string_key()
+        => base.Can_insert_and_read_back_with_string_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_with_null_string_foreign_key()
+        => base.Can_insert_and_read_back_with_null_string_foreign_key();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null()
+        => base.Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null();
+
+    /// <inheritdoc />
+    public override Task
+        Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null()
+        => base.Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_object_backed_data_types()
+        => base.Can_insert_and_read_back_object_backed_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_nullable_backed_data_types()
+        => base.Can_insert_and_read_back_nullable_backed_data_types();
+
+    /// <inheritdoc />
+    public override Task Can_insert_and_read_back_non_nullable_backed_data_types()
+        => base.Can_insert_and_read_back_non_nullable_backed_data_types();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_read_back_mapped_enum_from_collection_first_or_default()
+        => base.Can_read_back_mapped_enum_from_collection_first_or_default();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    public override Task Can_read_back_bool_mapped_as_int_through_navigation()
+        => base.Can_read_back_bool_mapped_as_int_through_navigation();
+
+    /// <inheritdoc />
+    public override Task Can_compare_enum_to_constant() => base.Can_compare_enum_to_constant();
+
+    /// <inheritdoc />
+    public override Task Can_compare_enum_to_parameter() => base.Can_compare_enum_to_parameter();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = ObjectToStringProjectionNotSupported)]
+    public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
+
+    /// <inheritdoc />
+    [ConditionalFact(Skip = DateTimeOffsetMemberProjectionNotSupported)]
+    public override Task Optional_datetime_reading_null_from_database()
+        => base.Optional_datetime_reading_null_from_database();
+
+    /// <inheritdoc />
+    public override Task Can_insert_query_multiline_string()
+        => base.Can_insert_query_multiline_string();
+
+    private static async Task AssertNoSync(Func<Task> testCode)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(testCode);
+
+        Assert.Contains("Sync enumerating", exception.Message);
+        Assert.Contains("DynamoDB", exception.Message);
+    }
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    /// <summary>Fixture for built-in data type specification tests.</summary>
+    public class BuiltInDataTypesDynamoFixture
+        : BuiltInDataTypesFixtureBase, IDynamoSpecificationFixture
+    {
+        /// <inheritdoc />
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        /// <inheritdoc />
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        /// <inheritdoc />
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        /// <inheritdoc />
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base
+                .AddOptions(builder)
+                .ConfigureWarnings(warnings => warnings.Ignore(
+                    CoreEventId.ManyServiceProvidersCreatedWarning,
+                    DynamoEventId.NoCompatibleSecondaryIndexFound,
+                    DynamoEventId.ScanLikeQueryDetected))
+                .UseDynamo(options
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        /// <inheritdoc />
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync().ConfigureAwait(false);
+            await context.Database.EnsureCreatedAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            ConfigureIdKey<BuiltInDataTypes>(modelBuilder);
+            ConfigureIdKey<BuiltInDataTypesShadow>(modelBuilder);
+            ConfigureIdKey<BuiltInNullableDataTypes>(modelBuilder);
+            ConfigureIdKey<BuiltInNullableDataTypesShadow>(modelBuilder);
+            ConfigureIdKey<NonNullableBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<NullableBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<MaxLengthDataTypes>(modelBuilder);
+            ConfigureIdKey<UnicodeDataTypes>(modelBuilder);
+            ConfigureIdKey<EmailTemplate>(modelBuilder);
+            ConfigureIdKey<ObjectBackedDataTypes>(modelBuilder);
+            ConfigureIdKey<Animal>(modelBuilder);
+            ConfigureIdKey<AnimalDetails>(modelBuilder);
+            ConfigureIdKey<AnimalIdentification>(modelBuilder);
+            ConfigureIdKey<DateTimeEnclosure>(modelBuilder);
+            ConfigureIdKey<StringEnclosure>(modelBuilder);
+            ConfigureIdKey<StringKeyDataType>(modelBuilder);
+            ConfigureIdKey<StringForeignKeyDataType>(modelBuilder);
+            ConfigureIdKey<BinaryKeyDataType>(modelBuilder);
+            ConfigureIdKey<BinaryForeignKeyDataType>(modelBuilder);
+
+            modelBuilder
+                .Entity<Animal>()
+                .HasMany(e => e.IdentificationMethods)
+                .WithOne()
+                .HasForeignKey(e => e.AnimalId);
+
+            modelBuilder
+                .Entity<Animal>()
+                .HasOne(e => e.Details)
+                .WithOne()
+                .HasForeignKey<AnimalDetails>(e => e.AnimalId);
+
+            modelBuilder
+                .Entity<StringKeyDataType>()
+                .HasMany(e => e.Dependents)
+                .WithOne(e => e.Principal)
+                .HasForeignKey(e => e.StringKeyDataTypeId);
+
+            modelBuilder
+                .Entity<BinaryKeyDataType>()
+                .HasMany(e => e.Dependents)
+                .WithOne(e => e.Principal)
+                .HasForeignKey(e => e.BinaryKeyDataTypeId);
+        }
+
+        private static EntityTypeBuilder<TEntity> ConfigureIdKey<TEntity>(ModelBuilder modelBuilder)
+            where TEntity : class
+        {
+            var entityTypeBuilder = modelBuilder.Entity<TEntity>().HasPartitionKey("Id");
+            entityTypeBuilder.Property("Id").ValueGeneratedNever();
+            return entityTypeBuilder;
+        }
+
+        /// <inheritdoc />
+        public override bool StrictEquality => true;
+
+        /// <inheritdoc />
+        public override int IntegerPrecision => 64;
+
+        /// <inheritdoc />
+        public override bool SupportsAnsi => false;
+
+        /// <inheritdoc />
+        public override bool SupportsUnicodeToAnsiConversion => false;
+
+        /// <inheritdoc />
+        public override bool SupportsLargeStringComparisons => true;
+
+        /// <inheritdoc />
+        public override bool SupportsBinaryKeys => true;
+
+        /// <inheritdoc />
+        public override bool SupportsDecimalComparisons => true;
+
+        /// <inheritdoc />
+        public override DateTime DefaultDateTime => new();
+
+        /// <inheritdoc />
+        public override bool PreservesDateTimeKind => false;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -14,8 +14,7 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-    private const string ProviderTypeMappingGaps =
-        "DynamoDB provider does not fully support this built-in type mapping query shape yet.";
+
 
     /// <summary>Ensures all inherited specification tests are reviewed by this provider.</summary>
     [ConditionalFact]
@@ -149,8 +148,25 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_null_binary_foreign_key();
 
     /// <inheritdoc />
-    public override Task Can_insert_and_read_back_with_string_key()
-        => base.Can_insert_and_read_back_with_string_key();
+    public override async Task Can_insert_and_read_back_with_string_key()
+    {
+        await using (var context = CreateContext())
+        {
+            context.Set<StringKeyDataType>().Add(new StringKeyDataType { Id = "Gumball!" });
+
+            Assert.Equal(1, await context.SaveChangesAsync());
+        }
+
+        await using (var context = CreateContext())
+        {
+            var entity = (await context
+                .Set<StringKeyDataType>()
+                .Where(e => e.Id == "Gumball!")
+                .ToListAsync()).Single();
+
+            Assert.Equal("Gumball!", entity.Id);
+        }
+    }
 
     /// <inheritdoc />
     [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
@@ -253,6 +269,7 @@ public class BuiltInDataTypesDynamoTest(
             base.OnModelCreating(modelBuilder, context);
 
             modelBuilder.Entity<DynamoBinaryKeyDataType>();
+            modelBuilder.Entity<StringKeyDataType>(b => b.Ignore(e => e.Dependents));
 
             modelBuilder.Ignore<Animal>();
             modelBuilder.Ignore<AnimalDetails>();

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -100,13 +100,19 @@ public class BuiltInDataTypesDynamoTest(
             Assert.Equal(3, await context.SaveChangesAsync());
         }
 
-        async Task<BinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
-            => (await context.Set<BinaryKeyDataType>().Where(e => e.Id == bytes).ToListAsync())
-                .Single();
+        async Task<DynamoBinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
+            => (await context
+                .Set<DynamoBinaryKeyDataType>()
+                .Where(e => e.Id == bytes)
+                .ToListAsync()).Single();
 
         await using (var context = CreateContext())
         {
-            var items = await context.Set<DynamoBinaryKeyDataType>().ToListAsync();
+            var items =
+                await context
+                    .Set<DynamoBinaryKeyDataType>()
+                    .Where(x => x.Id == new byte[] { 1, 2, 3 })
+                    .ToListAsync();
 
             var entity1 = await QueryByBinaryKey(context, [1, 2, 3]);
             Assert.Equal(new byte[] { 1, 2, 3 }, entity1.Id);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -97,6 +97,7 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_binary_key();
 
     /// <inheritdoc />
+    [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
     public override Task Can_insert_and_read_back_with_null_binary_foreign_key()
         => base.Can_insert_and_read_back_with_null_binary_foreign_key();
 
@@ -106,6 +107,7 @@ public class BuiltInDataTypesDynamoTest(
         => base.Can_insert_and_read_back_with_string_key();
 
     /// <inheritdoc />
+    [ConditionalFact(Skip = SkipReason.ForeignKeysNotSupported)]
     public override Task Can_insert_and_read_back_with_null_string_foreign_key()
         => base.Can_insert_and_read_back_with_null_string_foreign_key();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -48,7 +48,6 @@ public class BuiltInDataTypesDynamoTest(
     }
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ProviderTypeMappingGaps)]
     public override Task Can_query_using_any_data_type() => base.Can_query_using_any_data_type();
 
     /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -15,9 +15,6 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-    private const string DateTimeOffsetMemberProjectionNotSupported =
-        "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
-
     private const string ProviderTypeMappingGaps =
         "DynamoDB provider does not fully support this built-in type mapping query shape yet.";
 
@@ -153,7 +150,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = DateTimeOffsetMemberProjectionNotSupported)]
     public override Task Optional_datetime_reading_null_from_database()
         => base.Optional_datetime_reading_null_from_database();
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -15,9 +15,6 @@ public class BuiltInDataTypesDynamoTest(
     private const string NonEmbeddedNavigationsNotSupported =
         "DynamoDB does not support non-embedded navigation queries in this test shape.";
 
-    private const string ObjectToStringProjectionNotSupported =
-        "DynamoDB does not translate object ToString projection for built-in data type coverage yet.";
-
     private const string DateTimeOffsetMemberProjectionNotSupported =
         "DynamoDB does not translate DateTimeOffset member projection for built-in data type coverage yet.";
 
@@ -153,7 +150,6 @@ public class BuiltInDataTypesDynamoTest(
     public override Task Can_compare_enum_to_parameter() => base.Can_compare_enum_to_parameter();
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = ObjectToStringProjectionNotSupported)]
     public override Task Object_to_string_conversion() => base.Object_to_string_conversion();
 
     /// <inheritdoc />

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/BuiltInDataTypesDynamoTest.cs
@@ -11,9 +11,6 @@ public class BuiltInDataTypesDynamoTest(
     BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture fixture)
     : BuiltInDataTypesTestBase<BuiltInDataTypesDynamoTest.BuiltInDataTypesDynamoFixture>(fixture)
 {
-    private const string NonEmbeddedNavigationsNotSupported =
-        "DynamoDB does not support non-embedded navigation queries in this test shape.";
-
     /// <summary>Ensures all inherited specification tests are reviewed by this provider.</summary>
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
@@ -98,10 +95,8 @@ public class BuiltInDataTypesDynamoTest(
         }
 
         async Task<BinaryKeyDataType> QueryByBinaryKey(DbContext context, byte[] bytes)
-            => (await context
-                .Set<BinaryKeyDataType>()
-                .Where(e => e.Id == bytes)
-                .ToListAsync()).Single();
+            => (await context.Set<BinaryKeyDataType>().Where(e => e.Id == bytes).ToListAsync())
+                .Single();
 
         await using (var context = CreateContext())
         {
@@ -199,7 +194,7 @@ public class BuiltInDataTypesDynamoTest(
     }
 
     /// <inheritdoc />
-    [ConditionalFact(Skip = NonEmbeddedNavigationsNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NavigationPropertiesNotSupported)]
     public override Task Can_read_back_bool_mapped_as_int_through_navigation()
         => base.Can_read_back_bool_mapped_as_int_through_navigation();
 
@@ -346,8 +341,6 @@ public class BuiltInDataTypesDynamoTest(
         /// <inheritdoc />
         public override bool PreservesDateTimeKind => false;
     }
-
-
 
     protected class DynamoAnimal
     {

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Aliases="EFCoreRelational"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="Testcontainers.DynamoDb"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
@@ -27,5 +27,9 @@
   <ItemGroup>
     <ProjectReference
       Include="..\..\src\EntityFrameworkCore.DynamoDb\EntityFrameworkCore.DynamoDb.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 </Project>

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/FindDynamoTest.cs
@@ -8,9 +8,6 @@ namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 /// <summary>Specification find tests for the DynamoDB provider.</summary>
 public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFixture>
 {
-    private const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
-    private const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
-
     protected FindDynamoTest(FindDynamoFixture fixture) : base(fixture) => fixture.ClearSql();
 
     [ConditionalFact]
@@ -23,13 +20,13 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
     public override void Returns_null_for_int_key_not_in_store()
         => NoSyncTest(() => base.Returns_null_for_int_key_not_in_store());
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Find_nullable_int_key_tracked() { }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Find_nullable_int_key_from_store() { }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Returns_null_for_nullable_int_key_not_in_store() { }
 
     public override void Find_string_key_from_store()
@@ -135,13 +132,13 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Find_shadow_key_tracked() { }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Find_shadow_key_from_store() { }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Returns_null_for_shadow_key_not_in_store() { }
 
     public override void Returns_null_for_null_key_values_array()
@@ -151,7 +148,7 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = NullableKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.NullableKeysNotSupported)]
     public override void Returns_null_for_null_nullable_key() { }
 
     public override void Returns_null_for_null_in_composite_key()
@@ -175,36 +172,36 @@ public abstract class FindDynamoTest : FindTestBase<FindDynamoTest.FindDynamoFix
         AssertSql();
     }
 
-    [ConditionalFact(Skip = ShadowKeysNotSupported)]
+    [ConditionalFact(Skip = SkipReason.ShadowKeysNotSupported)]
     public override void Throws_for_bad_entity_type_with_different_namespace() { }
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Find_nullable_int_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Find_nullable_int_key_from_store_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = NullableKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.NullableKeysNotSupported)]
     public override Task Returns_null_for_nullable_int_key_not_in_store_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Find_shadow_key_tracked_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Find_shadow_key_from_store_async(CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Returns_null_for_shadow_key_not_in_store_async(
         CancellationType cancellationType)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = ShadowKeysNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.ShadowKeysNotSupported)]
     public override Task Throws_for_bad_entity_type_with_different_namespace_async(
         CancellationType cancellationType)
         => Task.CompletedTask;

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -1,6 +1,6 @@
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 
-public static class SkipReasons
+public static class SkipReason
 {
     public const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
     public const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -5,4 +5,7 @@ public static class SkipReason
     public const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
     public const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
     public const string ForeignKeysNotSupported = "DynamoDB does not support foreign keys.";
+
+    public const string NavigationPropertiesNotSupported =
+        "DynamoDB does not support navigation properties.";
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReasons.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReasons.cs
@@ -1,0 +1,8 @@
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+public static class SkipReasons
+{
+    public const string NullableKeysNotSupported = "DynamoDB does not support nullable keys.";
+    public const string ShadowKeysNotSupported = "DynamoDB does not support shadow keys.";
+    public const string ForeignKeysNotSupported = "DynamoDB does not support foreign keys.";
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/xunit.runner.json
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
## Summary
Adds DynamoDB specification test coverage around built-in data types, API consistency, and find/query behaviors. This branch layers specification-test scaffolding and DynamoDB-specific test utilities on top of `fix/validate-binary-key` rather than `main`.

## Changes
- Added `EntityFrameworkCore.DynamoDb.SpecificationTests` project with container-backed fixtures, test store helpers, and SQL logging utilities.
- Added built-in data type, API consistency, and `Find` specification tests for DynamoDB.
- Updated test project references, solution membership, and test placement guidance.
- Updated query SQL generation/tests for DynamoDB binary key behavior.

## Validation
- Not run in this session.

## Notes for Reviewers
- Base branch: `fix/validate-binary-key` (not `main`).
- Existing closed PR from same branch was #222; opened fresh PR per request.