### PR TITLE
chore(deps): update test package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,28 +8,28 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.17.9" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.4" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
-    <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.6.0-preview.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="LayeredCraft.DynamoMapper" Version="1.6.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <!-- Testing Libraries -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.XunitV3" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.XunitV3" Version="4.12.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.2.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="YTest.MTP.XUnit2" Version="1.0.3"/>
+    <PackageVersion Include="YTest.MTP.XUnit2" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup Label="Microsoft EF Core (net10.0)">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Updates several centrally managed package versions used by the provider and test projects. This includes the DynamoDB SDK, DynamoMapper, SourceLink, test SDK, and Testcontainers packages.

## Changes

- Updated `AWSSDK.DynamoDBv2` to `4.0.18.4`.
- Updated `LayeredCraft.DynamoMapper` to `1.6.3`.
- Updated `Microsoft.SourceLink.GitHub` to `10.0.300`.
- Updated `Microsoft.NET.Test.Sdk` to `18.5.1`.
- Updated Testcontainers packages to `4.12.0`.
- Normalized spacing on a few package-version entries.

## Validation

- `dotnet build`
