### PR TITLE
test(dynamodb): add value converter spec coverage

### DIFF
--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -50,6 +50,7 @@ change tracking, concurrency, Find, value converters, interceptors, and more.
 | `ConvertToProviderTypesTestBase`      |       2 |   ✗    |    ✗    | Additional enum/provider-type conversion query methods beyond `BuiltInDataTypesTestBase` |
 | `CustomConvertersTestBase`            |      29 |   ✓    |    ✗    | Value converter round-trips; unsupported converter edge cases explicitly skipped |
 | `SeedingTestBase`                     |       2 |   ✗    |    ✗    | `HasData` seeding is covered; keyless entity seeding is skipped because DynamoDB requires partition keys |
+| `ValueConvertersEndToEndTestBase`     |       1 |   ✗    |    ✗    | End-to-end converter insert/readback; DynamoDB fixture maps `ConvertingEntity` with partition key |
 
 ### Implement Next
 
@@ -62,7 +63,6 @@ Feasible but requires investigation or additional provider work before adding.
 | Test Class                        | Methods | Cosmos | MongoDB | Feasibility | Blocker                                                                                                                                                                                             |
 | --------------------------------- | ------: | :----: | :-----: | ----------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `KeysWithConvertersTestBase`      |      47 |   ✓    |    ✗    |        ~70% | Keys that pass through value converters; type mapping validation needed                                                                                                                             |
-| `ValueConvertersEndToEndTestBase` |       1 |   ✗    |    ✗    |        ~80% | Single E2E converter test; base-test `SingleAsync` shape must be adapted to provider key-condition constraints                                                                                      |
 | `WithConstructorsTestBase`        |      41 |   ✗    |    ✗    |        ~70% | Entities using non-default constructors; DynamoDB materializes via EF's normal pipeline                                                                                                             |
 | `PropertyValuesTestBase`          |     167 |   ✗    |    ✗    |        ~55% | `CurrentValues`/`OriginalValues`/`GetDatabaseValues`; `GetDatabaseValues` requires a read which DynamoDB supports, but relational semantics for shadow keys and navigation tracking reduce coverage |
 | `StoreGeneratedTestBase`          |      58 |   ✗    |    ✗    |        ~50% | Store-generated keys and concurrency tokens; partially supported (DynamoDB auto-generates string PKs but not sequences)                                                                             |

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -823,11 +823,15 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
         if (valueExpression.Type != type)
             valueExpression = Convert(valueExpression, type);
 
+        var nullValueExpression = dynamoTypeMapping.Converter?.ConvertsNulls == true
+            ? valueExpression
+            : nullReturnExpression;
+
         // item.TryGetValue(...) ? (isDynamoNull ? (required?throw:default) : value) :
         // (required?throw:default)
         var completeExpression = Condition(
             tryGetValueExpression,
-            Condition(isDynamoNullExpression, nullReturnExpression, valueExpression),
+            Condition(isDynamoNullExpression, nullValueExpression, valueExpression),
             missingReturnExpression);
 
         return Block([attributeValueVariable], completeExpression);

