### PR TITLE
ci(github): migrate to v10.0 templates with NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -19,7 +19,7 @@ jobs:
             dotnetVersion: "10.0.x"
           - configuration: "Debug EF11"
             dotnetVersion: "11.0.x"
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v9.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v9.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -12,10 +12,12 @@ on:
       - 'mkdocs.yml'
       - 'requirements.txt'
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  publish:
+  build:
     # Multi-version support: add a new matrix entry for the new EF version.
     # The release tag prefix (vN.*) drives configuration and SDK selection automatically
     # in publish-release.yaml via buildConfiguration: auto.
@@ -26,14 +28,29 @@ jobs:
           - configuration: "Release EF10"
             dotnetVersion: "10.0.x"
             drafterConfig: "release-drafter-ef10.yml"
+            artifact_name: "nuget-packages-ef10"
           - configuration: "Release EF11"
             dotnetVersion: "11.0.x"
             drafterConfig: "release-drafter-ef11.yml"
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v9.0
+            artifact_name: "nuget-packages-ef11"
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       buildConfiguration: ${{ matrix.configuration }}
       dotnetVersion: ${{ matrix.dotnetVersion }}
       drafterConfig: ${{ matrix.drafterConfig }}
       hasTests: true
+      artifact_name: ${{ matrix.artifact_name }}
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}
+          artifact_name: "nuget-packages-ef*"

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -33,7 +33,7 @@ jobs:
             dotnetVersion: "11.0.x"
             drafterConfig: "release-drafter-ef11.yml"
             artifact_name: "nuget-packages-ef11"
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@ci/matrix-artifact-name
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       buildConfiguration: ${{ matrix.configuration }}
@@ -50,7 +50,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@ci/matrix-artifact-name
         with:
           nuget_user: ${{ secrets.NUGET_USER }}
           artifact_name: "nuget-packages-ef*"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,14 +4,26 @@ on:
   release:
     types: [published]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v9.0
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: EntityFrameworkCore.DynamoDb.slnx
       dotnetVersion: "10.0.x"   # fallback only — overridden when buildConfiguration=auto
       buildConfiguration: auto
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v9.0
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}


### PR DESCRIPTION
## Summary

- Split `publish-preview` and `publish-release` into `build` + `push` jobs
- The `push` job uses the NuGet OIDC composite action so `job_workflow_ref` stays in this repo's context and matches the NuGet.org trusted publisher policy
- Matrix builds upload distinct artifacts (`nuget-packages-ef10` / `nuget-packages-ef11`); the push job collects all via glob pattern (`nuget-packages-ef*`)
- Version-bump `pr-build`, `pr-title-check`, and `release-drafter` to `v10.0` only — no other changes to those workflows

## Notes

- `publish-preview.yaml` temporarily points at `LayeredCraft/devops-templates@ci/matrix-artifact-name` (PR #30) to test the new `artifact_name` input. Will update to versioned tag after that PR merges.
- NuGet.org trusted publisher entries will need to be configured for this repo before the push job will succeed.

## Test plan

- [ ] PR build passes (matrix EF10 + EF11)
- [ ] Preview publish matrix builds produce `nuget-packages-ef10` and `nuget-packages-ef11` artifacts
- [ ] Push job downloads both artifacts via glob and pushes to NuGet.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)