### PR TITLE
feat(storage): add AOT-safe scalar value serializers for DynamoDB

### DIFF
--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoEntityWritePlanFactory.cs
@@ -1,9 +1,9 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Update;
 
 #pragma warning disable EF1001 // Internal EF Core API usage
@@ -129,382 +129,75 @@ internal sealed class EntityWritePlan(
         }
     }
 
+    private static readonly ConditionalWeakTable<IComplexType, ComplexTypeWritePlan>
+        ComplexTypePlanCache = new();
+
     /// <summary>Recursively serializes a complex type instance into a DynamoDB attribute map.</summary>
     private static void SerializeComplexTypeIntoMap(
         object instance,
         IComplexType complexType,
         Dictionary<string, AttributeValue> map)
-    {
-        foreach (var property in complexType.GetProperties())
-        {
-            if (property.IsRuntimeOnly())
-                continue;
+        => ComplexTypePlanCache
+            .GetValue(complexType, static type => ComplexTypeWritePlan.Create(type))
+            .Serialize(instance, map);
 
-            var rawValue = property.GetGetter().GetClrValue(instance);
-            map[property.GetAttributeName()] = SerializeScalarPropertyValue(rawValue, property);
+    /// <summary>Builds and executes serializers for members of a complex type.</summary>
+    private sealed class ComplexTypeWritePlan(
+        List<ComplexScalarWriteAction> scalarWriters,
+        List<ComplexPropertyWriteAction> complexWriters)
+    {
+        /// <summary>Creates a write plan for the given complex type.</summary>
+        public static ComplexTypeWritePlan Create(IComplexType complexType)
+        {
+            var scalarWriters = new List<ComplexScalarWriteAction>();
+            foreach (var property in complexType.GetProperties())
+            {
+                if (property.IsRuntimeOnly())
+                    continue;
+
+                scalarWriters.Add(
+                    new ComplexScalarWriteAction(
+                        property.GetAttributeName(),
+                        property.GetGetter(),
+                        DynamoWriteValueSerializerSource
+                            .GetOrCreateScalarValueSerializer(property)));
+            }
+
+            var complexWriters = new List<ComplexPropertyWriteAction>();
+            foreach (var complexProperty in complexType.GetComplexProperties())
+                complexWriters.Add(
+                    new ComplexPropertyWriteAction(
+                        complexProperty.GetAttributeName(),
+                        complexProperty,
+                        complexProperty.GetGetter()));
+
+            return new ComplexTypeWritePlan(scalarWriters, complexWriters);
         }
 
-        foreach (var nestedCp in complexType.GetComplexProperties())
+        /// <summary>Serializes the complex instance into the target map.</summary>
+        public void Serialize(object instance, Dictionary<string, AttributeValue> map)
         {
-            var nestedValue = nestedCp.GetGetter().GetClrValue(instance);
-            map[((IReadOnlyComplexProperty)nestedCp).GetAttributeName()] =
-                SerializeComplexProperty(nestedValue, nestedCp);
+            foreach (var writer in scalarWriters)
+                map[writer.AttributeName] = writer.Serialize(writer.Getter.GetClrValue(instance));
+
+            foreach (var writer in complexWriters)
+                map[writer.AttributeName] = SerializeComplexProperty(
+                    writer.Getter.GetClrValue(instance),
+                    writer.ComplexProperty);
         }
     }
 
-    /// <summary>
-    ///     Serializes a single scalar property value using the property's type mapping. Used only on
-    ///     the complex-type path; root entity scalar properties use typed delegates compiled at
-    ///     plan-build time.
-    /// </summary>
+    private readonly record struct ComplexScalarWriteAction(
+        string AttributeName,
+        IClrPropertyGetter Getter,
+        Func<object?, AttributeValue> Serialize);
+
+    private readonly record struct ComplexPropertyWriteAction(
+        string AttributeName,
+        IComplexProperty ComplexProperty,
+        IClrPropertyGetter Getter);
+
+    /// <summary>Serializes a scalar property value from an untyped EF edge.</summary>
     internal static AttributeValue SerializeScalarPropertyValue(object? value, IProperty property)
-    {
-        if (value is null)
-            return new AttributeValue { NULL = true };
-
-        var typeMapping = property.GetTypeMapping();
-        var converter = typeMapping.Converter;
-
-        // Property-level converters define the store shape for the entire property, even when the
-        // model CLR type itself looks like a collection.
-        if (converter is not null)
-        {
-            var providerValue = converter.ConvertToProvider(value);
-            return ConvertProviderShapeToAttributeValue(providerValue);
-        }
-
-        var clrType = property.ClrType;
-        var nonNullableType = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (nonNullableType == typeof(byte[]))
-            return DynamoWireValueConversion.ConvertProviderValueToAttributeValue((byte[])value);
-
-        if (DynamoTypeMappingSource.TryGetDictionaryValueType(
-            clrType,
-            out var dictionaryValueType,
-            out _))
-        {
-            var valueConverter = typeMapping.ElementTypeMapping?.Converter;
-            return valueConverter is null
-                ? SerializeDirectScalarDictionary(value, dictionaryValueType)
-                : SerializeConvertedScalarDictionary(value, valueConverter);
-        }
-
-        if (DynamoTypeMappingSource.TryGetSetElementType(clrType, out var setElementType))
-        {
-            var elementConverter = typeMapping.ElementTypeMapping?.Converter;
-            return elementConverter is null
-                ? SerializeDirectScalarSet(value, setElementType)
-                : SerializeConvertedScalarSet(value, elementConverter);
-        }
-
-        if (DynamoTypeMappingSource.TryGetListElementType(clrType, out var listElementType))
-        {
-            var elementConverter = typeMapping.ElementTypeMapping?.Converter;
-            return elementConverter is null
-                ? SerializeDirectScalarList(value, listElementType)
-                : SerializeConvertedScalarList(value, elementConverter);
-        }
-
-        return DynamoWireValueConversion.ConvertProviderValueToAttributeValue(value);
-    }
-
-    /// <summary>Serializes a provider-shaped scalar or list value.</summary>
-    private static AttributeValue ConvertProviderShapeToAttributeValue(object? providerValue)
-    {
-        if (providerValue is null)
-            return new AttributeValue { NULL = true };
-
-        if (providerValue is string or byte[])
-            return DynamoWireValueConversion.ConvertProviderValueToAttributeValue(providerValue);
-
-        if (providerValue is IEnumerable enumerable)
-            return SerializeBoxedScalarList(enumerable);
-
-        return DynamoWireValueConversion.ConvertProviderValueToAttributeValue(providerValue);
-    }
-
-    /// <summary>Serializes a complex scalar dictionary with no element converter.</summary>
-    private static AttributeValue SerializeDirectScalarDictionary(object value, Type valueType)
-    {
-        if (valueType == typeof(string))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, string>>)value);
-        if (valueType == typeof(int))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, int>>)value);
-        if (valueType == typeof(int?))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, int?>>)value);
-        if (valueType == typeof(long))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, long>>)value);
-        if (valueType == typeof(long?))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, long?>>)value);
-        if (valueType == typeof(decimal))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, decimal>>)value);
-        if (valueType == typeof(decimal?))
-            return DynamoAttributeValueCollectionHelpers.SerializeDictionary(
-                (IEnumerable<KeyValuePair<string, decimal?>>)value);
-
-        return SerializeBoxedScalarDictionary((IEnumerable)value);
-    }
-
-    /// <summary>Serializes a complex scalar dictionary using a value converter.</summary>
-    private static AttributeValue SerializeConvertedScalarDictionary(
-        object value,
-        ValueConverter valueConverter)
-    {
-        if (value is IDictionary dictionary)
-        {
-            var map = new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
-            foreach (DictionaryEntry item in dictionary)
-            {
-                var providerValue = item.Value is null
-                    ? null
-                    : valueConverter.ConvertToProvider(item.Value);
-                map[(string)item.Key] = ConvertProviderShapeToAttributeValue(providerValue);
-            }
-
-            return new AttributeValue { M = map };
-        }
-
-        return SerializeBoxedScalarDictionary(
-            (IEnumerable)value,
-            item =>
-            {
-                var providerValue = item is null ? null : valueConverter.ConvertToProvider(item);
-                return ConvertProviderShapeToAttributeValue(providerValue);
-            });
-    }
-
-    /// <summary>Serializes a complex scalar dictionary through boxed key-value pairs.</summary>
-    private static AttributeValue SerializeBoxedScalarDictionary(IEnumerable value)
-        => SerializeBoxedScalarDictionary(
-            value,
-            DynamoWireValueConversion.ConvertProviderValueToAttributeValue);
-
-    /// <summary>Serializes a complex scalar dictionary through boxed key-value pairs.</summary>
-    private static AttributeValue SerializeBoxedScalarDictionary(
-        IEnumerable value,
-        Func<object?, AttributeValue> serializeValue)
-    {
-        var map = new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
-        if (value is IDictionary dictionary)
-        {
-            foreach (DictionaryEntry item in dictionary)
-                map[(string)item.Key] = serializeValue(item.Value);
-            return new AttributeValue { M = map };
-        }
-
-        foreach (var item in value)
-        {
-            var (key, itemValue) = ReadKeyValuePair(item);
-            map[key] = serializeValue(itemValue);
-        }
-
-        return new AttributeValue { M = map };
-    }
-
-    /// <summary>Serializes a complex scalar set with no element converter.</summary>
-    private static AttributeValue SerializeDirectScalarSet(object value, Type elementType)
-    {
-        if (elementType == typeof(string))
-            return DynamoAttributeValueCollectionHelpers.SerializeSet((IEnumerable<string>)value);
-        if (elementType == typeof(int))
-            return DynamoAttributeValueCollectionHelpers.SerializeSet((IEnumerable<int>)value);
-        if (elementType == typeof(byte[]))
-            return DynamoAttributeValueCollectionHelpers.SerializeSet((IEnumerable<byte[]>)value);
-
-        return SerializeBoxedScalarSet((IEnumerable)value);
-    }
-
-    /// <summary>Serializes a complex scalar set using an element converter.</summary>
-    private static AttributeValue SerializeConvertedScalarSet(
-        object value,
-        ValueConverter elementConverter)
-    {
-        var providerValues = new List<object>();
-        foreach (var element in (IEnumerable)value)
-        {
-            if (element is null)
-                throw new InvalidOperationException("DynamoDB sets cannot contain null elements.");
-
-            var providerValue = elementConverter.ConvertToProvider(element);
-            if (providerValue is null)
-                throw new InvalidOperationException("DynamoDB sets cannot contain null elements.");
-            providerValues.Add(providerValue);
-        }
-
-        return SerializeBoxedScalarSet(providerValues);
-    }
-
-    /// <summary>Serializes a complex scalar set through boxed scalar elements.</summary>
-    private static AttributeValue SerializeBoxedScalarSet(IEnumerable value)
-    {
-        List<string>? ss = null;
-        List<string>? ns = null;
-        List<MemoryStream>? bs = null;
-        foreach (var element in value)
-        {
-            if (element is null)
-                throw new InvalidOperationException("DynamoDB sets cannot contain null elements.");
-
-            switch (element)
-            {
-                case string s:
-                    EnsureSetKind(ns, bs, "string");
-                    (ss ??= []).Add(s);
-                    break;
-                case byte[] bytes:
-                    EnsureSetKind(ss, ns, "binary");
-                    (bs ??= []).Add(DynamoWireValueConversion.CreateBinaryStream(bytes));
-                    break;
-                default:
-                    EnsureSetKind(ss, bs, "number");
-                    var attributeValue = DynamoWireValueConversion
-                        .ConvertProviderValueToAttributeValue(element);
-                    if (attributeValue.N is null)
-                        throw new InvalidOperationException(
-                            "DynamoDB sets can only contain string, binary, or numeric elements.");
-                    (ns ??= []).Add(attributeValue.N);
-                    break;
-            }
-        }
-
-        if (ss is { Count: > 0 })
-            return new AttributeValue { SS = ss };
-        if (bs is { Count: > 0 })
-            return new AttributeValue { BS = bs };
-        if (ns is { Count: > 0 })
-            return new AttributeValue { NS = ns };
-
-        throw new InvalidOperationException(
-            "DynamoDB sets cannot be empty; use a null property or a non-empty collection.");
-    }
-
-    /// <summary>Throws when a set would mix DynamoDB set kinds.</summary>
-    private static void EnsureSetKind(ICollection? first, ICollection? second, string kind)
-    {
-        if ((first?.Count ?? 0) > 0 || (second?.Count ?? 0) > 0)
-            throw new InvalidOperationException(
-                $"DynamoDB sets cannot mix {kind} elements with other element kinds.");
-    }
-
-    /// <summary>Serializes a complex scalar list with no element converter.</summary>
-    private static AttributeValue SerializeDirectScalarList(object value, Type elementType)
-    {
-        if (elementType == typeof(string))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<string>)value);
-        if (elementType == typeof(bool))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<bool>)value);
-        if (elementType == typeof(bool?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<bool?>)value);
-        if (elementType == typeof(byte))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<byte>)value);
-        if (elementType == typeof(byte?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<byte?>)value);
-        if (elementType == typeof(sbyte))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<sbyte>)value);
-        if (elementType == typeof(sbyte?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<sbyte?>)value);
-        if (elementType == typeof(short))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<short>)value);
-        if (elementType == typeof(short?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<short?>)value);
-        if (elementType == typeof(ushort))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<ushort>)value);
-        if (elementType == typeof(ushort?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<ushort?>)value);
-        if (elementType == typeof(int))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<int>)value);
-        if (elementType == typeof(int?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<int?>)value);
-        if (elementType == typeof(uint))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<uint>)value);
-        if (elementType == typeof(uint?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<uint?>)value);
-        if (elementType == typeof(long))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<long>)value);
-        if (elementType == typeof(long?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<long?>)value);
-        if (elementType == typeof(ulong))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<ulong>)value);
-        if (elementType == typeof(ulong?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<ulong?>)value);
-        if (elementType == typeof(float))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<float>)value);
-        if (elementType == typeof(float?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<float?>)value);
-        if (elementType == typeof(double))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<double>)value);
-        if (elementType == typeof(double?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<double?>)value);
-        if (elementType == typeof(decimal))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<decimal>)value);
-        if (elementType == typeof(decimal?))
-            return DynamoAttributeValueCollectionHelpers.SerializeList(
-                (IEnumerable<decimal?>)value);
-        if (elementType == typeof(byte[]))
-            return DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<byte[]>)value);
-
-        return SerializeBoxedScalarList((IEnumerable)value);
-    }
-
-    /// <summary>Serializes a complex scalar list using an element converter.</summary>
-    private static AttributeValue SerializeConvertedScalarList(
-        object value,
-        ValueConverter elementConverter)
-    {
-        var elements = new List<AttributeValue>();
-        foreach (var element in (IEnumerable)value)
-        {
-            if (element is null)
-            {
-                elements.Add(new AttributeValue { NULL = true });
-                continue;
-            }
-
-            var providerValue = elementConverter.ConvertToProvider(element);
-            elements.Add(
-                providerValue is null
-                    ? new AttributeValue { NULL = true }
-                    : DynamoWireValueConversion
-                        .ConvertProviderValueToAttributeValue(providerValue));
-        }
-
-        return new AttributeValue { L = elements };
-    }
-
-    /// <summary>Serializes a complex scalar list through boxed scalar elements.</summary>
-    private static AttributeValue SerializeBoxedScalarList(IEnumerable value)
-    {
-        var elements = new List<AttributeValue>();
-        foreach (var element in value)
-            elements.Add(DynamoWireValueConversion.ConvertProviderValueToAttributeValue(element));
-        return new AttributeValue { L = elements };
-    }
-
-    /// <summary>Reads a boxed <see cref="KeyValuePair{TKey,TValue}" /> instance.</summary>
-    private static (string Key, object? Value) ReadKeyValuePair(object item)
-    {
-        if (item is KeyValuePair<string, string> stringPair)
-            return (stringPair.Key, stringPair.Value);
-        if (item is KeyValuePair<string, int> intPair)
-            return (intPair.Key, intPair.Value);
-        if (item is KeyValuePair<string, int?> nullableIntPair)
-            return (nullableIntPair.Key, nullableIntPair.Value);
-        if (item is KeyValuePair<string, long> longPair)
-            return (longPair.Key, longPair.Value);
-        if (item is KeyValuePair<string, long?> nullableLongPair)
-            return (nullableLongPair.Key, nullableLongPair.Value);
-        if (item is KeyValuePair<string, decimal> decimalPair)
-            return (decimalPair.Key, decimalPair.Value);
-        if (item is KeyValuePair<string, decimal?> nullableDecimalPair)
-            return (nullableDecimalPair.Key, nullableDecimalPair.Value);
-
-        throw new NotSupportedException(
-            $"Dictionary item type {item.GetType()} is not supported for DynamoDB wire conversion");
-    }
+        => DynamoWriteValueSerializerSource.SerializeScalarPropertyValue(value, property);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteValueSerializerSource.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoWriteValueSerializerSource.cs
@@ -1,0 +1,742 @@
+using System.Collections;
+using System.Runtime.CompilerServices;
+using Amazon.DynamoDBv2.Model;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace EntityFrameworkCore.DynamoDb.Storage;
+
+/// <summary>Builds AOT-safe scalar write value serializers for untyped EF value edges.</summary>
+internal static class DynamoWriteValueSerializerSource
+{
+    private static readonly ConditionalWeakTable<IProperty, Func<object?, AttributeValue>>
+        ScalarValueSerializerCache = new();
+
+    /// <summary>Serializes a scalar property value from an untyped EF edge.</summary>
+    internal static AttributeValue SerializeScalarPropertyValue(object? value, IProperty property)
+        => GetOrCreateScalarValueSerializer(property)(value);
+
+    /// <summary>Gets or creates the scalar value serializer for a property.</summary>
+    internal static Func<object?, AttributeValue>
+        GetOrCreateScalarValueSerializer(IProperty property)
+        => ScalarValueSerializerCache.GetValue(property, CreateScalarValueSerializer);
+
+    /// <summary>Creates a typed serializer that casts once at the untyped edge.</summary>
+    private static Func<object?, AttributeValue> CreateScalarValueSerializer(IProperty property)
+    {
+        var clrType = property.ClrType;
+        var typeMapping = property.GetTypeMapping();
+        var propertyConverter = typeMapping.Converter;
+
+        // Property-level converters define the store shape for the entire property, even when the
+        // model CLR type itself looks like a collection.
+        if (propertyConverter is not null)
+            return CreateConvertedPropertySerializer(property, propertyConverter);
+
+        var nonNullableType = Nullable.GetUnderlyingType(clrType) ?? clrType;
+        if (nonNullableType == typeof(byte[]))
+            return CreateDirectScalarSerializer(clrType);
+
+        if (DynamoTypeMappingSource.TryGetDictionaryValueType(clrType, out var valueType, out _))
+        {
+            var valueConverter = typeMapping.ElementTypeMapping?.Converter;
+            return valueConverter is null
+                ? CreateDirectDictionarySerializer(valueType)
+                : CreateConvertedDictionarySerializer(valueType, valueConverter);
+        }
+
+        if (DynamoTypeMappingSource.TryGetSetElementType(clrType, out var setElementType))
+        {
+            var elementConverter = typeMapping.ElementTypeMapping?.Converter;
+            return elementConverter is null
+                ? CreateDirectSetSerializer(setElementType)
+                : CreateConvertedSetSerializer(setElementType, elementConverter);
+        }
+
+        if (DynamoTypeMappingSource.TryGetListElementType(clrType, out var listElementType))
+        {
+            var elementConverter = typeMapping.ElementTypeMapping?.Converter;
+            return elementConverter is null
+                ? CreateDirectListSerializer(listElementType)
+                : CreateConvertedListSerializer(listElementType, elementConverter);
+        }
+
+        return CreateDirectScalarSerializer(clrType);
+    }
+
+    private static AttributeValue NullAttributeValue() => new() { NULL = true };
+
+    private interface IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a serializer for the selected value type.</summary>
+        Func<object?, AttributeValue> Create<TValue>();
+    }
+
+    private interface IStructObjectValueSerializerFactory
+    {
+        /// <summary>Creates a serializer for the selected non-nullable value type.</summary>
+        Func<object?, AttributeValue> Create<TValue>() where TValue : struct;
+    }
+
+    private static Func<object?, AttributeValue>? TryDispatchWireType<TFactory>(
+        Type type,
+        TFactory factory) where TFactory : struct, IObjectValueSerializerFactory
+    {
+        if (type == typeof(string))
+            return factory.Create<string>();
+        if (type == typeof(bool))
+            return factory.Create<bool>();
+        if (type == typeof(bool?))
+            return factory.Create<bool?>();
+        if (type == typeof(byte))
+            return factory.Create<byte>();
+        if (type == typeof(byte?))
+            return factory.Create<byte?>();
+        if (type == typeof(sbyte))
+            return factory.Create<sbyte>();
+        if (type == typeof(sbyte?))
+            return factory.Create<sbyte?>();
+        if (type == typeof(short))
+            return factory.Create<short>();
+        if (type == typeof(short?))
+            return factory.Create<short?>();
+        if (type == typeof(ushort))
+            return factory.Create<ushort>();
+        if (type == typeof(ushort?))
+            return factory.Create<ushort?>();
+        if (type == typeof(int))
+            return factory.Create<int>();
+        if (type == typeof(int?))
+            return factory.Create<int?>();
+        if (type == typeof(uint))
+            return factory.Create<uint>();
+        if (type == typeof(uint?))
+            return factory.Create<uint?>();
+        if (type == typeof(long))
+            return factory.Create<long>();
+        if (type == typeof(long?))
+            return factory.Create<long?>();
+        if (type == typeof(ulong))
+            return factory.Create<ulong>();
+        if (type == typeof(ulong?))
+            return factory.Create<ulong?>();
+        if (type == typeof(float))
+            return factory.Create<float>();
+        if (type == typeof(float?))
+            return factory.Create<float?>();
+        if (type == typeof(double))
+            return factory.Create<double>();
+        if (type == typeof(double?))
+            return factory.Create<double?>();
+        if (type == typeof(decimal))
+            return factory.Create<decimal>();
+        if (type == typeof(decimal?))
+            return factory.Create<decimal?>();
+        if (type == typeof(byte[]))
+            return factory.Create<byte[]>();
+
+        return null;
+    }
+
+    private static Func<object?, AttributeValue>? TryDispatchModelType<TFactory>(
+        Type type,
+        TFactory factory) where TFactory : struct, IObjectValueSerializerFactory
+    {
+        var wireSerializer = TryDispatchWireType(type, factory);
+        if (wireSerializer is not null)
+            return wireSerializer;
+
+        if (type == typeof(Guid))
+            return factory.Create<Guid>();
+        if (type == typeof(Guid?))
+            return factory.Create<Guid?>();
+        if (type == typeof(DateTime))
+            return factory.Create<DateTime>();
+        if (type == typeof(DateTime?))
+            return factory.Create<DateTime?>();
+        if (type == typeof(DateTimeOffset))
+            return factory.Create<DateTimeOffset>();
+        if (type == typeof(DateTimeOffset?))
+            return factory.Create<DateTimeOffset?>();
+        if (type == typeof(TimeSpan))
+            return factory.Create<TimeSpan>();
+        if (type == typeof(TimeSpan?))
+            return factory.Create<TimeSpan?>();
+        if (type == typeof(DateOnly))
+            return factory.Create<DateOnly>();
+        if (type == typeof(DateOnly?))
+            return factory.Create<DateOnly?>();
+        if (type == typeof(TimeOnly))
+            return factory.Create<TimeOnly>();
+        if (type == typeof(TimeOnly?))
+            return factory.Create<TimeOnly?>();
+
+        return null;
+    }
+
+    private static Func<object?, AttributeValue>? TryDispatchStructModelType<TFactory>(
+        Type type,
+        TFactory factory) where TFactory : struct, IStructObjectValueSerializerFactory
+    {
+        if (type == typeof(bool))
+            return factory.Create<bool>();
+        if (type == typeof(byte))
+            return factory.Create<byte>();
+        if (type == typeof(sbyte))
+            return factory.Create<sbyte>();
+        if (type == typeof(short))
+            return factory.Create<short>();
+        if (type == typeof(ushort))
+            return factory.Create<ushort>();
+        if (type == typeof(int))
+            return factory.Create<int>();
+        if (type == typeof(uint))
+            return factory.Create<uint>();
+        if (type == typeof(long))
+            return factory.Create<long>();
+        if (type == typeof(ulong))
+            return factory.Create<ulong>();
+        if (type == typeof(float))
+            return factory.Create<float>();
+        if (type == typeof(double))
+            return factory.Create<double>();
+        if (type == typeof(decimal))
+            return factory.Create<decimal>();
+        if (type == typeof(Guid))
+            return factory.Create<Guid>();
+        if (type == typeof(DateTime))
+            return factory.Create<DateTime>();
+        if (type == typeof(DateTimeOffset))
+            return factory.Create<DateTimeOffset>();
+        if (type == typeof(TimeSpan))
+            return factory.Create<TimeSpan>();
+        if (type == typeof(DateOnly))
+            return factory.Create<DateOnly>();
+        if (type == typeof(TimeOnly))
+            return factory.Create<TimeOnly>();
+
+        return null;
+    }
+
+    private static Func<object?, AttributeValue> CreateDirectScalarSerializer(Type type)
+        => TryDispatchWireType(type, default(DirectScalarValueFactory))
+            ?? throw new NotSupportedException(
+                $"Scalar type '{type.ShortDisplayName()}' is not supported "
+                + "for DynamoDB wire conversion.");
+
+    private readonly struct DirectScalarValueFactory : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a direct scalar serializer for the selected wire type.</summary>
+        public Func<object?, AttributeValue> Create<TValue>()
+            => value => value is null
+                ? NullAttributeValue()
+                : DynamoWireValueConversion.ConvertProviderValueToAttributeValue((TValue)value);
+    }
+
+    private static Func<object?, AttributeValue> CreateDirectDictionarySerializer(Type valueType)
+        => TryDispatchWireType(valueType, default(DirectDictionaryValueFactory))
+            ?? throw new NotSupportedException(
+                $"Dictionary value type '{valueType.ShortDisplayName()}' is not supported "
+                + "for DynamoDB wire conversion.");
+
+    private readonly struct DirectDictionaryValueFactory : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a direct dictionary serializer for the selected value type.</summary>
+        public Func<object?, AttributeValue> Create<TValue>()
+            => value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeDictionary(
+                    (IEnumerable<KeyValuePair<string, TValue>>)value);
+    }
+
+    private static Func<object?, AttributeValue> CreateDirectSetSerializer(Type elementType)
+        => TryDispatchWireType(elementType, default(DirectSetValueFactory))
+            ?? throw new NotSupportedException(
+                $"Set element type '{elementType.ShortDisplayName()}' is not supported "
+                + "for DynamoDB wire conversion.");
+
+    private readonly struct DirectSetValueFactory : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a direct set serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>()
+            => value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeSet((IEnumerable<TElement>)value);
+    }
+
+    private static Func<object?, AttributeValue> CreateDirectListSerializer(Type elementType)
+        => TryDispatchWireType(elementType, default(DirectListValueFactory))
+            ?? throw new NotSupportedException(
+                $"List element type '{elementType.ShortDisplayName()}' is not supported "
+                + "for DynamoDB wire conversion.");
+
+    private readonly struct DirectListValueFactory : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a direct list serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>()
+            => value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeList((IEnumerable<TElement>)value);
+    }
+
+    private static Func<object?, AttributeValue> CreateConvertedPropertySerializer(
+        IProperty property,
+        ValueConverter converter)
+    {
+        var modelType = converter.ModelClrType;
+        var propertyType = property.ClrType;
+        var providerType = converter.ProviderClrType;
+
+        if (propertyType == modelType)
+            return TryDispatchModelType(
+                    modelType,
+                    new ConvertedPropertyValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedPropertySerializer(converter);
+
+        var underlying = Nullable.GetUnderlyingType(propertyType);
+        if (underlying == modelType)
+            return TryDispatchStructModelType(
+                    modelType,
+                    new ConvertedNullablePropertyValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedPropertySerializer(converter);
+
+        return CreateBoxedConvertedPropertySerializer(converter);
+    }
+
+    private readonly struct ConvertedPropertyValueFactory(
+        ValueConverter converter,
+        Type providerType) : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted scalar serializer for the selected model type.</summary>
+        public Func<object?, AttributeValue> Create<TModel>()
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedPropertyProviderFactory<TModel>(converter))
+                ?? CreateBoxedConvertedPropertySerializer(converter);
+    }
+
+    private readonly struct ConvertedPropertyProviderFactory<TModel>(ValueConverter converter)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted scalar serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TModel, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoWireValueConversion.ConvertProviderValueToAttributeValue(
+                    typed.ConvertToProviderTyped((TModel)value));
+        }
+    }
+
+    private readonly struct ConvertedNullablePropertyValueFactory(
+        ValueConverter converter,
+        Type providerType) : IStructObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted nullable scalar serializer for the selected model type.</summary>
+        public Func<object?, AttributeValue> Create<TModel>() where TModel : struct
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedNullablePropertyProviderFactory<TModel>(converter))
+                ?? CreateBoxedConvertedPropertySerializer(converter);
+    }
+
+    private readonly struct ConvertedNullablePropertyProviderFactory<TModel>(
+        ValueConverter converter) : IObjectValueSerializerFactory where TModel : struct
+    {
+        /// <summary>Creates a converted nullable scalar serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TModel, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoWireValueConversion.ConvertProviderValueToAttributeValue(
+                    typed.ConvertToProviderTyped((TModel)value));
+        }
+    }
+
+    private static Func<object?, AttributeValue> CreateBoxedConvertedPropertySerializer(
+        ValueConverter converter)
+        => value => value is null
+            ? NullAttributeValue()
+            : ConvertProviderShapeToAttributeValue(converter.ConvertToProvider(value));
+
+    private static Func<object?, AttributeValue> CreateConvertedDictionarySerializer(
+        Type valueType,
+        ValueConverter converter)
+    {
+        var modelType = converter.ModelClrType;
+        var providerType = converter.ProviderClrType;
+
+        if (valueType == modelType)
+            return TryDispatchModelType(
+                    modelType,
+                    new ConvertedDictionaryValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedDictionarySerializer(converter);
+
+        var underlying = Nullable.GetUnderlyingType(valueType);
+        if (underlying == modelType)
+            return TryDispatchStructModelType(
+                    modelType,
+                    new ConvertedNullableDictionaryValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedDictionarySerializer(converter);
+
+        return CreateBoxedConvertedDictionarySerializer(converter);
+    }
+
+    private readonly struct ConvertedDictionaryValueFactory(
+        ValueConverter converter,
+        Type providerType) : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted dictionary serializer for the selected value type.</summary>
+        public Func<object?, AttributeValue> Create<TValue>()
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedDictionaryProviderFactory<TValue>(converter))
+                ?? CreateBoxedConvertedDictionarySerializer(converter);
+    }
+
+    private readonly struct ConvertedDictionaryProviderFactory<TValue>(ValueConverter converter)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted dictionary serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TValue, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeDictionary(
+                    (IEnumerable<KeyValuePair<string, TValue>>)value,
+                    typed.ConvertToProviderTyped);
+        }
+    }
+
+    private readonly struct ConvertedNullableDictionaryValueFactory(
+        ValueConverter converter,
+        Type providerType) : IStructObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted nullable dictionary serializer for the selected value type.</summary>
+        public Func<object?, AttributeValue> Create<TValue>() where TValue : struct
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedNullableDictionaryProviderFactory<TValue>(converter))
+                ?? CreateBoxedConvertedDictionarySerializer(converter);
+    }
+
+    private readonly struct ConvertedNullableDictionaryProviderFactory<TValue>(
+        ValueConverter converter) : IObjectValueSerializerFactory where TValue : struct
+    {
+        /// <summary>Creates a converted nullable dictionary serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TValue, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeDictionary(
+                    (IEnumerable<KeyValuePair<string, TValue?>>)value,
+                    item => item.HasValue
+                        ? DynamoWireValueConversion.ConvertProviderValueToAttributeValue(
+                            typed.ConvertToProviderTyped(item.Value))
+                        : NullAttributeValue());
+        }
+    }
+
+    private static Func<object?, AttributeValue> CreateBoxedConvertedDictionarySerializer(
+        ValueConverter converter)
+        => value =>
+        {
+            if (value is null)
+                return NullAttributeValue();
+
+            if (value is not IDictionary dictionary)
+                throw new NotSupportedException(
+                    "Converted dictionary fallback requires a non-generic IDictionary instance.");
+
+            var map = new Dictionary<string, AttributeValue>(StringComparer.Ordinal);
+            foreach (DictionaryEntry item in dictionary)
+            {
+                var providerValue =
+                    item.Value is null ? null : converter.ConvertToProvider(item.Value);
+                map[(string)item.Key] = ConvertProviderShapeToAttributeValue(providerValue);
+            }
+
+            return new AttributeValue { M = map };
+        };
+
+    private static Func<object?, AttributeValue> CreateConvertedSetSerializer(
+        Type elementType,
+        ValueConverter converter)
+    {
+        var modelType = converter.ModelClrType;
+        var providerType = converter.ProviderClrType;
+
+        if (elementType == modelType)
+            return TryDispatchModelType(
+                    modelType,
+                    new ConvertedSetValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedSetSerializer(converter);
+
+        var underlying = Nullable.GetUnderlyingType(elementType);
+        if (underlying == modelType)
+            return TryDispatchStructModelType(
+                    modelType,
+                    new ConvertedNullableSetValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedSetSerializer(converter);
+
+        return CreateBoxedConvertedSetSerializer(converter);
+    }
+
+    private readonly struct ConvertedSetValueFactory(ValueConverter converter, Type providerType)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted set serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>()
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedSetProviderFactory<TElement>(converter))
+                ?? CreateBoxedConvertedSetSerializer(converter);
+    }
+
+    private readonly struct ConvertedSetProviderFactory<TElement>(ValueConverter converter)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted set serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TElement, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeSet(
+                    (IEnumerable<TElement>)value,
+                    typed.ConvertToProviderTyped);
+        }
+    }
+
+    private readonly struct ConvertedNullableSetValueFactory(
+        ValueConverter converter,
+        Type providerType) : IStructObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted nullable set serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>() where TElement : struct
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedNullableSetProviderFactory<TElement>(converter))
+                ?? CreateBoxedConvertedSetSerializer(converter);
+    }
+
+    private readonly struct ConvertedNullableSetProviderFactory<TElement>(ValueConverter converter)
+        : IObjectValueSerializerFactory where TElement : struct
+    {
+        /// <summary>Creates a converted nullable set serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TElement, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeSet(
+                    (IEnumerable<TElement?>)value,
+                    item => item.HasValue
+                        ? typed.ConvertToProviderTyped(item.Value)
+                        : throw new InvalidOperationException(
+                            "DynamoDB sets cannot contain null elements."));
+        }
+    }
+
+    private static Func<object?, AttributeValue> CreateBoxedConvertedSetSerializer(
+        ValueConverter converter)
+        => value =>
+        {
+            if (value is null)
+                return NullAttributeValue();
+
+            var providerValues = new List<object>();
+            foreach (var element in (IEnumerable)value)
+            {
+                if (element is null)
+                    throw new InvalidOperationException(
+                        "DynamoDB sets cannot contain null elements.");
+
+                var providerValue = converter.ConvertToProvider(element);
+                if (providerValue is null)
+                    throw new InvalidOperationException(
+                        "DynamoDB sets cannot contain null elements.");
+
+                providerValues.Add(providerValue);
+            }
+
+            return SerializeBoxedScalarSet(providerValues);
+        };
+
+    private static Func<object?, AttributeValue> CreateConvertedListSerializer(
+        Type elementType,
+        ValueConverter converter)
+    {
+        var modelType = converter.ModelClrType;
+        var providerType = converter.ProviderClrType;
+
+        if (elementType == modelType)
+            return TryDispatchModelType(
+                    modelType,
+                    new ConvertedListValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedListSerializer(converter);
+
+        var underlying = Nullable.GetUnderlyingType(elementType);
+        if (underlying == modelType)
+            return TryDispatchStructModelType(
+                    modelType,
+                    new ConvertedNullableListValueFactory(converter, providerType))
+                ?? CreateBoxedConvertedListSerializer(converter);
+
+        return CreateBoxedConvertedListSerializer(converter);
+    }
+
+    private readonly struct ConvertedListValueFactory(ValueConverter converter, Type providerType)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted list serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>()
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedListProviderFactory<TElement>(converter))
+                ?? CreateBoxedConvertedListSerializer(converter);
+    }
+
+    private readonly struct ConvertedListProviderFactory<TElement>(ValueConverter converter)
+        : IObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted list serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TElement, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeList(
+                    (IEnumerable<TElement>)value,
+                    typed.ConvertToProviderTyped);
+        }
+    }
+
+    private readonly struct ConvertedNullableListValueFactory(
+        ValueConverter converter,
+        Type providerType) : IStructObjectValueSerializerFactory
+    {
+        /// <summary>Creates a converted nullable list serializer for the selected element type.</summary>
+        public Func<object?, AttributeValue> Create<TElement>() where TElement : struct
+            => TryDispatchWireType(
+                    providerType,
+                    new ConvertedNullableListProviderFactory<TElement>(converter))
+                ?? CreateBoxedConvertedListSerializer(converter);
+    }
+
+    private readonly struct ConvertedNullableListProviderFactory<TElement>(ValueConverter converter)
+        : IObjectValueSerializerFactory where TElement : struct
+    {
+        /// <summary>Creates a converted nullable list serializer for the selected provider type.</summary>
+        public Func<object?, AttributeValue> Create<TProvider>()
+        {
+            var typed = (ValueConverter<TElement, TProvider>)converter;
+            return value => value is null
+                ? NullAttributeValue()
+                : DynamoAttributeValueCollectionHelpers.SerializeList(
+                    (IEnumerable<TElement?>)value,
+                    item => item.HasValue
+                        ? DynamoWireValueConversion.ConvertProviderValueToAttributeValue(
+                            typed.ConvertToProviderTyped(item.Value))
+                        : NullAttributeValue());
+        }
+    }
+
+    private static Func<object?, AttributeValue> CreateBoxedConvertedListSerializer(
+        ValueConverter converter)
+        => value =>
+        {
+            if (value is null)
+                return NullAttributeValue();
+
+            var elements = new List<AttributeValue>();
+            foreach (var element in (IEnumerable)value)
+            {
+                var providerValue = element is null ? null : converter.ConvertToProvider(element);
+                elements.Add(ConvertProviderShapeToAttributeValue(providerValue));
+            }
+
+            return new AttributeValue { L = elements };
+        };
+
+    /// <summary>Serializes a provider-shaped scalar or list value from a boxed fallback.</summary>
+    private static AttributeValue ConvertProviderShapeToAttributeValue(object? providerValue)
+    {
+        if (providerValue is null)
+            return NullAttributeValue();
+
+        if (providerValue is string or byte[])
+            return DynamoWireValueConversion.ConvertProviderValueToAttributeValue(providerValue);
+
+        if (providerValue is IEnumerable enumerable)
+            return SerializeBoxedScalarList(enumerable);
+
+        return DynamoWireValueConversion.ConvertProviderValueToAttributeValue(providerValue);
+    }
+
+    /// <summary>Serializes scalar set elements through boxed provider values.</summary>
+    private static AttributeValue SerializeBoxedScalarSet(IEnumerable value)
+    {
+        List<string>? ss = null;
+        List<string>? ns = null;
+        List<MemoryStream>? bs = null;
+        foreach (var element in value)
+        {
+            if (element is null)
+                throw new InvalidOperationException("DynamoDB sets cannot contain null elements.");
+
+            switch (element)
+            {
+                case string s:
+                    EnsureSetKind(ns, bs, "string");
+                    (ss ??= []).Add(s);
+                    break;
+                case byte[] bytes:
+                    EnsureSetKind(ss, ns, "binary");
+                    (bs ??= []).Add(DynamoWireValueConversion.CreateBinaryStream(bytes));
+                    break;
+                default:
+                    EnsureSetKind(ss, bs, "number");
+                    var attributeValue = DynamoWireValueConversion
+                        .ConvertProviderValueToAttributeValue(element);
+                    if (attributeValue.N is null)
+                        throw new InvalidOperationException(
+                            "DynamoDB sets can only contain string, binary, or numeric elements.");
+                    (ns ??= []).Add(attributeValue.N);
+                    break;
+            }
+        }
+
+        if (ss is { Count: > 0 })
+            return new AttributeValue { SS = ss };
+        if (bs is { Count: > 0 })
+            return new AttributeValue { BS = bs };
+        if (ns is { Count: > 0 })
+            return new AttributeValue { NS = ns };
+
+        throw new InvalidOperationException(
+            "DynamoDB sets cannot be empty; use a null property or a non-empty collection.");
+    }
+
+    /// <summary>Throws when a set would mix DynamoDB set kinds.</summary>
+    private static void EnsureSetKind(ICollection? first, ICollection? second, string kind)
+    {
+        if ((first?.Count ?? 0) > 0 || (second?.Count ?? 0) > 0)
+            throw new InvalidOperationException(
+                $"DynamoDB sets cannot mix {kind} elements with other element kinds.");
+    }
+
+    /// <summary>Serializes a complex scalar list through boxed scalar elements.</summary>
+    private static AttributeValue SerializeBoxedScalarList(IEnumerable value)
+    {
+        var elements = new List<AttributeValue>();
+        foreach (var element in value)
+            elements.Add(DynamoWireValueConversion.ConvertProviderValueToAttributeValue(element));
+        return new AttributeValue { L = elements };
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Storage/DynamoEntityItemSerializerSourceTests.cs
@@ -308,8 +308,30 @@ public class DynamoEntityItemSerializerSourceTests
                     {
                         ["a"] = 1, ["b"] = 2,
                     },
-                LongCounts = new ReadOnlyDictionary<string, long>(
-                    new Dictionary<string, long>(StringComparer.Ordinal) { ["big"] = 42 }),
+                LongCounts =
+                    new ReadOnlyDictionary<string, long>(
+                        new Dictionary<string, long>(StringComparer.Ordinal) { ["big"] = 42 }),
+                Flags =
+                    new Dictionary<string, bool>(StringComparer.Ordinal) { ["enabled"] = true },
+                OptionalFlags =
+                    new ReadOnlyDictionary<string, bool?>(
+                        new Dictionary<string, bool?>(StringComparer.Ordinal)
+                        {
+                            ["yes"] = true, ["unknown"] = null,
+                        }),
+                UnsignedCounts =
+                    new ReadOnlyDictionary<string, uint>(
+                        new Dictionary<string, uint>(StringComparer.Ordinal) { ["u"] = 7 }),
+                Doubles =
+                    new Dictionary<string, double?>(StringComparer.Ordinal)
+                    {
+                        ["pi"] = 3.14, ["missing"] = null,
+                    },
+                BinaryByName =
+                    new Dictionary<string, byte[]>(StringComparer.Ordinal)
+                    {
+                        ["blob"] = [4, 5, 6],
+                    },
                 Payload = [1, 2, 3],
             },
         };
