### PR TITLE
docs(dynamodb-spec-tests): harden spec skill guidance

### DIFF
--- a/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
@@ -9,9 +9,11 @@ Use this skill when working on EF Core specification-test coverage for this prov
 upstream base classes, adding or repairing DynamoDB spec tests, classifying inherited methods,
 updating compliance inventory, and keeping coverage docs aligned.
 
-Spec tests are expensive because each inherited EF Core method needs a decision: pass, adapt, skip
-for a real DynamoDB constraint, or expose a provider gap. Before editing, understand the upstream
-fixture model and DynamoDB mapping constraints for every entity involved.
+Spec tests are expensive because each inherited EF Core method needs an evidence-backed decision:
+pass, adapt, skip for a real DynamoDB constraint, fix a provider gap, or repair a test/fixture bug.
+Before editing, understand the upstream fixture model and DynamoDB mapping constraints for every
+entity involved. Do not classify failures by instinct; run the inherited test surface first, then
+triage failures with evidence.
 
 ## Start by loading context
 
@@ -104,10 +106,19 @@ public sealed class XxxDynamoTestDefault : XxxDynamoTest
 }
 ```
 
-8. Override every inherited test method. No method left undecided.
-9. Update `ComplianceDynamoTest.GetBaseTestClasses()` when adding/removing implemented base class.
-10. Update `docs/spec-test-coverage.md` in same change.
-11. Run focused tests, then compliance/broader spec tests when practical.
+8. Override every inherited test method. No method left undecided. First pass should keep methods
+   unblocked: call `base` for all plausibly supported cases, wrap expected sync-query paths with
+   `NoSyncTest`, and avoid skips until a failure has been investigated. Only pre-skip cases that are
+   obviously impossible from the method name/body and already covered by a canonical `SkipReason`
+   such as joins, navigations, or `GROUP BY`.
+9. Run the whole target class or method family with all overrides present. Treat the first red run
+   as
+   the classification input, not as failure of the implementation approach.
+10. Split failures into small clusters and use scout/research subagents for triage when available;
+    see "Subagent failure triage workflow" below. The parent agent owns final classification.
+11. Update `ComplianceDynamoTest.GetBaseTestClasses()` when adding/removing implemented base class.
+12. Update `docs/spec-test-coverage.md` in same change.
+13. Run focused tests, then compliance/broader spec tests when practical.
 
 ## Override decision taxonomy
 
@@ -146,11 +157,16 @@ handling or skips.
 ### Real DynamoDB architectural constraint
 
 Skip only after verifying test shape requires something DynamoDB/PartiQL/provider model cannot
-support. Use `SkipReason` constants from
-`tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs`
-for shared durable constraints; this shared file supersedes stale guidance that says to define skip
-constants per class. Method-specific translation limitations may use a local/literal skip reason;
-promote repeated reasons to `SkipReason` when they recur across classes.
+support. DynamoDB PartiQL supports a DynamoDB-specific subset centered on `SELECT`, `INSERT`,
+`UPDATE`, and `DELETE`; it is not relational SQL. Durable unsupported areas include joins,
+relational navigation graphs, arbitrary multi-table relationship behavior, `GROUP BY`, set
+operations, explicit EF transaction scopes, and key shapes DynamoDB tables cannot represent.
+
+Centralize skip reasons in
+`tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs`. Use existing constants for
+shared durable constraints and add new constants there when a reason is likely to recur. Do not add
+per-class skip constants. Avoid local/literal skip strings except for truly one-off upstream quirks
+that should not become shared policy.
 
 Keep skipped overrides wired to the inherited base implementation whenever possible. Do not copy
 legacy empty skipped overrides or `Task.CompletedTask` skip bodies from older classes; introduce
@@ -175,7 +191,9 @@ Common durable constraints:
 ### Provider gap
 
 If test expectation is compatible with DynamoDB and PartiQL, do not hide it behind an architectural
-skip. Fix provider, or document an explicit tracked provider-gap skip if fix exceeds task scope.
+skip. Treat it as provider work: fix provider behavior so the spec test passes, or leave a narrowly
+documented provider-gap skip only when the fix exceeds approved scope. Provider-gap skip reasons
+should also be centralized in `SkipReason.cs` when they are durable or repeated.
 
 Typical provider-gap areas:
 
@@ -187,29 +205,53 @@ Typical provider-gap areas:
 - execution in `src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs`
 - type mapping in `src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs`
 
-## Scout/subagent failure triage
+## Subagent failure triage workflow
 
-After first implementation pass, run target tests and split failures. If subagents are available in
-the parent/orchestrator session, use scout-style delegation: one scout per failing method or small
-cluster. Do not launch subagents from child-worker sessions. If delegation is unavailable, perform
-the same evidence checklist inline.
+Use subagents to save parent-context tokens after the first red run. This is a core part of the
+workflow, not optional polish, when many inherited tests fail.
+
+1. Ensure every inherited method is overridden and runnable. Nothing should be left blocked by the
+   override guard.
+2. Run the whole target class or focused method family.
+3. Group failures by method or by same exception/query-shape cluster.
+4. In the parent/orchestrator session, launch scout/research subagents for each failure or cluster.
+   Prefer fresh-context scouts with the failure output and exact file paths. Do not launch subagents
+   from child-worker sessions.
+5. Require each scout to classify the failure as exactly one primary category:
+  - **DynamoDB architectural constraint**: DynamoDB/PartiQL cannot express the behavior, e.g.
+    joins, relationship navigation graphs, `GROUP BY`, set operations, unsupported key shape, or
+    explicit transaction semantics. Result: skip with canonical `SkipReason` and update docs/counts
+    when coverage meaning changes.
+  - **Provider gap**: DynamoDB/PartiQL can express the behavior, but this provider cannot translate,
+    generate, execute, materialize, or map it yet. Result: update provider and make test pass unless
+    scope explicitly says to defer with a tracked centralized skip reason.
+  - **Test/fixture bug**: mapping, table/key config, seed data, logging hook, scan opt-in, or
+    assertion baseline is wrong. Result: fix spec fixture/test code.
+  - **Expected sync-query path**: failure is from unsupported sync query enumeration. Result: wrap
+    with `NoSyncTest`, not a skip.
+  - **Environmental failure**: DynamoDB Local/Testcontainers/SDK setup issue. Result: fix or report
+    environment; do not change support classification.
+6. Parent agent reconciles scout reports, applies fixes/skips centrally, and keeps `SkipReason.cs`,
+   `ComplianceDynamoTest`, and `docs/spec-test-coverage.md` consistent.
 
 Scout prompt shape:
 
 ```text
 Analyze failing spec test <Class.Method>. Read upstream base method, Dynamo override, fixture, and failure output.
 Return: upstream intent, observed failure, generated PartiQL/error, DynamoDB support classification
