### PR TITLE
test: add comparison translation spec coverage

### DIFF
--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -38,7 +38,6 @@ change tracking, concurrency, Find, value converters, interceptors, and more.
 | `ComplexTypesTrackingTestBase`        |     128 |   ✓    |    ✗    | Complex type change tracking; DynamoDB complex types fully supported         |
 | `ConcurrencyDetectorDisabledTestBase` |       1 |   ✓    |    ✗    | `ConcurrencyDetector` opt-out                                                |
 | `ConcurrencyDetectorEnabledTestBase`  |       1 |   ✓    |    ✗    | `ConcurrencyDetector` opt-in                                                 |
-| `OptimisticConcurrencyTestBase`       |      33 |   ✓    |    ✗    | ETag / version token concurrency                                             |
 | `FindTestBase`                        |      69 |   ✓    |    ✗    | `Find`/`FindAsync` by primary key                                            |
 | `ComplianceTestBase`                  |       1 |   ✗    |    ✗    | Compliance marker for implemented provider spec bases                        |
 | `OverzealousInitializationTestBase`   |       1 |   ✓    |    ✗    | Navigation-based fixup test is explicitly skipped                            |
@@ -53,6 +52,8 @@ change tracking, concurrency, Find, value converters, interceptors, and more.
 | `ValueConvertersEndToEndTestBase`     |       1 |   ✗    |    ✗    | End-to-end converter insert/readback; DynamoDB fixture maps `ConvertingEntity` with partition key |
 | `KeysWithConvertersTestBase`          |      47 |   ✓    |    ✗    | Converted partition-key mapping has DynamoDB-specific coverage; inherited FK, shadow-FK, and owned-entity cases are explicitly skipped |
 
+Additional provider-specific coverage: `DynamoConcurrencyTest` has 6 local tests for DynamoDB optimistic concurrency behavior. It intentionally does not inherit `OptimisticConcurrencyTestBase` because DynamoDB concurrency semantics differ from the EF Core spec fixture.
+
 ### Implement Next
 
 No non-query specification test classes are currently queued here.
@@ -63,7 +64,6 @@ Feasible but requires investigation or additional provider work before adding.
 
 | Test Class                        | Methods | Cosmos | MongoDB | Feasibility | Blocker                                                                                                                                                                                             |
 | --------------------------------- | ------: | :----: | :-----: | ----------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `KeysWithConvertersTestBase`      |      47 |   ✓    |    ✗    |        ~70% | Keys that pass through value converters; type mapping validation needed                                                                                                                             |
 | `WithConstructorsTestBase`        |      41 |   ✗    |    ✗    |        ~70% | Entities using non-default constructors; DynamoDB materializes via EF's normal pipeline                                                                                                             |
 | `PropertyValuesTestBase`          |     167 |   ✗    |    ✗    |        ~55% | `CurrentValues`/`OriginalValues`/`GetDatabaseValues`; `GetDatabaseValues` requires a read which DynamoDB supports, but relational semantics for shadow keys and navigation tracking reduce coverage |
 | `StoreGeneratedTestBase`          |      58 |   ✗    |    ✗    |        ~50% | Store-generated keys and concurrency tokens; partially supported (DynamoDB auto-generates string PKs but not sequences)                                                                             |
@@ -74,6 +74,7 @@ Feasible but requires investigation or additional provider work before adding.
 
 | Test Class                                 | Methods | Cosmos | MongoDB | Reason                                                                     |
 | ------------------------------------------ | ------: | :----: | :-----: | -------------------------------------------------------------------------- |
+| `OptimisticConcurrencyTestBase`            |      33 |   ✓    |    ✗    | Covered by provider-specific `DynamoConcurrencyTest`; EF spec fixture semantics do not match DynamoDB concurrency |
 | `LazyLoadTestBase`                         |      97 |   ✗    |    ✗    | Lazy loading requires navigation property support                          |
 | `LazyLoadProxyTestBase`                    |      75 |   ✗    |    ✗    | Lazy load via proxies; requires navigations                                |
 | `LoadTestBase`                             |     106 |   ✗    |    ✗    | Explicit/implicit load operations; navigation-dependent                    |