--- a/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/Internal/DynamoValueReaderWriter.cs
@@ -172,7 +172,13 @@ internal sealed class DynamoConvertedValueReaderWriter<TModel, TProvider>(
         => innerReaderWriter;
 
     internal override bool HasValue(AttributeValue attributeValue)
-        => innerReaderWriter.HasValue(attributeValue);
+    {
+        if (attributeValue is null)
+            return converter.ConvertsNulls;
+
+        return innerReaderWriter.HasValue(attributeValue)
+            || (converter.ConvertsNulls && attributeValue.NULL == true);
+    }
 
     internal override Expression CreateReadExpression(
         Expression attributeValueExpression,
@@ -196,8 +202,16 @@ internal sealed class DynamoConvertedValueReaderWriter<TModel, TProvider>(
         AttributeValue attributeValue,
         string propertyPath,
         IProperty? property)
-        => (TModel)converter.ConvertFromProvider(
-            innerReaderWriter.Read(attributeValue, propertyPath, true, property))!;
+    {
+        var providerValue =
+            attributeValue is not null
+            && attributeValue.NULL != true
+            && innerReaderWriter.HasValue(attributeValue)
+                ? innerReaderWriter.Read(attributeValue, propertyPath, true, property)
+                : default;
+
+        return (TModel)converter.ConvertFromProvider(providerValue)!;
+    }
 
     public override AttributeValue Write(TModel value)
         => innerReaderWriter.Write((TProvider)converter.ConvertToProvider(value)!);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
@@ -8,7 +8,7 @@ those tests run against a real DynamoDB Local instance.
 ## Shared Infrastructure
 
 | File                                                   | Role                                                                                                                         |
-|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `TestUtilities/DynamoSpecificationContainerFixture.cs` | Shared DynamoDB Local container (Testcontainers). Started asynchronously by spec test infrastructure and disposed after use. |
 | `TestUtilities/DynamoTestStoreFactory.cs`              | Singleton factory. Plugs into EF Core test infra; vends `DynamoTestStore` and `TestSqlLoggerFactory`.                        |
 | `TestUtilities/DynamoTestStore.cs`                     | Per-test store backed by the shared container client.                                                                        |
@@ -84,7 +84,27 @@ public abstract class XxxDynamoTest : XxxTestBase<XxxDynamoTest.XxxDynamoFixture
 }
 ```
 
-### 3. Handle overrides
+### 3. Update tracking files
+
+When adding or removing a DynamoDB implementation of an EF Core spec test base, update both tracking
+files in the same change:
+
+1. `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs`
+
+   - Add the EF Core spec base type to `GetBaseTestClasses()` when a concrete DynamoDB test exists.
+   - Use the upstream base type, e.g. `ValueConvertersEndToEndTestBase<>`, not the DynamoDB concrete test type.
+   - Remove entries only when the provider implementation is removed.
+
+2. `docs/spec-test-coverage.md`
+
+   - Move the spec base between `Implemented`, `Implement Next`, `Future`, or `Skip` as status changes.
+   - Keep method counts and notes accurate.
+   - Mention DynamoDB-specific limitations or fixture adaptations in user-facing terms.
+
+These files are compliance/documentation inventory. Keep them synchronized so `ComplianceDynamoTest`
+and the coverage docs tell the same story.
+
+### 4. Handle overrides
 
 Every specification test class must include `Check_all_tests_overridden` and call
 `DynamoTestHelpers.AssertAllTestMethodsOverridden(typeof(CurrentDynamoTestBase))`. Use the provider
@@ -134,7 +154,7 @@ public override async Task Some_async_test(CancellationType ct)
 ## Known DynamoDB Limitations
 
 | Feature        | Skip reason                                   |
-|----------------|-----------------------------------------------|
+| -------------- | --------------------------------------------- |
 | Composite keys | `"DynamoDB does not support composite keys."` |
 | Nullable keys  | `"DynamoDB does not support nullable keys."`  |
 | Shadow keys    | `"DynamoDB does not support shadow keys."`    |

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
@@ -27,6 +27,7 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(QueryExpressionInterceptionTestBase);
         yield return typeof(SaveChangesInterceptionTestBase);
         yield return typeof(SeedingTestBase);
+        yield return typeof(ValueConvertersEndToEndTestBase<>);
         yield return typeof(NorthwindAsNoTrackingQueryTestBase<>);
         yield return typeof(NorthwindAsTrackingQueryTestBase<>);
         yield return typeof(NorthwindChangeTrackingQueryTestBase<>);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ValueConvertersEndToEndDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ValueConvertersEndToEndDynamoTest.cs
@@ -1,0 +1,50 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
+
+public abstract class ValueConvertersEndToEndDynamoTest(
+    ValueConvertersEndToEndDynamoTest.ValueConvertersEndToEndDynamoFixture fixture)
+    : ValueConvertersEndToEndTestBase<
+        ValueConvertersEndToEndDynamoTest.ValueConvertersEndToEndDynamoFixture>(fixture)
+{
+    public override Task Can_insert_and_read_back_with_conversions(int[] valueOrder)
+        => base.Can_insert_and_read_back_with_conversions(valueOrder);
+
+    public class ValueConvertersEndToEndDynamoFixture
+        : ValueConvertersEndToEndFixtureBase, IDynamoSpecificationFixture
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base
+                .AddOptions(builder)
+                .UseDynamo(options
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder
+                .Entity<ConvertingEntity>()
+                .ToTable("ConvertingEntities")
+                .HasPartitionKey(e => e.Id);
+        }
+    }
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class ValueConvertersEndToEndDynamoTestDefault : ValueConvertersEndToEndDynamoTest
+    {
+        public ValueConvertersEndToEndDynamoTestDefault(
+            ValueConvertersEndToEndDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+    }
+}


### PR DESCRIPTION
## 📋 Summary

Adds DynamoDB coverage for EF Core's end-to-end value converter specification test. The new spec test exposed missing null-converter handling in the provider, so this PR includes the small runtime fix needed for the coverage to pass.

## 📝 Changes

- Add `ValueConvertersEndToEndDynamoTest` for insert/readback value converter coverage.
- Register `ValueConvertersEndToEndTestBase<>` in `ComplianceDynamoTest`.
- Track `ValueConvertersEndToEndTestBase` as implemented in `docs/spec-test-coverage.md`.
- Document spec-test tracking expectations in `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md`.
- Support DynamoDB `NULL` attributes with configured converters that convert nulls.
- Preserve nullable projection behavior when removing DynamoDB projection bindings.

## 🧪 Validation

- `dotnet test --project tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --filter "FullyQualifiedName~ComplianceDynamoTest"`