-(architecture constraint vs provider gap vs test/fixture bug vs expected sync path), recommended code change,
-needed SkipReason/docs update, and confidence.
+(DynamoDB architectural constraint vs provider gap vs test/fixture bug vs expected sync path vs environmental),
+recommended code change, needed SkipReason/docs update, and confidence.
+If claiming unsupported, cite the DynamoDB/PartiQL capability gap. If claiming provider gap, name likely provider file.
 ```
 
 Require each scout to answer with evidence, not vibes:
 
-- exact base method behavior
-- exact exception or PartiQL mismatch
-- whether Cosmos/Mongo implement/skip comparable method
+- exact base method behavior and assertion intent
+- exact exception, generated PartiQL, or baseline mismatch
+- whether Cosmos/Mongo implement/skip comparable method, when relevant
 - DynamoDB/PartiQL limitation if claiming unsupported
 - provider file likely responsible if claiming provider gap
+- smallest safe code/test/doc change
 
 Then reconcile scouts centrally. Do not let scouts mass-skip failures; classify each one from
 evidence. Human/lead agent makes final classification.

--- a/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dynamodb-efcore-specification-tests
-description: Use when implementing, extending, classifying, or debugging EF Core cross-provider specification tests for the DynamoDB EF Core provider, especially Specification.Tests bases, *TestBase<TFixture> inheritance, Dynamo test overrides, ComplianceDynamoTest inventory, skip/pass/fail classification, and spec-test coverage planning.
+description: "Use for DynamoDB EF Core specification-test work: adding, extending, classifying, or debugging tests under tests/EntityFrameworkCore.DynamoDb.SpecificationTests, overriding EF Core *TestBase<TFixture> bases, triaging pass/skip/fail outcomes, updating ComplianceDynamoTest, or editing docs/spec-test-coverage.md. Not for normal unit/integration suites."
 ---
 
 # DynamoDB EF Core Specification Tests
@@ -28,7 +28,10 @@ triage failures with evidence.
   - candidate status (`Implemented`, `Implement Next`, `Future`, `Skip`)
   - method counts and notes
   - threshold rule for newly implemented base classes: implement only when DynamoDB can meaningfully
-    cover about 70% or more of unique methods, including accurate explicit skips
+    cover about 70% or more of unique methods. Count passing/adapted methods, intentional sync
+    wrappers, and durable DynamoDB architectural skips. Do not count provider-gap deferrals as
+    coverage. If a class would be mostly skips, implement only when the docs explicitly choose to
+    document that unsupported surface.
 3. Read target upstream EF Core base test from
    `~/Repos/CSharp/efcore/test/EFCore.Specification.Tests/`.
 4. Read closest existing DynamoDB spec class in same family. Prefer newer/compliant examples over
@@ -46,7 +49,10 @@ triage failures with evidence.
 2. Create or extend `*DynamoTest.cs` in `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/`.
 3. Reuse existing shared family fixtures when present, especially
    `NorthwindQueryDynamoFixture<TModelCustomizer>` and `BasicTypesQueryDynamoFixture`. Otherwise
-   create a fixture by extending the base fixture type from the upstream spec test.
+   create a fixture by extending the base fixture type from the upstream spec test. Inspect upstream
+   fixture hooks before copying patterns: `CreateContext`, `AddOptions`, `OnModelCreating`,
+   `CleanAsync`, `SeedAsync`, expected data, entity sorters/assertors, model customizers, service
+   replacement, logging, and test-store lifetime.
 4. Wire shared DynamoDB infrastructure:
   - all live-DynamoDB fixtures: `DynamoTestStoreFactory.Instance`
   - all live-DynamoDB fixtures:
@@ -108,16 +114,26 @@ public sealed class XxxDynamoTestDefault : XxxDynamoTest
 
 8. Override every inherited test method. No method left undecided. First pass should keep methods
    unblocked: call `base` for inherited tests and wrap expected sync-query paths with `NoSyncTest`.
-   Do not add support-classification skips before the first red run; failures are the evidence used
-   for classification.
-9. Run the whole target class or method family with all overrides present. Treat the first red run as
+   Avoid support-classification skips before the first red run; failures are the evidence used for
+   classification. Exception: when the upstream method body clearly and statically requires a
+   durable DynamoDB constraint (navigation graph, FK relationship, keyless type, explicit
+   transaction, >2-part key), an early skip is acceptable only with a cited upstream shape and
+   centralized `SkipReason`. Never pre-skip provider gaps.
+9. For large inherited surfaces, bootstrap mechanically: create the class/fixture skeleton, compile,
+   run only the override guard, copy missing method names/signatures from guard failures, preserve
+   upstream attributes/parameters/return types, and repeat until the guard passes. Redirect test
+   output to a file if the runner truncates guard failures. Use simple base calls or `NoSyncTest`
+   wrappers first; do not hand-classify 100+ methods from memory.
+10. Run the whole target class or method family with all overrides present. Treat the first red run as
    the classification input, not as failure of the implementation approach.
-10. Split failures into small clusters and use scout/research subagents for triage when there is more
+11. Split failures into small clusters and use scout/research subagents for triage when there is more
     than one failure or a failure has unclear support status; see "Subagent failure triage workflow"
     below. The parent agent owns final classification.
-11. Update `ComplianceDynamoTest.GetBaseTestClasses()` when adding/removing implemented base class.
-12. Update `docs/spec-test-coverage.md` in same change.
-13. Run focused tests, then compliance/broader spec tests when practical.
+12. Update `ComplianceDynamoTest.GetBaseTestClasses()` when adding/removing implemented base class.
+    If a base exists only for some target frameworks, wrap `using` statements and `yield return`
+    entries in matching `#if` guards.
+13. Update `docs/spec-test-coverage.md` in same change.
+14. Run focused tests, then compliance/broader spec tests when practical.
 
 ## Override decision taxonomy
 