@@ -244,15 +245,22 @@ ______________________________________________________________________
 
 ## Translations Tests
 
-These tests use the `BasicTypesModel` fixture (separate from Northwind). A dedicated
-`BasicTypesDynamoFixture` must be created before any translation tests can be added.
+These tests use the `BasicTypesModel` fixture (separate from Northwind). The shared
+`BasicTypesQueryDynamoFixture` now covers DynamoDB translation tests over scalar CLR types.
 Cosmos DB implements all translation categories; MongoDB implements none.
 
 ### Operators
 
+#### Implemented
+
+| Test Class                               | Methods | Cosmos | Notes                                                      |
+| ---------------------------------------- | ------: | :----: | ---------------------------------------------------------- |
+| `ComparisonOperatorTranslationsTestBase` |       6 |   ✓    | Equal, not-equal, less/greater-than; core PartiQL comparisons |
+
+#### Future
+
 | Test Class                                  | Methods | Cosmos | Feasibility | Notes                                                             |
 | ------------------------------------------- | ------: | :----: | ----------: | ----------------------------------------------------------------- |
-| `ComparisonOperatorTranslationsTestBase`    |       6 |   ✓    |        ~95% | `<`, `<=`, `>`, `>=`, `==`, `!=`; core PartiQL comparisons        |
 | `LogicalOperatorTranslationsTestBase`       |       6 |   ✓    |        ~95% | `AND`, `OR`, `NOT`; supported                                     |
 | `ArithmeticOperatorTranslationsTestBase`    |       5 |   ✓    |        ~80% | `+`, `-`, `*`, `/`, `%`; PartiQL arithmetic on numerics           |
 | `MiscellaneousOperatorTranslationsTestBase` |       2 |   ✓    |        ~70% | Miscellaneous operators; mostly translatable                      |
@@ -288,16 +296,18 @@ ______________________________________________________________________
 
 | Category                    |              Implemented | Implement Next |                   Future |                       Skip |
 | --------------------------- | -----------------------: | -------------: | -----------------------: | -------------------------: |
-| Non-Query (top-level)       | 18 classes / 388 methods |              — |  6 classes / 452 methods |   19 classes / 984 methods |
+| Non-Query (top-level)       | 18 classes / 356 methods |              — |  5 classes / 451 methods | 20 classes / 1,017 methods |
 | BulkUpdates                 |                        — |              — | 5 classes / 135+ methods |       1 class / 33 methods |
 | Northwind Query             |  7 classes / 441 methods |              — |  3 classes / 491 methods |  12 classes / 924+ methods |
-| Other Query                 |  1 class / 74 methods |              — | 12 classes / 389 methods | 16 classes / 1,683 methods |
+| Other Query                 |   1 class / 74 methods |              — | 12 classes / 389 methods | 16 classes / 1,683 methods |
 | Associations                |                        — |              — |    3 classes / 8 methods | 13+ classes / 123+ methods |
-| Translations (need fixture) |                        — |              — | 16 classes / 321 methods |                          — |
+| Translations                |    1 class / 6 methods |              — | 15 classes / 315 methods |                          — |
 
 ______________________________________________________________________
 
-## Implementation Order
+## Recent Implementation Order
+
+This list records recently completed additions; authoritative implemented/not-implemented status is in the tables above.
 
 ### Immediate (complete)
 
@@ -315,6 +325,8 @@ ______________________________________________________________________
 12. `CustomConvertersDynamoTest` — 29 methods
 13. `ComplexTypeQueryDynamoTest` — 74 methods
 14. `SeedingDynamoTest` — 2 methods
+15. `KeysWithConvertersDynamoTest` — 47 methods
+16. `ComparisonOperatorTranslationsDynamoTest` — 6 methods
 
 ### Near-term (small, high confidence)
 
@@ -322,23 +334,23 @@ No near-term specification test classes are currently queued here.
 
 ### Medium-term (requires investigation or new fixture)
 
