### PR TITLE
ci(github): add version-template to release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,8 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 commitish: main
 
+version-template: '10.0.0'
+
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
## Summary

Adds `version-template: '10.0.0'` to `.github/release-drafter.yml` so release-drafter uses the correct base version when resolving the next release version.

## Changes

- `.github/release-drafter.yml` — added `version-template` field

## Validation

Config-only change; release-drafter will pick it up on the next draft run.