@@ -165,11 +181,13 @@ operations, explicit EF transaction scopes, and key shapes DynamoDB tables canno
 
 Centralize skip reasons in
 `tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs`. Use existing constants or add
-new constants there. Do not add per-class constants or local/literal skip strings.
+new constants there. Do not add per-class constants or local/literal skip strings for new work;
+legacy tests may still contain older patterns.
 
 Keep skipped overrides wired to the inherited base implementation whenever possible. Do not copy
-legacy empty skipped overrides or `Task.CompletedTask` skip bodies from older classes; introduce
-such exceptions only when calling base is unsafe, and document why.
+legacy empty skipped overrides or `Task.CompletedTask` skip bodies from older classes. Introduce a
+no-op skipped body only when calling base is unsafe (for example, model creation fails before xUnit
+can apply the skip), and add an adjacent comment naming the unsafe side effect or exception.
 
 ```csharp
 [ConditionalTheory(Skip = SkipReason.JoinsNotSupported)]
@@ -192,7 +210,9 @@ Common durable constraints:
 If test expectation is compatible with DynamoDB and PartiQL, do not hide it behind an architectural
 skip. Treat it as provider work and fix provider behavior so the spec test passes. Defer with a
 provider-gap skip only when the user explicitly approves deferral or the task scope forbids provider
-changes; the skip reason must be centralized in `SkipReason.cs` and mention the tracked gap.
+changes; the skip reason must be centralized in `SkipReason.cs` and mention the tracked gap. Existing
+provider-gap constants are not blanket permission to skip new failures; cite the tracked issue or
+scope decision when using them.
 
 Typical provider-gap areas:
 
@@ -203,6 +223,13 @@ Typical provider-gap areas:
   `src/EntityFrameworkCore.DynamoDb/Query/Internal/DynamoShapedQueryCompilingExpressionVisitor.cs`
 - execution in `src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs`
 - type mapping in `src/EntityFrameworkCore.DynamoDb/Storage/DynamoTypeMappingSource.cs`
+
+Route by symptom:
+
+- “could not be translated” or method-call pattern missing → translator visitors/method translators
+- malformed or baseline-mismatched PartiQL → `DynamoQuerySqlGenerator` or stale `AssertSql`
+- AWS SDK validation/runtime item mismatch → `DynamoClientWrapper` or serializer/wire-shape code
+- wrong CLR values/materialization → shaped-query compiler or type mapping
 
 ## Subagent failure triage workflow
 
@@ -216,7 +243,8 @@ workflow, not optional polish, when many inherited tests fail.
 4. In the parent/orchestrator session, launch scout/research subagents for each failure or cluster
    when there is more than one failure or a failure has unclear support status. Prefer fresh-context
    scouts with the failure output and exact file paths. Use researcher only when external DynamoDB,
-   PartiQL, or EF Core evidence is needed. Do not launch subagents from child-worker sessions.
+   PartiQL, or EF Core evidence is needed. Do not launch subagents from child-worker sessions; if
+   running as a child/subagent, do local targeted triage and return failure clusters to the parent.
 5. Require each scout to classify the failure as exactly one primary category:
    - **DynamoDB architectural constraint**: DynamoDB/PartiQL cannot express the behavior, e.g.
      joins, relationship navigation graphs, `GROUP BY`, set operations, unsupported key shape, or
@@ -245,7 +273,12 @@ recommended code change, needed SkipReason/docs update, and confidence.
 If claiming unsupported, cite the DynamoDB/PartiQL capability gap. If claiming provider gap, name likely provider file.
 ```
 
