### PR TITLE
test(tests): add complex property projection coverage

### DIFF
--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -223,10 +223,10 @@ sub-families are skipped; complex-property sub-families are partially implemente
 
 ### Implemented
 
-| Test Class                                    | Methods | Cosmos | MongoDB | Notes                                                                                                                                                                                                                                                                                                                                                  |
-| --------------------------------------------- | ------: | :----: | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ComplexPropertiesStructuralEqualityTestBase` |      16 |   ✗    |    ✗    | Complex property structural equality; scalar and nested complex comparisons execute, while collection equality (issue #257), collection Contains, and complex-null parameter comparison are explicitly skipped                                                                                                                                         |
-| `ComplexPropertiesProjectionTestBase`         |       4 |   ✗    |    ✗    | Complex property projections execute for root and scalar/structural projections. Skips split into DynamoDB limits (navigation traversal, cross-partition ordering, SelectMany/list flattening, global ordered subqueries) and provider gaps (nullable complex `.Value`, nullable scalar from null complex, duplicate-root projection materialization). |
+| Test Class                                    | Methods | Cosmos | MongoDB | Notes                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------------------------- | ------: | :----: | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ComplexPropertiesStructuralEqualityTestBase` |      16 |   ✗    |    ✗    | Complex property structural equality; scalar and nested complex comparisons execute, while collection equality (issue #257), collection Contains, and complex-null parameter comparison are explicitly skipped                                                                                                                                                                       |
+| `ComplexPropertiesProjectionTestBase`         |      20 |   ✗    |    ✗    | Complex property projections execute for root, scalar, structural, nullable value-type, and collection projections. Ordered base variants are adapted to unordered scans where DynamoDB cannot guarantee global ordering. Explicit skips cover navigation traversal, SelectMany/list flattening, subquery pushdown, and the remaining duplicate-root projection materialization gap. |
 
 ### Future
 
@@ -317,7 +317,7 @@ ______________________________________________________________________
 | BulkUpdates           |                        — |              — | 5 classes / 135+ methods |       1 class / 33 methods |
 | Northwind Query       |  7 classes / 441 methods |              — |  3 classes / 491 methods |  12 classes / 924+ methods |
 | Other Query           |     1 class / 74 methods |              — | 10 classes / 381 methods | 18 classes / 1,691 methods |
-| Associations          |   3 classes / 26 methods |              — |    2 classes / 4 methods | 13+ classes / 123+ methods |
+| Associations          |   3 classes / 42 methods |              — |    2 classes / 4 methods | 13+ classes / 123+ methods |
 | Translations          |  5 classes / 134 methods |              — |  8 classes / 162 methods |     3 classes / 25 methods |
 
 ______________________________________________________________________
@@ -350,7 +350,7 @@ This list records recently completed additions; authoritative implemented/not-im
 20. `EnumTranslationsDynamoTest` — 18 methods
 21. `StringTranslationsDynamoTest` — 100 methods
 22. `ComplexPropertiesStructuralEqualityDynamoTest` — 16 methods
-23. `ComplexPropertiesProjectionDynamoTest` — 4 methods
+23. `ComplexPropertiesProjectionDynamoTest` — 20 methods
 
 ### Near-term (small, high confidence)
 
@@ -372,7 +372,7 @@ No medium-term specification test classes are currently queued here.
 
 | Status         | Classes | Methods |
 | -------------- | ------: | ------: |
-| Implemented    |      34 |   1,031 |
+| Implemented    |      34 |   1,047 |
 | Implement Next |       0 |       0 |
 | Future         |      32 |  1,583+ |
 | Skip           |     68+ |  3,854+ |

--- a/docs/spec-test-coverage.md
+++ b/docs/spec-test-coverage.md
@@ -223,16 +223,16 @@ sub-families are skipped; complex-property sub-families are partially implemente
 
 ### Implemented
 
-| Test Class                                    | Methods | Cosmos | MongoDB | Notes                                                                                                                                                                                                          |
-| --------------------------------------------- | ------: | :----: | :-----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ComplexPropertiesStructuralEqualityTestBase` |      16 |   ✗    |    ✗    | Complex property structural equality; scalar and nested complex comparisons execute, while collection equality (issue #257), collection Contains, and complex-null parameter comparison are explicitly skipped |
+| Test Class                                    | Methods | Cosmos | MongoDB | Notes                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------------------- | ------: | :----: | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ComplexPropertiesStructuralEqualityTestBase` |      16 |   ✗    |    ✗    | Complex property structural equality; scalar and nested complex comparisons execute, while collection equality (issue #257), collection Contains, and complex-null parameter comparison are explicitly skipped                                                                                                                                         |
+| `ComplexPropertiesProjectionTestBase`         |       4 |   ✗    |    ✗    | Complex property projections execute for root and scalar/structural projections. Skips split into DynamoDB limits (navigation traversal, cross-partition ordering, SelectMany/list flattening, global ordered subqueries) and provider gaps (nullable complex `.Value`, nullable scalar from null complex, duplicate-root projection materialization). |
 
 ### Future
 
 | Test Class                                    | Methods | Cosmos | MongoDB | Feasibility | Notes                                  |
 | --------------------------------------------- | ------: | :----: | :-----: | ----------: | -------------------------------------- |
 | `ComplexPropertiesMiscellaneousTestBase`      |       3 |   ✗    |    ✗    |        ~70% | Miscellaneous complex property queries |
-| `ComplexPropertiesProjectionTestBase`         |       4 |   ✗    |    ✗    |        ~70% | Complex type projections               |
 | `ComplexPropertiesStructuralEqualityTestBase` |       1 |   ✗    |    ✗    |        ~70% | Structural equality on complex types   |
 
 ### Skip — Navigation or Set Operation Dependent
@@ -317,7 +317,7 @@ ______________________________________________________________________
 | BulkUpdates           |                        — |              — | 5 classes / 135+ methods |       1 class / 33 methods |
 | Northwind Query       |  7 classes / 441 methods |              — |  3 classes / 491 methods |  12 classes / 924+ methods |
 | Other Query           |     1 class / 74 methods |              — | 10 classes / 381 methods | 18 classes / 1,691 methods |
-| Associations          |   2 classes / 22 methods |              — |    3 classes / 8 methods | 13+ classes / 123+ methods |
+| Associations          |   3 classes / 26 methods |              — |    2 classes / 4 methods | 13+ classes / 123+ methods |
 | Translations          |  5 classes / 134 methods |              — |  8 classes / 162 methods |     3 classes / 25 methods |
 
 ______________________________________________________________________
@@ -350,6 +350,7 @@ This list records recently completed additions; authoritative implemented/not-im
 20. `EnumTranslationsDynamoTest` — 18 methods
 21. `StringTranslationsDynamoTest` — 100 methods
 22. `ComplexPropertiesStructuralEqualityDynamoTest` — 16 methods
+23. `ComplexPropertiesProjectionDynamoTest` — 4 methods
 
 ### Near-term (small, high confidence)
 
@@ -371,7 +372,7 @@ No medium-term specification test classes are currently queued here.
 
 | Status         | Classes | Methods |
 | -------------- | ------: | ------: |
-| Implemented    |      33 |   1,027 |
+| Implemented    |      34 |   1,031 |
 | Implement Next |       0 |       0 |
-| Future         |      33 |  1,587+ |
+| Future         |      32 |  1,583+ |
 | Skip           |     68+ |  3,854+ |

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoComplexTypeProjectionExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoComplexTypeProjectionExpression.cs
@@ -39,20 +39,20 @@ internal sealed class DynamoComplexTypeProjectionExpression(
     /// </summary>
     public Expression InnerShaper { get; } = innerShaper;
 
-    private Type ClrType { get; } = clrType ?? innerShaper.Type;
+    private Type ProjectionClrType { get; } = clrType ?? innerShaper.Type;
 
     /// <inheritdoc />
     public override ExpressionType NodeType => ExpressionType.Extension;
 
     /// <inheritdoc />
-    public override Type Type => ClrType;
+    public override Type Type => ProjectionClrType;
 
     /// <summary>
     ///     Returns this projection with the requested result CLR type; nullable complex
     ///     <c>.Value</c> uses the same inner shaper but projects the non-nullable struct type.
     /// </summary>
     public DynamoComplexTypeProjectionExpression WithClrType(Type type)
-        => type == ClrType
+        => type == ProjectionClrType
             ? this
             : new DynamoComplexTypeProjectionExpression(ComplexProperty, InnerShaper, type);
 
@@ -62,7 +62,10 @@ internal sealed class DynamoComplexTypeProjectionExpression(
         var visited = visitor.Visit(InnerShaper);
         return ReferenceEquals(visited, InnerShaper)
             ? this
-            : new DynamoComplexTypeProjectionExpression(ComplexProperty, visited, ClrType);
+            : new DynamoComplexTypeProjectionExpression(
+                ComplexProperty,
+                visited,
+                ProjectionClrType);
     }
 
     /// <inheritdoc />

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoComplexTypeProjectionExpression.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoComplexTypeProjectionExpression.cs
@@ -27,7 +27,8 @@ namespace EntityFrameworkCore.DynamoDb.Query.Internal;
 /// </remarks>
 internal sealed class DynamoComplexTypeProjectionExpression(
     IComplexProperty complexProperty,
-    Expression innerShaper) : Expression
+    Expression innerShaper,
+    Type? clrType = null) : Expression
 {
     /// <summary>The complex property being projected.</summary>
     public IComplexProperty ComplexProperty { get; } = complexProperty;
@@ -38,11 +39,22 @@ internal sealed class DynamoComplexTypeProjectionExpression(
     /// </summary>
     public Expression InnerShaper { get; } = innerShaper;
 
+    private Type ClrType { get; } = clrType ?? innerShaper.Type;
+
     /// <inheritdoc />
     public override ExpressionType NodeType => ExpressionType.Extension;
 
     /// <inheritdoc />
-    public override Type Type => InnerShaper.Type;
+    public override Type Type => ClrType;
+
+    /// <summary>
+    ///     Returns this projection with the requested result CLR type; nullable complex
+    ///     <c>.Value</c> uses the same inner shaper but projects the non-nullable struct type.
+    /// </summary>
+    public DynamoComplexTypeProjectionExpression WithClrType(Type type)
+        => type == ClrType
+            ? this
+            : new DynamoComplexTypeProjectionExpression(ComplexProperty, InnerShaper, type);
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -50,7 +62,7 @@ internal sealed class DynamoComplexTypeProjectionExpression(
         var visited = visitor.Visit(InnerShaper);
         return ReferenceEquals(visited, InnerShaper)
             ? this
-            : new DynamoComplexTypeProjectionExpression(ComplexProperty, visited);
+            : new DynamoComplexTypeProjectionExpression(ComplexProperty, visited, ClrType);
     }
 
     /// <inheritdoc />

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingExpressionVisitor.cs
@@ -338,27 +338,7 @@ public sealed class DynamoProjectionBindingExpressionVisitor(
                 if (!_indexBasedBinding)
                     return QueryCompilationContext.NotTranslatedExpression;
 
-                var attributeName = ((IReadOnlyComplexProperty)complexProperty).GetAttributeName();
-                _selectExpression.AddEmbeddedAttributeToProjection(attributeName);
-
-                if (complexProperty.IsCollection)
-                {
-                    var elementShaper = new StructuralTypeShaperExpression(
-                        complexProperty.ComplexType,
-                        Expression.Constant(ValueBuffer.Empty),
-                        false);
-
-                    return new DynamoComplexCollectionProjectionExpression(
-                        complexProperty,
-                        elementShaper);
-                }
-
-                var innerShaper = new StructuralTypeShaperExpression(
-                    complexProperty.ComplexType,
-                    Expression.Constant(ValueBuffer.Empty),
-                    complexProperty.IsNullable);
-
-                return new DynamoComplexTypeProjectionExpression(complexProperty, innerShaper);
+                return CreateComplexProjection(complexProperty, node.Type);
             }
 
             var sqlProperty =
@@ -421,8 +401,46 @@ public sealed class DynamoProjectionBindingExpressionVisitor(
         if (instance == null)
             return QueryCompilationContext.NotTranslatedExpression;
 
+        if (IsNullableValueMember(node.Member)
+            && Nullable.GetUnderlyingType(node.Expression.Type) == node.Type)
+        {
+            if (instance is DynamoComplexTypeProjectionExpression complexProjection)
+                return complexProjection.WithClrType(node.Type);
+
+            if (instance.Type == node.Type)
+                return instance;
+        }
+
         return node.Update(instance);
     }
+
+    private Expression CreateComplexProjection(IComplexProperty complexProperty, Type resultType)
+    {
+        var attributeName = ((IReadOnlyComplexProperty)complexProperty).GetAttributeName();
+        _selectExpression.AddEmbeddedAttributeToProjection(attributeName);
+
+        if (complexProperty.IsCollection)
+        {
+            var elementShaper = new StructuralTypeShaperExpression(
+                complexProperty.ComplexType,
+                Expression.Constant(ValueBuffer.Empty),
+                false);
+
+            return new DynamoComplexCollectionProjectionExpression(complexProperty, elementShaper);
+        }
+
+        var innerShaper = new StructuralTypeShaperExpression(
+            complexProperty.ComplexType,
+            Expression.Constant(ValueBuffer.Empty),
+            complexProperty.IsNullable);
+
+        return new DynamoComplexTypeProjectionExpression(complexProperty, innerShaper, resultType);
+    }
+
+    private static bool IsNullableValueMember(MemberInfo member)
+        => member.Name == nameof(Nullable<int>.Value)
+            && member.DeclaringType is { IsGenericType: true } declaringType
+            && declaringType.GetGenericTypeDefinition() == typeof(Nullable<>);
 
     /// <summary>Handles EF.Property&lt;T&gt; calls and general method call expressions.</summary>
     protected override Expression VisitMethodCall(MethodCallExpression node)
@@ -444,27 +462,7 @@ public sealed class DynamoProjectionBindingExpressionVisitor(
                 if (!_indexBasedBinding)
                     return QueryCompilationContext.NotTranslatedExpression;
 
-                var attributeName = ((IReadOnlyComplexProperty)complexProperty).GetAttributeName();
-                _selectExpression.AddEmbeddedAttributeToProjection(attributeName);
-
-                if (complexProperty.IsCollection)
-                {
-                    var elementShaper = new StructuralTypeShaperExpression(
-                        complexProperty.ComplexType,
-                        Expression.Constant(ValueBuffer.Empty),
-                        false);
-
-                    return new DynamoComplexCollectionProjectionExpression(
-                        complexProperty,
-                        elementShaper);
-                }
-
-                var innerShaper = new StructuralTypeShaperExpression(
-                    complexProperty.ComplexType,
-                    Expression.Constant(ValueBuffer.Empty),
-                    complexProperty.IsNullable);
-
-                return new DynamoComplexTypeProjectionExpression(complexProperty, innerShaper);
+                return CreateComplexProjection(complexProperty, node.Type);
             }
 
             var ownerEntityType = ownerStructuralType as IEntityType;

--- a/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoProjectionBindingRemovingExpressionVisitor.cs
@@ -153,6 +153,35 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
     {
         if (node.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked
             && Nullable.GetUnderlyingType(node.Type) != null
+            && node.Operand is MemberExpression memberOperand
+            && memberOperand.Expression is not null
+            && Nullable.GetUnderlyingType(memberOperand.Expression.Type) == null)
+        {
+            var visitedInstance = Visit(memberOperand.Expression);
+            if (visitedInstance == QueryCompilationContext.NotTranslatedExpression
+                || visitedInstance == null)
+                return QueryCompilationContext.NotTranslatedExpression;
+
+            if (ShouldApplyNullPropagation(visitedInstance.Type))
+            {
+                var sourceVariable = Variable(visitedInstance.Type, "nullableMemberSource");
+                var memberAccess = memberOperand.Update(sourceVariable);
+                Expression convertedMember = node.NodeType == ExpressionType.ConvertChecked
+                    ? ConvertChecked(memberAccess, node.Type)
+                    : Convert(memberAccess, node.Type);
+
+                return Block(
+                    [sourceVariable],
+                    Assign(sourceVariable, visitedInstance),
+                    Condition(
+                        Equal(sourceVariable, Constant(null, sourceVariable.Type)),
+                        Default(node.Type),
+                        convertedMember));
+            }
+        }
+
+        if (node.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked
+            && Nullable.GetUnderlyingType(node.Type) != null
             && TryGetNullableValueSource(node.Operand, out var nullableSource))
         {
             var visitedSource = Visit(nullableSource);
@@ -196,10 +225,9 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
 
         switch (expression)
         {
-            case MemberExpression
-            {
-                Member.Name: nameof(Nullable<int>.Value), Expression: { } source
-            } when Nullable.GetUnderlyingType(source.Type) != null:
+            case MemberExpression { Member: { } member, Expression: { } source }
+                when IsNullableValueMember(member)
+                && Nullable.GetUnderlyingType(source.Type) != null:
                 nullableSource = source;
                 return true;
 
@@ -216,6 +244,11 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
         nullableSource = expression;
         return false;
     }
+
+    private static bool IsNullableValueMember(MemberInfo member)
+        => member.Name == nameof(Nullable<int>.Value)
+            && member.DeclaringType is { IsGenericType: true } declaringType
+            && declaringType.GetGenericTypeDefinition() == typeof(Nullable<>);
 
     /// <summary>Removes conversion nodes when searching for nullable value sources.</summary>
     private static Expression UnwrapConvert(Expression expression)
@@ -249,6 +282,10 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
         if (instanceExpression == QueryCompilationContext.NotTranslatedExpression
             || instanceExpression == null)
             return QueryCompilationContext.NotTranslatedExpression;
+
+        if (IsNullableValueMember(node.Member)
+            && Nullable.GetUnderlyingType(node.Expression.Type) == instanceExpression.Type)
+            return instanceExpression;
 
         var memberAccess = node.Update(instanceExpression);
         return ShouldApplyNullPropagation(instanceExpression.Type)
@@ -459,14 +496,17 @@ public sealed class DynamoProjectionBindingRemovingExpressionVisitor(
         var visitedMaterializer = Visit(projection.InnerShaper);
         _attributeContextStack.Pop();
 
+        var resultType = projection.Type;
         Expression complexInstance = cp.IsNullable
             ? Condition(
                 Equal(
                     complexMapVariable,
                     Constant(null, typeof(Dictionary<string, AttributeValue>))),
-                Constant(null, cp.ClrType),
-                Convert(visitedMaterializer, cp.ClrType))
-            : Convert(visitedMaterializer, cp.ClrType);
+                resultType.IsValueType && Nullable.GetUnderlyingType(resultType) == null
+                    ? Default(resultType)
+                    : Constant(null, resultType),
+                Convert(visitedMaterializer, resultType))
+            : Convert(visitedMaterializer, resultType);
 
         return Block(
             [complexMapVariable],

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/ComplianceDynamoTest.cs
@@ -36,6 +36,7 @@ public sealed class ComplianceDynamoTest : ComplianceTestBase
         yield return typeof(SeedingTestBase);
         yield return typeof(ValueConvertersEndToEndTestBase<>);
         yield return typeof(ComplexPropertiesMiscellaneousTestBase<>);
+        yield return typeof(ComplexPropertiesProjectionTestBase<>);
         yield return typeof(ComplexPropertiesStructuralEqualityTestBase<>);
         yield return typeof(ComparisonOperatorTranslationsTestBase<>);
         yield return typeof(LogicalOperatorTranslationsTestBase<>);

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
@@ -24,9 +24,17 @@ public abstract class ComplexPropertiesProjectionDynamoTest
     public override Task Select_root(QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_root(queryTrackingBehavior);
 
-    public override Task Select_scalar_property_on_required_associate(
+    public override async Task Select_scalar_property_on_required_associate(
         QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_scalar_property_on_required_associate(queryTrackingBehavior);
+    {
+        await base.Select_scalar_property_on_required_associate(queryTrackingBehavior);
+
+        AssertSql(
+            """
+            SELECT "requiredAssociate"
+            FROM "RootEntities"
+            """);
+    }
 
     public override Task Select_property_on_optional_associate(
         QueryTrackingBehavior queryTrackingBehavior)
@@ -36,14 +44,20 @@ public abstract class ComplexPropertiesProjectionDynamoTest
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_value_type_property_on_null_associate_throws(queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
     public override Task Select_nullable_value_type_property_on_null_associate(
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_nullable_value_type_property_on_null_associate(queryTrackingBehavior);
 
-    public override Task Select_associate(QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_associate(queryTrackingBehavior);
+    public override async Task Select_associate(QueryTrackingBehavior queryTrackingBehavior)
+    {
+        await base.Select_associate(queryTrackingBehavior);
+
+        AssertSql(
+            """
+            SELECT "requiredAssociate"
+            FROM "RootEntities"
+            """);
+    }
 
     public override Task Select_optional_associate(QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_optional_associate(queryTrackingBehavior);
@@ -78,39 +92,51 @@ public abstract class ComplexPropertiesProjectionDynamoTest
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_untranslatable_method_on_associate_scalar_property(queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_associate_collection(QueryTrackingBehavior queryTrackingBehavior)
+    public override async Task Select_associate_collection(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising complex collection
         // projection.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss.Set<RootEntity>().Select(x => x.AssociateCollection),
             elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
             elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_nested_collection_on_required_associate(
-            QueryTrackingBehavior queryTrackingBehavior)
+        AssertSql(
+            """
+            SELECT "associateCollection"
+            FROM "RootEntities"
+            """);
+    }
+
+    public override async Task Select_nested_collection_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising nested collection
         // projection.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss.Set<RootEntity>().Select(x => x.RequiredAssociate.NestedCollection),
             elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
             elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_nested_collection_on_optional_associate(
-            QueryTrackingBehavior queryTrackingBehavior)
+        AssertSql(
+            """
+            SELECT "requiredAssociate"
+            FROM "RootEntities"
+            """);
+    }
+
+    public override async Task Select_nested_collection_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising nested collection
         // projection.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss
                 .Set<RootEntity>()
                 .Select(x => x.OptionalAssociate!.NestedCollection
@@ -122,6 +148,13 @@ public abstract class ComplexPropertiesProjectionDynamoTest
             elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
             elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
             queryTrackingBehavior: queryTrackingBehavior);
+
+        AssertSql(
+            """
+            SELECT "optionalAssociate"
+            FROM "RootEntities"
+            """);
+    }
 
     [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
     [MemberData(nameof(TrackingData))]
@@ -158,7 +191,7 @@ public abstract class ComplexPropertiesProjectionDynamoTest
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    [ConditionalTheory(Skip = SkipReason.SubqueryPushdownNotSupported)]
     [MemberData(nameof(TrackingData))]
     public override Task Select_subquery_FirstOrDefault_complex_collection(
         QueryTrackingBehavior queryTrackingBehavior)
@@ -167,39 +200,61 @@ public abstract class ComplexPropertiesProjectionDynamoTest
     public override Task Select_root_with_value_types(QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_root_with_value_types(queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_non_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
+    public override async Task Select_non_nullable_value_type(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising value-type complex
         // projection.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss.Set<ValueRootEntity>().Select(x => x.RequiredAssociate),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
+        AssertSql(
+            """
+            SELECT "requiredAssociate"
+            FROM "ValueRootEntities"
+            """);
+    }
+
+    public override async Task Select_nullable_value_type(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising nullable value-type
         // complex projection.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss.Set<ValueRootEntity>().Select(x => x.OptionalAssociate),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory]
-    [MemberData(nameof(TrackingData))]
-    public override Task Select_nullable_value_type_with_Value(
-            QueryTrackingBehavior queryTrackingBehavior)
+        AssertSql(
+            """
+            SELECT "optionalAssociate"
+            FROM "ValueRootEntities"
+            """);
+    }
+
+    public override async Task Select_nullable_value_type_with_Value(
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
         // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
         // global ordering, so use an unordered scan while still exercising nullable value-type
         // complex projection through .Value.
-        => AssertQuery(
+        await AssertQuery(
             ss => ss.Set<ValueRootEntity>().Select(x => x.OptionalAssociate!.Value),
             ss => ss
                 .Set<ValueRootEntity>()
                 .Select(x => x.OptionalAssociate == null ? default : x.OptionalAssociate!.Value),
             queryTrackingBehavior: queryTrackingBehavior);
+
+        AssertSql(
+            """
+            SELECT "optionalAssociate"
+            FROM "ValueRootEntities"
+            """);
+    }
+
+    private void AssertSql(params string[] expected) => Fixture.AssertSql(expected);
 
     public class ComplexPropertiesProjectionDynamoFixture
         : ComplexPropertiesFixtureBase, IDynamoSpecificationFixture

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
@@ -78,22 +78,50 @@ public abstract class ComplexPropertiesProjectionDynamoTest
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_untranslatable_method_on_associate_scalar_property(queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_associate_collection(QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_associate_collection(queryTrackingBehavior);
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising complex collection
+        // projection.
+        => AssertQuery(
+            ss => ss.Set<RootEntity>().Select(x => x.AssociateCollection),
+            elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
+            queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_nested_collection_on_required_associate(
-        QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_nested_collection_on_required_associate(queryTrackingBehavior);
+            QueryTrackingBehavior queryTrackingBehavior)
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising nested collection
+        // projection.
+        => AssertQuery(
+            ss => ss.Set<RootEntity>().Select(x => x.RequiredAssociate.NestedCollection),
+            elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
+            queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_nested_collection_on_optional_associate(
-        QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_nested_collection_on_optional_associate(queryTrackingBehavior);
+            QueryTrackingBehavior queryTrackingBehavior)
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising nested collection
+        // projection.
+        => AssertQuery(
+            ss => ss
+                .Set<RootEntity>()
+                .Select(x => x.OptionalAssociate!.NestedCollection
+                    ?? new List<NestedAssociateType>()),
+            ss => ss
+                .Set<RootEntity>()
+                .Select(x => x.OptionalAssociate.Maybe(xx => xx!.NestedCollection)
+                    ?? new List<NestedAssociateType>()),
+            elementSorter: e => e.Count == 0 ? 0 : e[0].Id,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
+            queryTrackingBehavior: queryTrackingBehavior);
 
     [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
     [MemberData(nameof(TrackingData))]

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
@@ -36,7 +36,7 @@ public abstract class ComplexPropertiesProjectionDynamoTest
         QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_value_type_property_on_null_associate_throws(queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_nullable_value_type_property_on_null_associate(
         QueryTrackingBehavior queryTrackingBehavior)
@@ -159,11 +159,19 @@ public abstract class ComplexPropertiesProjectionDynamoTest
             ss => ss.Set<ValueRootEntity>().Select(x => x.OptionalAssociate),
             queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_nullable_value_type_with_Value(
-        QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_nullable_value_type_with_Value(queryTrackingBehavior);
+            QueryTrackingBehavior queryTrackingBehavior)
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising nullable value-type
+        // complex projection through .Value.
+        => AssertQuery(
+            ss => ss.Set<ValueRootEntity>().Select(x => x.OptionalAssociate!.Value),
+            ss => ss
+                .Set<ValueRootEntity>()
+                .Select(x => x.OptionalAssociate == null ? default : x.OptionalAssociate!.Value),
+            queryTrackingBehavior: queryTrackingBehavior);
 
     public class ComplexPropertiesProjectionDynamoFixture
         : ComplexPropertiesFixtureBase, IDynamoSpecificationFixture

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
@@ -139,15 +139,25 @@ public abstract class ComplexPropertiesProjectionDynamoTest
     public override Task Select_root_with_value_types(QueryTrackingBehavior queryTrackingBehavior)
         => base.Select_root_with_value_types(queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_non_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_non_nullable_value_type(queryTrackingBehavior);
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising value-type complex
+        // projection.
+        => AssertQuery(
+            ss => ss.Set<ValueRootEntity>().Select(x => x.RequiredAssociate),
+            queryTrackingBehavior: queryTrackingBehavior);
 
-    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [ConditionalTheory]
     [MemberData(nameof(TrackingData))]
     public override Task Select_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
-        => base.Select_nullable_value_type(queryTrackingBehavior);
+        // Base test orders by partition key without constraining it. DynamoDB cannot guarantee
+        // global ordering, so use an unordered scan while still exercising nullable value-type
+        // complex projection.
+        => AssertQuery(
+            ss => ss.Set<ValueRootEntity>().Select(x => x.OptionalAssociate),
+            queryTrackingBehavior: queryTrackingBehavior);
 
     [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
     [MemberData(nameof(TrackingData))]

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/Query/Associations/ComplexProperties/ComplexPropertiesProjectionDynamoTest.cs
@@ -1,0 +1,248 @@
+using EntityFrameworkCore.DynamoDb.Diagnostics;
+using EntityFrameworkCore.DynamoDb.SpecificationTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.Associations;
+using Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace EntityFrameworkCore.DynamoDb.SpecificationTests.Query.Associations.ComplexProperties;
+
+public abstract class ComplexPropertiesProjectionDynamoTest
+    : ComplexPropertiesProjectionTestBase<ComplexPropertiesProjectionDynamoTest.
+        ComplexPropertiesProjectionDynamoFixture>
+{
+    protected ComplexPropertiesProjectionDynamoTest(
+        ComplexPropertiesProjectionDynamoFixture fixture) : base(fixture)
+        => fixture.ClearSql();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => DynamoTestHelpers.AssertAllTestMethodsOverridden(
+            typeof(ComplexPropertiesProjectionDynamoTest));
+
+    public override Task Select_root(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_root(queryTrackingBehavior);
+
+    public override Task Select_scalar_property_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_scalar_property_on_required_associate(queryTrackingBehavior);
+
+    public override Task Select_property_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_property_on_optional_associate(queryTrackingBehavior);
+
+    public override Task Select_value_type_property_on_null_associate_throws(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_value_type_property_on_null_associate_throws(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_nullable_value_type_property_on_null_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_nullable_value_type_property_on_null_associate(queryTrackingBehavior);
+
+    public override Task Select_associate(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_associate(queryTrackingBehavior);
+
+    public override Task Select_optional_associate(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_optional_associate(queryTrackingBehavior);
+
+    public override Task Select_required_nested_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_required_nested_on_required_associate(queryTrackingBehavior);
+
+    public override Task Select_optional_nested_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_optional_nested_on_required_associate(queryTrackingBehavior);
+
+    public override Task Select_required_nested_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_required_nested_on_optional_associate(queryTrackingBehavior);
+
+    public override Task Select_optional_nested_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_optional_nested_on_optional_associate(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.NavigationPropertiesNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_required_associate_via_optional_navigation(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_required_associate_via_optional_navigation(queryTrackingBehavior);
+
+    public override Task Select_unmapped_associate_scalar_property(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_unmapped_associate_scalar_property(queryTrackingBehavior);
+
+    public override Task Select_untranslatable_method_on_associate_scalar_property(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_untranslatable_method_on_associate_scalar_property(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_associate_collection(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_associate_collection(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_nested_collection_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_nested_collection_on_required_associate(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_nested_collection_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_nested_collection_on_optional_associate(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task SelectMany_associate_collection(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.SelectMany_associate_collection(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task SelectMany_nested_collection_on_required_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.SelectMany_nested_collection_on_required_associate(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task SelectMany_nested_collection_on_optional_associate(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.SelectMany_nested_collection_on_optional_associate(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_root_duplicated(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_root_duplicated(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.SubqueryPushdownNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_subquery_required_related_FirstOrDefault(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_subquery_required_related_FirstOrDefault(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.SubqueryPushdownNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_subquery_optional_related_FirstOrDefault(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.QueryShapeNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_subquery_FirstOrDefault_complex_collection(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_subquery_FirstOrDefault_complex_collection(queryTrackingBehavior);
+
+    public override Task Select_root_with_value_types(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_root_with_value_types(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_non_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_non_nullable_value_type(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.OrderedResultSetNotSupported)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_nullable_value_type(QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_nullable_value_type(queryTrackingBehavior);
+
+    [ConditionalTheory(Skip = SkipReason.ComplexProjectionMaterializationGap)]
+    [MemberData(nameof(TrackingData))]
+    public override Task Select_nullable_value_type_with_Value(
+        QueryTrackingBehavior queryTrackingBehavior)
+        => base.Select_nullable_value_type_with_Value(queryTrackingBehavior);
+
+    public class ComplexPropertiesProjectionDynamoFixture
+        : ComplexPropertiesFixtureBase, IDynamoSpecificationFixture
+    {
+        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override ITestStoreFactory TestStoreFactory => DynamoTestStoreFactory.Instance;
+
+        protected override bool ShouldLogCategory(string logCategory)
+            => DynamoSpecificationFixtureExtensions.ShouldLogDynamoSql(logCategory);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base
+                .AddOptions(builder)
+                .ConfigureWarnings(warnings => warnings.Ignore(
+                    CoreEventId.ManyServiceProvidersCreatedWarning,
+                    CoreEventId.MappedNavigationIgnoredWarning,
+                    DynamoEventId.ScanLikeQueryDetected))
+                .UseDynamo(options
+                    => options.DynamoDbClient(DynamoTestStoreFactory.Instance.Client));
+
+        protected override async Task CleanAsync(DbContext context)
+        {
+            await context.Database.EnsureDeletedAsync();
+            await context.Database.EnsureCreatedAsync();
+        }
+
+        protected override async Task SeedAsync(PoolableDbContext context)
+        {
+            context.Set<RootEntity>().AddRange(Data.RootEntities);
+            context.Set<ValueRootEntity>().AddRange(Data.ValueRootEntities);
+
+            await context.SaveChangesAsync();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            modelBuilder.Ignore<RootReferencingEntity>();
+
+            modelBuilder.Entity<RootEntity>(b =>
+            {
+                b.ToTable("RootEntities").HasPartitionKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+
+                b.ComplexProperty(
+                    e => e.RequiredAssociate,
+                    rrb => rrb.ComplexProperty(r => r.OptionalNestedAssociate).IsRequired(false));
+
+                b.ComplexProperty(
+                    e => e.OptionalAssociate,
+                    orb =>
+                    {
+                        orb.IsRequired(false);
+                        orb.ComplexProperty(r => r.OptionalNestedAssociate).IsRequired(false);
+                    });
+
+                b.ComplexCollection(
+                    e => e.AssociateCollection,
+                    rcb => rcb.ComplexProperty(r => r.OptionalNestedAssociate).IsRequired(false));
+            });
+
+            modelBuilder.Entity<ValueRootEntity>(b =>
+            {
+                b.ToTable("ValueRootEntities").HasPartitionKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.ComplexProperty(e => e.RequiredAssociate);
+
+                b.ComplexProperty(
+                    e => e.OptionalAssociate,
+                    orb =>
+                    {
+                        orb.IsRequired(false);
+                        orb.ComplexProperty(r => r.OptionalNested).IsRequired(false);
+                    });
+
+                b.ComplexCollection(
+                    e => e.AssociateCollection,
+                    rcb => rcb.ComplexProperty(r => r.OptionalNestedAssociate).IsRequired(false));
+            });
+        }
+    }
+
+    [Collection(DynamoSpecificationCollection.Name)]
+    public sealed class ComplexPropertiesProjectionDynamoTestDefault
+        : ComplexPropertiesProjectionDynamoTest
+    {
+        public ComplexPropertiesProjectionDynamoTestDefault(
+            ComplexPropertiesProjectionDynamoFixture fixture,
+            DynamoSpecificationContainerFixture containerFixture) : base(fixture)
+            => _ = containerFixture;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs
@@ -15,6 +15,9 @@ public static class SkipReason
     public const string ComplexCollectionStructuralEqualityNotSupported =
         "DynamoDB provider does not support structural equality comparisons for complex collection properties. See issue #257.";
 
+    public const string ComplexProjectionMaterializationGap =
+        "DynamoDB provider does not yet support this complex-property projection materialization shape.";
+
     public const string SubqueryPushdownNotSupported =
         "DynamoDB provider does not support the subquery pushdown required by this query shape.";
 


### PR DESCRIPTION
## Summary

Adds DynamoDB specification coverage for EF Core complex-property projection scenarios and enables the cases this provider can already translate/materialize. The branch also fixes nullable complex value projection handling so value-type projections and `.Value` access work against DynamoDB-backed queries.

## Changes

- Add `ComplexPropertiesProjectionDynamoTest` coverage for complex property projections.
- Unskip supported complex collection projections by avoiding unsupported global `OrderBy` and comparing unordered results.
- Keep unsupported shapes skipped with DynamoDB-specific reasons, including navigation, `SelectMany`, subquery pushdown, and duplicated-root materialization gaps.
- Update projection binding/removal logic for nullable complex value projection shapes.
- Refresh spec test coverage documentation and compliance registration.

## Validation

- `dotnet test tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --no-restore -- --filter "FullyQualifiedName~ComplexPropertiesProjectionDynamoTest" --output Normal`
  - Passed: `55` succeeded, `8` skipped, `0` failed.
- Manually re-ran skipped branch-added tests without skip attributes to confirm which failures are real provider limitations.
