### PR TITLE
test(tests): add near-term specification coverage

### DIFF
--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -45,6 +45,7 @@ change tracking, concurrency, Find, value converters, interceptors, and more.
 | `SaveChangesInterceptionTestBase` | 13 | ✗ | ✗ | Transaction-dependent cases are explicitly skipped |
 | `QueryExpressionInterceptionTestBase` | 4 | ✓ | ✗ | `Single`-based query shapes are explicitly skipped |
 | `MaterializationInterceptionTestBase` | 7 | ✓ | ✗ | Materialization interceptor coverage; owned/complex collection cases skipped |
+| `CompositeKeyEndToEndTestBase` | 3 | ✗ | ✗ | PK+SK round-trip covered; three-part composite-key cases skipped |
 
 ### Implement Next
 
@@ -66,7 +67,6 @@ Feasible but requires investigation or additional provider work before adding.
 | `StoreGeneratedTestBase` | 58 | ✗ | ✗ | ~50% | Store-generated keys and concurrency tokens; partially supported (DynamoDB auto-generates string PKs but not sequences) |
 | `DataAnnotationTestBase` | 84 | ✗ | ✗ | ~40% | Attribute-driven model configuration; many tests exercise relational-only annotations (schema, unique indexes, FK attributes) |
 | `FieldMappingTestBase` | 101 | ✗ | ✗ | ~40% | Backing field mapping; basic field mapping works but tests assume relational load scenarios |
-| `CompositeKeyEndToEndTestBase` | 3 | ✗ | ✗ | ~70% | Composite PK round-trips (PK + SK); DynamoDB supports two-part keys; three tests |
 
 ### Skip — Architectural Constraints
 