-Require each scout to answer with evidence, not vibes:
+Require each scout to answer with evidence, not vibes. A compact table is ideal:
+
+| Method | Upstream intent/line | Dynamo override | Async/sync | Exception or PartiQL | Capability evidence | Classification | Action | Skip/docs impact |
+| ------ | -------------------- | --------------- | ---------- | -------------------- | ------------------- | -------------- | ------ | ---------------- |
+
+Include:
 
 - exact base method behavior and assertion intent
 - exact exception, generated PartiQL, or baseline mismatch
@@ -278,8 +311,9 @@ If any answer is no, keep triaging. Do not convert uncertainty into a skip.
 
 For each failure ask, in order:
 
-1. Did sync variant run? Use `DynamoTestHelpers.Instance.NoSyncTest(...)` or a local wrapper if
-   failure is expected sync query enumeration.
+1. Did sync variant run? Use inherited/local `NoSyncTest(...)` when existing family classes expose
+   one; otherwise use `DynamoTestHelpers.Instance.NoSyncTest(...)` if failure is expected sync query
+   enumeration.
 2. Is fixture wrong? Missing table/key/ignored navigation/seed data often masquerades as provider
    bug.
 3. Is `AssertSql` stale? Inspect captured `PartiQL baseline mismatch` details.
@@ -290,7 +324,8 @@ For each failure ask, in order:
    changes.
 6. Can DynamoDB PartiQL express query? If yes, treat failure as provider gap until proven otherwise.
 7. Is result ordering assumed without stable DynamoDB order? Use existing ordered-result skip reason
