### PR TITLE
test(tests): add Northwind tracking and tagging specs

### DIFF
--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -120,14 +120,13 @@ Uses the `Customer / Employee / Order / Product` dataset with `NorthwindQueryDyn
 |---|---:|:---:|:---:|---|
 | `NorthwindWhereQueryTestBase` | 203 | ✓ | ✓ | Predicate filtering; core WHERE coverage |
 | `NorthwindSelectQueryTestBase` | 186 | ✓ | ✓ | Projections and SELECT shapes |
+| `NorthwindAsNoTrackingQueryTestBase` | 11 | ✗ | ✓ | `AsNoTracking()` passthrough; join/navigation-shaped cases skipped |
+| `NorthwindAsTrackingQueryTestBase` | 5 | ✗ | ✓ | `AsTracking()` on `IQueryable`; sync-only base tests assert async-only provider behavior |
+| `NorthwindQueryTaggingQueryTestBase` | 9 | ✗ | ✓ | `TagWith()` has no translation impact; sync-only base tests assert async-only provider behavior |
 
 ### Implement Next
 
-| Test Class | Methods | Cosmos | MongoDB | Feasibility | Rationale |
-|---|---:|:---:|:---:|---:|---|
-| `NorthwindAsNoTrackingQueryTestBase` | 11 | ✗ | ✓ | ~95% | `AsNoTracking()` is a passthrough for DynamoDB |
-| `NorthwindAsTrackingQueryTestBase` | 5 | ✗ | ✓ | ~95% | `AsTracking()` on `IQueryable`; trivial |
-| `NorthwindQueryTaggingQueryTestBase` | 9 | ✗ | ✓ | ~90% | `TagWith()` query comments; no translation impact |
+No Northwind query specification test classes are currently queued here.
 
 ### Future
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
@@ -22,6 +22,9 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(OverzealousInitializationTestBase<>);
         yield return typeof(QueryExpressionInterceptionTestBase);
         yield return typeof(SaveChangesInterceptionTestBase);
+        yield return typeof(NorthwindAsNoTrackingQueryTestBase<>);
+        yield return typeof(NorthwindAsTrackingQueryTestBase<>);
+        yield return typeof(NorthwindQueryTaggingQueryTestBase<>);
         yield return typeof(NorthwindSelectQueryTestBase<>);
         yield return typeof(NorthwindWhereQueryTestBase<>);
     }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindAsNoTrackingQueryDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindAsNoTrackingQueryDynamoTest.cs
@@ -1,0 +1,124 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query;
+
+/// <summary>Northwind AsNoTracking query specification tests for the DynamoDB provider.</summary>
+public abstract class NorthwindAsNoTrackingQueryDynamoTest
+    : NorthwindAsNoTrackingQueryTestBase<NorthwindQueryDynamoFixture<NoopModelCustomizer>>
+{
+    protected NorthwindAsNoTrackingQueryDynamoTest(NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture)
+        : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(NorthwindAsNoTrackingQueryDynamoTest));
+
+    public override Task Entity_not_added_to_state_manager(bool useParam, bool async)
+        => NoSyncTest(async, async a =>
+        {
+            await base.Entity_not_added_to_state_manager(useParam, a);
+            AssertSql(
+            """
+            SELECT "customerID", "address", "city", "companyName", "contactName", "contactTitle", "country", "fax", "phone", "postalCode", "region"
+            FROM "Customers"
+            """);
+        });
+
+    [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
+    public override Task Applied_to_body_clause(bool async)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
+    public override Task Applied_to_multiple_body_clauses(bool async)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
+    public override Task Applied_to_body_clause_with_projection(bool async)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
+    public override Task Applied_to_projection(bool async)
+        => Task.CompletedTask;
+
+    public override Task Can_get_current_values(bool async)
+        => NoSyncTest(async, async a =>
+        {
+            if (!a)
+            {
+                DynamoTestHelpers.Instance.NoSyncTest(() =>
+                {
+                    using var syncContext = CreateContext();
+                    _ = syncContext.Set<Customer>()
+                        .Where(c => c.CustomerID == "ALFKI")
+                        .AsNoTracking()
+                        .First();
+                });
+                return;
+            }
+
+            await using var context = CreateContext();
+            var customer = await context.Set<Customer>().FirstAsync(c => c.CustomerID == "ALFKI");
+            customer.CompanyName = "foo";
+            var customer2 = await context.Set<Customer>()
+                .AsNoTracking()
+                .FirstAsync(c => c.CustomerID == "ALFKI");
+
+            Assert.NotEqual(customer.CompanyName, customer2.CompanyName);
+        });
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Include_reference_and_collection(bool async)
+        => Task.CompletedTask;
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Applied_after_navigation_expansion(bool async)
+        => Task.CompletedTask;
+
+    public override Task Where_simple_shadow(bool async)
+        => NoSyncTest(async, async a =>
+        {
+            await base.Where_simple_shadow(a);
+            AssertSql(
+            """
+            SELECT "employeeID", "city", "country", "firstName", "reportsTo", "title"
+            FROM "Employees"
+            WHERE "title" = 'Sales Representative'
+            """);
+        });
+
+    public override Task Query_fast_path_when_ctor_binding(bool async)
+        => NoSyncTest(async, async a =>
+        {
+            await base.Query_fast_path_when_ctor_binding(a);
+            AssertSql(
+            """
+            SELECT "customerID", "address", "city", "companyName", "contactName", "contactTitle", "country", "fax", "phone", "postalCode", "region"
+            FROM "Customers"
+            """);
+        });
+
+    [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
+    public override Task SelectMany_simple(bool async)
+        => Task.CompletedTask;
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    private static Task NoSyncTest(bool async, Func<bool, Task> testCode)
+        => DynamoTestHelpers.Instance.NoSyncTest(async, testCode);
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class NorthwindAsNoTrackingQueryDynamoTestDefault : NorthwindAsNoTrackingQueryDynamoTest
+    {
+        public NorthwindAsNoTrackingQueryDynamoTestDefault(
+            NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindAsTrackingQueryDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindAsTrackingQueryDynamoTest.cs
@@ -1,0 +1,69 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query;
+
+/// <summary>Northwind AsTracking query specification tests for the DynamoDB provider.</summary>
+public abstract class NorthwindAsTrackingQueryDynamoTest
+    : NorthwindAsTrackingQueryTestBase<NorthwindQueryDynamoFixture<NoopModelCustomizer>>
+{
+    protected NorthwindAsTrackingQueryDynamoTest(NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture)
+        : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(NorthwindAsTrackingQueryDynamoTest));
+
+    public override void Entity_added_to_state_manager(bool useParam)
+    {
+        using var context = CreateContext();
+        var query = context.Set<Customer>().AsQueryable();
+
+        // The base spec is sync-only, but DynamoDB query execution is async-only.
+        var list = (useParam ? query.AsTracking(QueryTrackingBehavior.TrackAll) : query.AsTracking())
+            .ToListAsync()
+            .GetAwaiter()
+            .GetResult();
+
+        Assert.Equal(91, list.Count);
+        Assert.Equal(91, context.ChangeTracker.Entries().Count());
+        AssertSql(
+        """
+        SELECT "customerID", "address", "city", "companyName", "contactName", "contactTitle", "country", "fax", "phone", "postalCode", "region"
+        FROM "Customers"
+        """);
+    }
+
+    [ConditionalFact(Skip = SkipReason.JoinsNotSupported)]
+    public override void Applied_to_body_clause()
+        => base.Applied_to_body_clause();
+
+    [ConditionalFact(Skip = SkipReason.JoinsNotSupported)]
+    public override void Applied_to_multiple_body_clauses()
+        => base.Applied_to_multiple_body_clauses();
+
+    [ConditionalFact(Skip = SkipReason.JoinsNotSupported)]
+    public override void Applied_to_body_clause_with_projection()
+        => base.Applied_to_body_clause_with_projection();
+
+    [ConditionalFact(Skip = SkipReason.JoinsNotSupported)]
+    public override void Applied_to_projection()
+        => base.Applied_to_projection();
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class NorthwindAsTrackingQueryDynamoTestDefault : NorthwindAsTrackingQueryDynamoTest
+    {
+        public NorthwindAsTrackingQueryDynamoTestDefault(
+            NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindQueryTaggingQueryDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindQueryTaggingQueryDynamoTest.cs
@@ -1,0 +1,90 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query;
+
+/// <summary>Northwind query-tagging specification tests for the DynamoDB provider.</summary>
+public abstract class NorthwindQueryTaggingQueryDynamoTest
+    : NorthwindQueryTaggingQueryTestBase<NorthwindQueryDynamoFixture<NoopModelCustomizer>>
+{
+    protected NorthwindQueryTaggingQueryDynamoTest(NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture)
+        : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(NorthwindQueryTaggingQueryDynamoTest));
+
+    public override void Single_query_tag()
+        => AssertTaggedCustomer("Yanni");
+
+    public override void Single_query_multiple_tags()
+        => AssertTaggedCustomer("Yanni", "Enya");
+
+    public override void Duplicate_tags()
+        => AssertTaggedCustomer("Yanni", "Yanni");
+
+    [ConditionalFact(Skip = SkipReason.JoinsNotSupported)]
+    public override void Tags_on_subquery()
+        => base.Tags_on_subquery();
+
+    [ConditionalFact(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override void Tag_on_include_query()
+        => base.Tag_on_include_query();
+
+    public override void Tag_on_scalar_query()
+    {
+        using var context = CreateContext();
+        // The base spec orders without constraining the partition key, which DynamoDB cannot
+        // execute. Keep the OrderBy while adding the key predicate required for a safe First* path.
+        var orderDate = context.Set<Order>()
+            .Where(o => o.OrderID == 10248)
+            .OrderBy(o => o.OrderID)
+            .Select(o => o.OrderDate)
+            .TagWith("Yanni")
+            .FirstAsync()
+            .GetAwaiter()
+            .GetResult();
+
+        Assert.NotNull(orderDate);
+    }
+
+    public override void Single_query_multiline_tag()
+        => AssertTaggedCustomer("Yanni\r\nAND\r\nLaurel");
+
+    public override void Single_query_multiple_multiline_tag()
+        => AssertTaggedCustomer("Yanni\r\nAND\r\nLaurel", "Yet\r\nAnother\r\nMultiline\r\nTag");
+
+    public override void Single_query_multiline_tag_with_empty_lines()
+        => AssertTaggedCustomer("Yanni\r\n\r\nAND\r\n\r\nLaurel");
+
+    private void AssertTaggedCustomer(params string[] tags)
+    {
+        using var context = CreateContext();
+
+        // The base spec orders before First(), but DynamoDB requires a partition-key predicate for
+        // ORDER BY. The predicate preserves a key-only First* path while keeping the ordered shape.
+        IQueryable<Customer> query = context.Set<Customer>()
+            .Where(c => c.CustomerID == "ALFKI")
+            .OrderBy(c => c.CustomerID);
+        foreach (var tag in tags)
+            query = query.TagWith(tag);
+
+        var customer = query.FirstAsync().GetAwaiter().GetResult();
+        Assert.NotNull(customer);
+    }
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class NorthwindQueryTaggingQueryDynamoTestDefault : NorthwindQueryTaggingQueryDynamoTest
+    {
+        public NorthwindQueryTaggingQueryDynamoTestDefault(
+            NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -15,6 +15,9 @@ public static class SkipReason
     public const string NavigationPropertiesNotSupported =
         "DynamoDB does not support navigation properties.";
 
+    public const string JoinsNotSupported =
+        "DynamoDB PartiQL does not support joins.";
+
     public const string TransactionsNotSupported =
         "DynamoDB provider does not support explicit EF Core transaction scopes via Database.BeginTransaction().";
 


### PR DESCRIPTION
## Summary

Adds DynamoDB provider specification coverage for Northwind tracking and query-tagging behavior. The new tests cover `AsNoTracking()`, `AsTracking()`, and `TagWith()` where those query shapes are meaningful for DynamoDB, with explicit skips for join/navigation cases that remain unsupported.

## Changes

- Added `NorthwindAsNoTrackingQueryDynamoTest` with async coverage, SQL baselines, no-tracking current-value behavior, and explicit unsupported join/navigation skips.
- Added `NorthwindAsTrackingQueryDynamoTest` with tracking state-manager validation and join-shape skips.
- Added `NorthwindQueryTaggingQueryDynamoTest` with tag passthrough coverage and DynamoDB-safe query shapes.
- Registered the new spec bases in `ComplianceDynamoTest` and added a shared join skip reason.
- Moved these classes from Implement Next to Implemented in `docs/spec-test-coverage.md`.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --no-restore --filter "FullyQualifiedName~NorthwindAsNoTrackingQueryDynamoTest|FullyQualifiedName~NorthwindAsTrackingQueryDynamoTest|FullyQualifiedName~NorthwindQueryTaggingQueryDynamoTest|FullyQualifiedName~ComplianceDynamoTest"`
  - Passed: 36 total, 23 succeeded, 13 skipped, 0 failed