-15. `KeysWithConvertersDynamoTest`
-16. Translations operator tests (Comparison, Logical, Arithmetic) — needs `BasicTypesDynamoFixture`
-17. `StringTranslationsDynamoTest` — needs `BasicTypesDynamoFixture`
+17. `LogicalOperatorTranslationsDynamoTest`
+18. `ArithmeticOperatorTranslationsDynamoTest`
+19. `StringTranslationsDynamoTest`
 
 ### Long-term (after core coverage is stable)
 
-18. `InheritanceQueryDynamoTest` — blocked on `OfType`, `is`/`GetType()` discriminator translation, and fixture work
-19. `PrimitiveCollectionsQueryDynamoTest`
-20. `NorthwindQueryFiltersDynamoTest`
-21. `BulkUpdates` family — blocked on `ExecuteUpdate`/`ExecuteDelete`
-22. Remaining translation tests (Math, Miscellaneous, Enum, Guid)
+20. `InheritanceQueryDynamoTest` — blocked on `OfType`, `is`/`GetType()` discriminator translation, and fixture work
+21. `PrimitiveCollectionsQueryDynamoTest`
+22. `NorthwindQueryFiltersDynamoTest`
+23. `BulkUpdates` family — blocked on `ExecuteUpdate`/`ExecuteDelete`
+24. Remaining translation tests (Math, Miscellaneous, Enum, Guid)
 
 ### Current totals
 
 | Status         | Classes | Methods |
 | -------------- | ------: | ------: |
-| Implemented    |      26 |     903 |
+| Implemented    |      27 |     877 |
 | Implement Next |       0 |       0 |
-| Future         |      45 |  1,796+ |
-| Skip           |     61+ |  3,747+ |
+| Future         |      43 |  1,789+ |
+| Skip           |     62+ |  3,780+ |

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Translations.Operators;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests;
 
@@ -29,6 +30,7 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(SaveChangesInterceptionTestBase);
         yield return typeof(SeedingTestBase);
         yield return typeof(ValueConvertersEndToEndTestBase<>);
+        yield return typeof(ComparisonOperatorTranslationsTestBase<>);
         yield return typeof(NorthwindAsNoTrackingQueryTestBase<>);
         yield return typeof(NorthwindAsTrackingQueryTestBase<>);
         yield return typeof(NorthwindChangeTrackingQueryTestBase<>);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