-   or adapt assertion only when base allows.
+   or adapt assertion only when base allows. Sort-key queries may have stable DynamoDB order; scans
+   and many filtered shapes do not.
 8. Is failure environmental? DynamoDB Local/Testcontainers/setup failure should not change test
    classification.
 
@@ -318,19 +353,19 @@ must agree.
 Use the .NET test MCP server when available. CLI fallback focused class/method:
 
 ```bash
-dotnet test tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --filter "FullyQualifiedName~ClassOrMethod"
+task test:spec CONFIG="Debug EF10" FILTER="FullyQualifiedName~ClassOrMethod"
 ```
 
 Compliance inventory:
 
 ```bash
-dotnet test tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj --filter "FullyQualifiedName~ComplianceDynamoTest"
+task test:spec CONFIG="Debug EF10" FILTER="FullyQualifiedName~ComplianceDynamoTest"
 ```
 
 Full spec project when practical:
 
 ```bash
-dotnet test tests/EntityFrameworkCore.DynamoDb.SpecificationTests/EntityFrameworkCore.DynamoDb.SpecificationTests.csproj
+task test:spec:all
 ```
 
 When debugging query baselines, inspect assertion failures and captured `PartiQL baseline mismatch`

--- a/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
+++ b/.agents/skills/dynamodb-efcore-specification-tests/SKILL.md
@@ -107,22 +107,23 @@ public sealed class XxxDynamoTestDefault : XxxDynamoTest
 ```
 
 8. Override every inherited test method. No method left undecided. First pass should keep methods
-   unblocked: call `base` for all plausibly supported cases, wrap expected sync-query paths with
-   `NoSyncTest`, and avoid skips until a failure has been investigated. Only pre-skip cases that are
-   obviously impossible from the method name/body and already covered by a canonical `SkipReason`
-   such as joins, navigations, or `GROUP BY`.
-9. Run the whole target class or method family with all overrides present. Treat the first red run
-   as
+   unblocked: call `base` for inherited tests and wrap expected sync-query paths with `NoSyncTest`.
+   Do not add support-classification skips before the first red run; failures are the evidence used
+   for classification.
+9. Run the whole target class or method family with all overrides present. Treat the first red run as
    the classification input, not as failure of the implementation approach.
-10. Split failures into small clusters and use scout/research subagents for triage when available;
-    see "Subagent failure triage workflow" below. The parent agent owns final classification.
+10. Split failures into small clusters and use scout/research subagents for triage when there is more
+    than one failure or a failure has unclear support status; see "Subagent failure triage workflow"
+    below. The parent agent owns final classification.
 11. Update `ComplianceDynamoTest.GetBaseTestClasses()` when adding/removing implemented base class.
 12. Update `docs/spec-test-coverage.md` in same change.
 13. Run focused tests, then compliance/broader spec tests when practical.
 
 ## Override decision taxonomy
 
-For each inherited method, classify before coding.
+For each inherited method, classify before finalizing the override. The first implementation pass
+runs inherited methods to collect evidence; the final pass turns that evidence into supported calls,
+fixture fixes, provider fixes, sync wrappers, or centralized skips.
 
 ### Supported async query or behavior
 
@@ -163,10 +164,8 @@ relational navigation graphs, arbitrary multi-table relationship behavior, `GROU
 operations, explicit EF transaction scopes, and key shapes DynamoDB tables cannot represent.
 
 Centralize skip reasons in
-`tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs`. Use existing constants for
-shared durable constraints and add new constants there when a reason is likely to recur. Do not add
-per-class skip constants. Avoid local/literal skip strings except for truly one-off upstream quirks
-that should not become shared policy.
+`tests/EntityFrameworkCore.DynamoDb.SpecificationTests/SkipReason.cs`. Use existing constants or add
+new constants there. Do not add per-class constants or local/literal skip strings.
 
 Keep skipped overrides wired to the inherited base implementation whenever possible. Do not copy
 legacy empty skipped overrides or `Task.CompletedTask` skip bodies from older classes; introduce