@@ -330,6 +352,13 @@ public class DynamoEntityItemSerializerSourceTests
         details["counts"].M["a"].N.Should().Be("1");
         details["counts"].M["b"].N.Should().Be("2");
         details["longCounts"].M["big"].N.Should().Be("42");
+        details["flags"].M["enabled"].BOOL.Should().BeTrue();
+        details["optionalFlags"].M["yes"].BOOL.Should().BeTrue();
+        details["optionalFlags"].M["unknown"].NULL.Should().BeTrue();
+        details["unsignedCounts"].M["u"].N.Should().Be("7");
+        details["doubles"].M["pi"].N.Should().Be("3.14");
+        details["doubles"].M["missing"].NULL.Should().BeTrue();
+        details["binaryByName"].M["blob"].B.ToArray().Should().Equal(4, 5, 6);
         details["payload"].B.ToArray().Should().Equal(1, 2, 3);
         details["payload"].L.Should().BeNull();
     }
@@ -438,6 +467,18 @@ public class DynamoEntityItemSerializerSourceTests
 
         public IReadOnlyDictionary<string, long> LongCounts { get; set; } =
             new ReadOnlyDictionary<string, long>(new Dictionary<string, long>());
+
+        public Dictionary<string, bool> Flags { get; set; } = new(StringComparer.Ordinal);
+
+        public IReadOnlyDictionary<string, bool?> OptionalFlags { get; set; } =
+            new ReadOnlyDictionary<string, bool?>(new Dictionary<string, bool?>());
+
+        public IReadOnlyDictionary<string, uint> UnsignedCounts { get; set; } =
+            new ReadOnlyDictionary<string, uint>(new Dictionary<string, uint>());
+
+        public Dictionary<string, double?> Doubles { get; set; } = new(StringComparer.Ordinal);
+
+        public Dictionary<string, byte[]> BinaryByName { get; set; } = new(StringComparer.Ordinal);
 
         public byte[] Payload { get; set; } = [];
         public ConvertedCodeList ConvertedCodes { get; set; } = new(string.Empty);


### PR DESCRIPTION
## Summary

Adds a dedicated `DynamoWriteValueSerializerSource` to move scalar DynamoDB write serialization out of the entity write-plan factory. This keeps write-path serialization AOT-safe while reducing reflection-heavy factory responsibilities.

## Changes

- Introduced generated scalar value serializer source for DynamoDB write values.
- Refactored `DynamoEntityWritePlanFactory` to use dedicated serializer source.
- Updated serializer source tests around write-plan scalar serialization behavior.

## Validation

- Not run in this session; branch was already clean and pushed before PR creation.

## Notes for Reviewers

- Base branch intentionally set to `test/add-ComplexTypesTrackingTest`, not `main`, for stacked review.