@@ -1,0 +1,49 @@
+using EntityFrameworkCore.DynamoDb.Diagnostics;
+using EntityFrameworkCore.DynamoDb.Infrastructure;
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.Translations;
+using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query.Translations;
+
+/// <summary>Basic types query fixture for DynamoDB translation specification tests.</summary>
+public class BasicTypesQueryDynamoFixture : BasicTypesQueryFixtureBase, IDynamoSpecificationFixture
+{
+    public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+    protected override bool UsePooling => false;
+
+    protected override bool ShouldLogCategory(string logCategory)
+        => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base
+            .AddOptions(builder)
+            .ConfigureWarnings(warnings
+                => warnings
+                    .Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)
+                    .Ignore(DynamoEventId.ScanLikeQueryDetected))
+            .UseDynamo(options
+                => options
+                    .DynamoDbClient(DynamoTestStoreFactory.Instance.Client)
+                    .TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking));
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder
+            .Entity<BasicTypesEntity>()
+            .ToTable("BasicTypesEntities")
+            .HasPartitionKey(e => e.Id);
+        modelBuilder
+            .Entity<NullableBasicTypesEntity>()
+            .ToTable("NullableBasicTypesEntities")
+            .HasPartitionKey(e => e.Id);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
@@ -4,7 +4,6 @@ using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Translations;
-using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query.Translations;

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/BasicTypesQueryDynamoFixture.cs
@@ -32,18 +32,4 @@ public class BasicTypesQueryDynamoFixture : BasicTypesQueryFixtureBase, IDynamoS
                 => options
                     .DynamoDbClient(DynamoTestStoreFactory.Instance.Client)
                     .TransactionOverflowBehavior(TransactionOverflowBehavior.UseChunking));
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
-    {
-        base.OnModelCreating(modelBuilder, context);
-
-        modelBuilder
-            .Entity<BasicTypesEntity>()
-            .ToTable("BasicTypesEntities")
-            .HasPartitionKey(e => e.Id);
-        modelBuilder
-            .Entity<NullableBasicTypesEntity>()
-            .ToTable("NullableBasicTypesEntities")
-            .HasPartitionKey(e => e.Id);
-    }
 }

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/Operators/ComparisonOperatorTranslationsDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/Operators/ComparisonOperatorTranslationsDynamoTest.cs
@@ -1,0 +1,102 @@
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore.Query.Translations.Operators;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query.Translations.Operators;
+
+/// <summary>Comparison operator translation specification tests for the DynamoDB provider.</summary>
+public abstract class ComparisonOperatorTranslationsDynamoTest
+    : ComparisonOperatorTranslationsTestBase<BasicTypesQueryDynamoFixture>
+{
+    protected ComparisonOperatorTranslationsDynamoTest(BasicTypesQueryDynamoFixture fixture) :
+        base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(
+            typeof(ComparisonOperatorTranslationsDynamoTest));
+
+    public override async Task Equal()
+    {
+        await base.Equal();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" = 8
+            """);
+    }
+
+    public override async Task NotEqual()
+    {
+        await base.NotEqual();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" <> 8
+            """);
+    }
+
+    public override async Task GreaterThan()
+    {
+        await base.GreaterThan();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" > 8
+            """);
+    }
+
+    public override async Task GreaterThanOrEqual()
+    {
+        await base.GreaterThanOrEqual();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" >= 8
+            """);
+    }
+
+    public override async Task LessThan()
+    {
+        await base.LessThan();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" < 8
+            """);
+    }
+
+    public override async Task LessThanOrEqual()
+    {
+        await base.LessThanOrEqual();
+
+        AssertSql(
+            """
+            SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
+            FROM "BasicTypesEntities"
+            WHERE "int" <= 8
+            """);
+    }
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class ComparisonOperatorTranslationsDynamoTestDefault
+        : ComparisonOperatorTranslationsDynamoTest
+    {
+        public ComparisonOperatorTranslationsDynamoTestDefault(
+            BasicTypesQueryDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/Operators/ComparisonOperatorTranslationsDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Translations/Operators/ComparisonOperatorTranslationsDynamoTest.cs
@@ -23,7 +23,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" = 8
             """);
     }
@@ -35,7 +35,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" <> 8
             """);
     }
@@ -47,7 +47,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" > 8
             """);
     }
@@ -59,7 +59,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" >= 8
             """);
     }
@@ -71,7 +71,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" < 8
             """);
     }
@@ -83,7 +83,7 @@ public abstract class ComparisonOperatorTranslationsDynamoTest
         AssertSql(
             """
             SELECT "id", "bool", "byte", "byteArray", "dateOnly", "dateTime", "dateTimeOffset", "decimal", "double", "enum", "flagsEnum", "float", "guid", "int", "long", "short", "string", "timeOnly", "timeSpan"
-            FROM "BasicTypesEntities"
+            FROM "BasicTypesEntity"
             WHERE "int" <= 8
             """);
     }


### PR DESCRIPTION
## Summary

Adds DynamoDB specification coverage for EF Core comparison operator translations over the basic scalar type model. Introduces a shared `BasicTypesQueryDynamoFixture` so translation spec tests can execute against DynamoDB and assert generated PartiQL.

## Changes

- Added `BasicTypesQueryDynamoFixture` for translation specification tests.
- Added `ComparisonOperatorTranslationsDynamoTest` covering `=`, `<>`, `<`, `<=`, `>`, and `>=` PartiQL generation.
- Registered comparison operator translation tests in `ComplianceDynamoTest`.
- Updated `docs/spec-test-coverage.md` to reflect new translation coverage and current spec-test inventory.

## Validation

- `dotnet test tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --filter 'FullyQualifiedName~ComparisonOperatorTranslationsDynamoTest'`