@@ -191,9 +190,9 @@ Common durable constraints:
 ### Provider gap
 
 If test expectation is compatible with DynamoDB and PartiQL, do not hide it behind an architectural
-skip. Treat it as provider work: fix provider behavior so the spec test passes, or leave a narrowly
-documented provider-gap skip only when the fix exceeds approved scope. Provider-gap skip reasons
-should also be centralized in `SkipReason.cs` when they are durable or repeated.
+skip. Treat it as provider work and fix provider behavior so the spec test passes. Defer with a
+provider-gap skip only when the user explicitly approves deferral or the task scope forbids provider
+changes; the skip reason must be centralized in `SkipReason.cs` and mention the tracked gap.
 
 Typical provider-gap areas:
 
@@ -214,23 +213,25 @@ workflow, not optional polish, when many inherited tests fail.
    override guard.
 2. Run the whole target class or focused method family.
 3. Group failures by method or by same exception/query-shape cluster.
-4. In the parent/orchestrator session, launch scout/research subagents for each failure or cluster.
-   Prefer fresh-context scouts with the failure output and exact file paths. Do not launch subagents
-   from child-worker sessions.
+4. In the parent/orchestrator session, launch scout/research subagents for each failure or cluster
+   when there is more than one failure or a failure has unclear support status. Prefer fresh-context
+   scouts with the failure output and exact file paths. Use researcher only when external DynamoDB,
+   PartiQL, or EF Core evidence is needed. Do not launch subagents from child-worker sessions.
 5. Require each scout to classify the failure as exactly one primary category:
-  - **DynamoDB architectural constraint**: DynamoDB/PartiQL cannot express the behavior, e.g.
-    joins, relationship navigation graphs, `GROUP BY`, set operations, unsupported key shape, or
-    explicit transaction semantics. Result: skip with canonical `SkipReason` and update docs/counts
-    when coverage meaning changes.
-  - **Provider gap**: DynamoDB/PartiQL can express the behavior, but this provider cannot translate,
-    generate, execute, materialize, or map it yet. Result: update provider and make test pass unless
-    scope explicitly says to defer with a tracked centralized skip reason.
-  - **Test/fixture bug**: mapping, table/key config, seed data, logging hook, scan opt-in, or
-    assertion baseline is wrong. Result: fix spec fixture/test code.
-  - **Expected sync-query path**: failure is from unsupported sync query enumeration. Result: wrap
-    with `NoSyncTest`, not a skip.
-  - **Environmental failure**: DynamoDB Local/Testcontainers/SDK setup issue. Result: fix or report
-    environment; do not change support classification.
+   - **DynamoDB architectural constraint**: DynamoDB/PartiQL cannot express the behavior, e.g.
+     joins, relationship navigation graphs, `GROUP BY`, set operations, unsupported key shape, or
+     explicit transaction semantics. Result: skip with canonical `SkipReason` and update docs/counts
+     when coverage meaning changes.
+   - **Provider gap**: DynamoDB/PartiQL can express the behavior, but this provider cannot translate,
+     generate, execute, materialize, or map it yet. Result: update provider and make test pass unless
+     the user explicitly approves deferral or scope forbids provider changes; any deferred skip uses
+     a tracked centralized `SkipReason`.
+   - **Test/fixture bug**: mapping, table/key config, seed data, logging hook, scan opt-in, or
+     assertion baseline is wrong. Result: fix spec fixture/test code.
+   - **Expected sync-query path**: failure is from unsupported sync query enumeration. Result: wrap
+     with `NoSyncTest`, not a skip.
+   - **Environmental failure**: DynamoDB Local/Testcontainers/SDK setup issue. Result: fix or report
+     environment; do not change support classification.
 6. Parent agent reconciles scout reports, applies fixes/skips centrally, and keeps `SkipReason.cs`,
    `ComplianceDynamoTest`, and `docs/spec-test-coverage.md` consistent.
 
@@ -255,6 +256,23 @@ Require each scout to answer with evidence, not vibes:
 
 Then reconcile scouts centrally. Do not let scouts mass-skip failures; classify each one from
 evidence. Human/lead agent makes final classification.