@@ -124,6 +124,7 @@ Uses the `Customer / Employee / Order / Product` dataset with `NorthwindQueryDyn
 | `NorthwindAsTrackingQueryTestBase` | 5 | ✗ | ✓ | `AsTracking()` on `IQueryable`; sync-only base tests assert async-only provider behavior |
 | `NorthwindQueryTaggingQueryTestBase` | 9 | ✗ | ✓ | `TagWith()` has no translation impact; sync-only base tests assert async-only provider behavior |
 | `NorthwindChangeTrackingQueryTestBase` | 17 | ✗ | ✓ | Query tracking behavior and state transitions; join-shaped modifier-precedence cases skipped |
+| `NorthwindFunctionsQueryTestBase` | 10 | ✓ | ✓ | Static equality function covered; navigation/unsupported function cases skipped |
 
 ### Implement Next
 
@@ -133,7 +134,6 @@ No Northwind query specification test classes are currently queued here.
 
 | Test Class | Methods | Cosmos | MongoDB | Feasibility | Blocker |
 |---|---:|:---:|:---:|---:|---|
-| `NorthwindFunctionsQueryTestBase` | 10 | ✓ | ✓ | ~70% | Math/string functions in WHERE; PartiQL coverage is partial |
 | `NorthwindQueryFiltersQueryTestBase` | 17 | ✗ | ✓ | ~65% | Global `HasQueryFilter`; feasible but not yet validated at scale |
 | `NorthwindDbFunctionsQueryTestBase` | 5 | ✓ | ✓ | ~60% | `EF.Functions.*`; small surface, mostly skippable |
 | `NorthwindMiscellaneousQueryTestBase` | 469 | ✓ | ✓ | ~35% | Very broad: Take/Skip, cast, null semantics, subqueries, async patterns; too many unsupported operators — below 70% threshold until core coverage matures |
@@ -281,12 +281,12 @@ translations are low-feasibility until dedicated temporal translation support is
 
 | Category | Implemented | Implement Next | Future | Skip |
 |---|---:|---:|---:|---:|
-| Non-Query (top-level) | 13 classes / 305 methods | — | 11 classes / ~535 methods | 19 classes / ~985 methods |
-| BulkUpdates | — | — | 4 classes / 135 methods | 2 classes / 33 methods |
-| Northwind Query | 6 classes / 431 methods | — | 4 classes / 501 methods | 9 classes / ~924 methods |
-| Other Query | — | — | 13 classes / ~465 methods | 16 classes / ~1,680 methods |
-| Associations | — | — | 3 classes / 8 methods | 12+ classes / 80+ methods |
-| Translations (need fixture) | — | — | 16 classes / ~331 methods | — |
+| Non-Query (top-level) | 14 classes / 308 methods | — | 10 classes / 532 methods | 19 classes / 984 methods |
+| BulkUpdates | — | — | 5 classes / 135+ methods | 1 class / 33 methods |
+| Northwind Query | 7 classes / 441 methods | — | 3 classes / 491 methods | 12 classes / 924+ methods |
+| Other Query | — | — | 13 classes / 465 methods | 16 classes / 1,683 methods |
+| Associations | — | — | 3 classes / 8 methods | 13+ classes / 123+ methods |
+| Translations (need fixture) | — | — | 16 classes / 321 methods | — |
 
 ---
 
@@ -302,11 +302,12 @@ translations are low-feasibility until dedicated temporal translation support is
 6. `NorthwindAsTrackingQueryDynamoTest` — 5 methods
 7. `NorthwindQueryTaggingQueryDynamoTest` — 9 methods
 8. `NorthwindChangeTrackingQueryDynamoTest` — 17 methods
+9. `CompositeKeyEndToEndDynamoTest` — 3 methods
+10. `NorthwindFunctionsQueryDynamoTest` — 10 methods
 
 ### Near-term (small, high confidence)
 
-9. `CompositeKeyEndToEndDynamoTest` — 3 methods (validates PK+SK)
-10. `NorthwindFunctionsQueryDynamoTest` — targeted subset of supported string-function methods
+No near-term specification test classes are currently queued here.
 
 ### Medium-term (requires investigation or new fixture)
 
@@ -327,7 +328,7 @@ translations are low-feasibility until dedicated temporal translation support is
 
 | Status | Classes | Methods |
 |---|---:|---:|
-| Implemented | 19 | 736 |
+| Implemented | 21 | 749 |
 | Implement Next | 0 | 0 |
-| Future | 51 | ~1,975 |
-| Skip | 58+ | ~3,702+ |
+| Future | 50 | 1,956+ |
+| Skip | 61+ | 3,747+ |

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
@@ -13,6 +13,7 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(ApiConsistencyTestBase<>);
         yield return typeof(BuiltInDataTypesTestBase<>);
         yield return typeof(ComplexTypesTrackingTestBase<>);
+        yield return typeof(CompositeKeyEndToEndTestBase<>);
         yield return typeof(ComplianceTestBase);
         yield return typeof(ConcurrencyDetectorDisabledTestBase<>);
         yield return typeof(ConcurrencyDetectorEnabledTestBase<>);
@@ -25,6 +26,7 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(NorthwindAsNoTrackingQueryTestBase<>);
         yield return typeof(NorthwindAsTrackingQueryTestBase<>);
         yield return typeof(NorthwindChangeTrackingQueryTestBase<>);
+        yield return typeof(NorthwindFunctionsQueryTestBase<>);
         yield return typeof(NorthwindQueryTaggingQueryTestBase<>);
         yield return typeof(NorthwindSelectQueryTestBase<>);
         yield return typeof(NorthwindWhereQueryTestBase<>);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/CompositeKeyEndToEndDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/CompositeKeyEndToEndDynamoTest.cs
@@ -1,0 +1,119 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+/// <summary>Composite-key end-to-end specification tests for the DynamoDB provider.</summary>
+public abstract class CompositeKeyEndToEndDynamoTest
+    : CompositeKeyEndToEndTestBase<CompositeKeyEndToEndDynamoTest.CompositeKeyEndToEndDynamoFixture>
+{
+    protected CompositeKeyEndToEndDynamoTest(CompositeKeyEndToEndDynamoFixture fixture)
+        : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(CompositeKeyEndToEndDynamoTest));
+
+    [ConditionalFact(Skip = SkipReason.ThreePartCompositeKeysNotSupported)]
+    public override Task Can_use_two_non_generated_integers_as_composite_key_end_to_end()
+        => base.Can_use_two_non_generated_integers_as_composite_key_end_to_end();
+
+    [ConditionalFact(Skip = SkipReason.ThreePartCompositeKeysNotSupported)]
+    public override Task Can_use_generated_values_in_composite_key_end_to_end()
+        => base.Can_use_generated_values_in_composite_key_end_to_end();
+
+    public override async Task Only_one_part_of_a_composite_key_needs_to_vary_for_uniqueness()
+    {
+        // The base test uses sync enumeration and aggregate Count(). DynamoDB query execution is
+        // async-only and does not translate query aggregates, so this keeps the same end-to-end
+        // scenario with async reads and intentional scans.
+        int[] ids;
+        await using (var context = CreateContext())
+        {
+            var pony1 = context.EarthPonies.Add(new EarthPony { Id1 = 1, Id2 = 7, Name = "Apple Jack 1" }).Entity;
+            var pony2 = context.EarthPonies.Add(new EarthPony { Id1 = 2, Id2 = 7, Name = "Apple Jack 2" }).Entity;
+            var pony3 = context.EarthPonies.Add(new EarthPony { Id1 = 3, Id2 = 7, Name = "Apple Jack 3" }).Entity;
+
+            await context.SaveChangesAsync();
+            ids = [pony1.Id1, pony2.Id1, pony3.Id1];
+        }
+
+        await using (var context = CreateContext())
+        {
+            var list = await context.EarthPonies.AllowScan().ToListAsync();
+            Assert.Equal(list.Count, list.Count(e => e.Name == "Apple Jack 1") * 3);
+            Assert.Equal("Apple Jack 1", list.Single(e => e.Id1 == ids[0]).Name);
+            Assert.Equal("Apple Jack 2", list.Single(e => e.Id1 == ids[1]).Name);
+            Assert.Equal("Apple Jack 3", list.Single(e => e.Id1 == ids[2]).Name);
+            list.Single(e => e.Id1 == ids[1]).Name = "Pinky Pie 2";
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = CreateContext())
+        {
+            var array = await context.EarthPonies.AllowScan().ToArrayAsync();
+            Assert.Equal(array.Length, array.Count(e => e.Name == "Apple Jack 1") * 3);
+            Assert.Equal("Apple Jack 1", array.Single(e => e.Id1 == ids[0]).Name);
+            Assert.Equal("Pinky Pie 2", array.Single(e => e.Id1 == ids[1]).Name);
+            Assert.Equal("Apple Jack 3", array.Single(e => e.Id1 == ids[2]).Name);
+            context.EarthPonies.RemoveRange(array);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = CreateContext())
+        {
+            Assert.Empty(await context.EarthPonies.AllowScan().ToListAsync());
+        }
+    }
+
+    public class CompositeKeyEndToEndDynamoFixture
+        : CompositeKeyEndToEndFixtureBase, IDynamoSpecificationFixture
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        protected override Type ContextType { get; } = typeof(DynamoBronieContext);
+
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder)
+                .UseDynamo(options => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
+        }
+    }
+
+    protected class DynamoBronieContext(DbContextOptions options) : BronieContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Keep only the two-part key entity. Ignoring the base type does not cascade to the
+            // derived types, so each unsupported three-part-key type is ignored explicitly.
+            modelBuilder.Ignore<Flyer>();
+            modelBuilder.Ignore<Pegasus>();
+            modelBuilder.Ignore<Unicorn>();
+            modelBuilder.Entity<EarthPony>()
+                .ToTable("EarthPonies")
+                .HasPartitionKey(e => e.Id1)
+                .HasSortKey(e => e.Id2);
+        }
+    }
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class CompositeKeyEndToEndDynamoTestDefault : CompositeKeyEndToEndDynamoTest
+    {
+        public CompositeKeyEndToEndDynamoTestDefault(
+            CompositeKeyEndToEndDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindFunctionsQueryDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/NorthwindFunctionsQueryDynamoTest.cs
@@ -1,0 +1,81 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query;
+
+/// <summary>Northwind function-query specification tests for the DynamoDB provider.</summary>
+public abstract class NorthwindFunctionsQueryDynamoTest
+    : NorthwindFunctionsQueryTestBase<NorthwindQueryDynamoFixture<NoopModelCustomizer>>
+{
+    protected NorthwindFunctionsQueryDynamoTest(NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture)
+        : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(NorthwindFunctionsQueryDynamoTest));
+
+    [ConditionalTheory(Skip = SkipReason.EntityTypeNotMappedInFixture)]
+    public override Task Client_evaluation_of_uncorrelated_method_call(bool async)
+        => base.Client_evaluation_of_uncorrelated_method_call(async);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    public override Task Order_by_length_twice(bool async)
+        => base.Order_by_length_twice(async);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool async)
+        => base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(async);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Sum_over_round_works_correctly_in_projection(bool async)
+        => base.Sum_over_round_works_correctly_in_projection(async);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Sum_over_round_works_correctly_in_projection_2(bool async)
+        => base.Sum_over_round_works_correctly_in_projection_2(async);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Sum_over_truncate_works_correctly_in_projection(bool async)
+        => base.Sum_over_truncate_works_correctly_in_projection(async);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    public override Task Sum_over_truncate_works_correctly_in_projection_2(bool async)
+        => base.Sum_over_truncate_works_correctly_in_projection_2(async);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    public override Task Where_functions_nested(bool async)
+        => base.Where_functions_nested(async);
+
+    public override Task Static_equals_nullable_datetime_compared_to_non_nullable(bool async)
+        => NoSyncTest(async, async a =>
+        {
+            await base.Static_equals_nullable_datetime_compared_to_non_nullable(a);
+            AssertSql(
+            """
+            SELECT "orderID", "customerID", "employeeID", "orderDate"
+            FROM "Orders"
+            WHERE "orderDate" = ?
+            """);
+        });
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    public override Task Static_equals_int_compared_to_long(bool async)
+        => base.Static_equals_int_compared_to_long(async);
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    private static Task NoSyncTest(bool async, Func<bool, Task> testCode)
+        => DynamoTestHelpers.Instance.NoSyncTest(async, testCode);
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class NorthwindFunctionsQueryDynamoTestDefault : NorthwindFunctionsQueryDynamoTest
+    {
+        public NorthwindFunctionsQueryDynamoTestDefault(
+            NorthwindQueryDynamoFixture<NoopModelCustomizer> fixture,
+            DynamoSpecificationContainerFixture containerFixture)
+            : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -18,6 +18,12 @@ public static class SkipReason
     public const string JoinsNotSupported =
         "DynamoDB PartiQL does not support joins.";
 
+    public const string EntityTypeNotMappedInFixture =
+        "This entity type is not mapped in the DynamoDB specification test fixture.";
+
+    public const string ThreePartCompositeKeysNotSupported =
+        "DynamoDB table keys support only a partition key and optional sort key.";
+
     public const string TransactionsNotSupported =
         "DynamoDB provider does not support explicit EF Core transaction scopes via Database.BeginTransaction().";
 


### PR DESCRIPTION
## Summary

Adds the remaining near-term EF Core specification coverage for the DynamoDB provider. This implements the composite-key end-to-end spec where it maps to DynamoDB's PK+SK model and adds Northwind function-query spec coverage with explicit skips for unsupported navigation/function shapes.

## Changes

- Added `CompositeKeyEndToEndDynamoTest` with a DynamoDB-specific context using `HasPartitionKey(...)` and `HasSortKey(...)`.
- Added `NorthwindFunctionsQueryDynamoTest` with explicit overrides for all inherited methods.
- Added skip reasons for three-part composite keys and `GROUP BY`.
- Registered the new spec bases in `ComplianceDynamoTest`.
- Updated `docs/spec-test-coverage.md` to move both near-term items into Implemented, empty the near-term bucket, and refresh totals.

## Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --no-restore --filter "FullyQualifiedName~NorthwindFunctionsQueryDynamoTest|FullyQualifiedName~CompositeKeyEndToEndDynamoTest|FullyQualifiedName~NorthwindChangeTrackingQueryDynamoTest|FullyQualifiedName~ComplianceDynamoTest"`
  - Passed: 35 total, 21 succeeded, 14 skipped, 0 failed