+
+## Pressure-test support decisions
+
+Before marking a class or method cluster done, challenge every skip and provider-gap decision:
+
+- Did every inherited method run in the first red pass, then end as a supported call, intentional
+  sync-query wrapper, fixture/provider fix, or centralized `SkipReason` skip?
+- For every skip, is the reason a durable DynamoDB/PartiQL/model constraint rather than current
+  provider behavior?
+- For every provider-gap failure, did the agent identify the likely provider layer and attempt the
+  fix when in scope?
+- Did at least one scout report, external source, upstream base method, or comparable provider test
+  support each non-obvious classification?
+- Are `SkipReason.cs`, `ComplianceDynamoTest`, and `docs/spec-test-coverage.md` consistent with the
+  final classification?
+
+If any answer is no, keep triaging. Do not convert uncertainty into a skip.
 
 ## Failure triage checklist
 

--- a/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
+++ b/tests/EntityFrameworkCore.DynamoDb.SpecificationTests/AGENTS.md
@@ -122,16 +122,17 @@ public override void Some_sync_test()
     => NoSyncTest(() => base.Some_sync_test());
 ```
 
-**Unsupported scenarios** — keep override wired to base implementation, even when skipped. Do not
-use empty bodies or `Task.CompletedTask`; calling base preserves future compatibility if skip
-removed or condition changes:
+**Unsupported scenarios** — use centralized constants from `SkipReason.cs` for recurring provider
+limitations and keep overrides wired to base implementation, even when skipped. Do not use empty
+bodies or `Task.CompletedTask`; calling base preserves future compatibility if skip removed or
+condition changes:
 
 ```csharp
-[ConditionalFact(Skip = "DynamoDB does not support composite keys.")]
+[ConditionalFact(Skip = SkipReason.ThreePartCompositeKeysNotSupported)]
 public override void Some_unsupported_test()
     => base.Some_unsupported_test();
 
-[ConditionalTheory(Skip = "DynamoDB does not support composite keys.")]
+[ConditionalTheory(Skip = SkipReason.ThreePartCompositeKeysNotSupported)]
 public override Task Some_unsupported_test_async(CancellationType ct)
     => base.Some_unsupported_test_async(ct);
 ```
@@ -153,11 +154,12 @@ public override async Task Some_async_test(CancellationType ct)
 
 ## Known DynamoDB Limitations
 
-| Feature        | Skip reason                            |
-| -------------- | -------------------------------------- |
-| Composite keys | `SkipReason.CompositeKeysNotSupported` |
-| Nullable keys  | `SkipReason.NullableKeysNotSupported`  |
-| Shadow keys    | `SkipReason.ShadowKeysNotSupported`    |
+| Feature                   | Skip reason                                     |
+| ------------------------- | ----------------------------------------------- |
+| Three-part composite keys | `SkipReason.ThreePartCompositeKeysNotSupported` |
+| Nullable keys             | `SkipReason.NullableKeysNotSupported`           |
+| Shadow keys               | `SkipReason.ShadowKeysNotSupported`             |
 
-Use shared constants from `SkipReason.cs` for recurring provider limitations. Use local/literal skip
-reasons only for one-off method-specific gaps.
+Use shared constants from `SkipReason.cs` for skip reasons in new work. Add a new centralized
+constant when none exists. Older tests may still contain local/literal reasons, but avoid adding new
+ones unless there is a deliberate one-off assertion with no provider-support meaning.


### PR DESCRIPTION
## Summary

Tightens the DynamoDB EF Core specification-test skill after review and pressure testing. The updates make the workflow safer for large inherited EF Core spec surfaces by clarifying when to run first-red passes, how to count coverage, and how to avoid turning provider gaps into skips.

## Changes

- Clarified skill trigger text so it targets `tests/EntityFrameworkCore.DynamoDb.SpecificationTests`, `ComplianceDynamoTest`, and `docs/spec-test-coverage.md` while excluding normal unit/integration suites.
- Added guidance for large inherited test surfaces: mechanical override-guard bootstrap, fixture hook inspection, output redirection, and framework-conditional compliance entries.
- Tightened failure triage rules around durable DynamoDB constraints, provider-gap deferrals, no-op skipped overrides, subagent triage evidence, and symptom-to-provider-layer routing.
- Aligned the spec-test local `AGENTS.md` examples with centralized `SkipReason` usage and the existing `ThreePartCompositeKeysNotSupported` constant.

## Validation

- Ran `git diff --check`.
- Sanity-checked skill frontmatter parsing with `python3`.
- Pressure-tested with subagent review/scout passes; no blocker/high-risk findings remained after follow-up edits.

## Notes for Reviewers

This is documentation/agent-instruction only. No product code or test behavior changes.
