### PR TITLE
test(query): cover binary query translations

### DIFF
--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/QueryTypeMappingTable/QueryTypeMappingTests.cs
@@ -122,6 +122,65 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
     }
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Binary_length_filter_returns_expected_item()
+    {
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.BinaryValue.Length == 4)
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#1");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE size("binaryValue") = 4
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Binary_sequence_equal_parameter_returns_expected_item()
+    {
+        var value = new byte[] { 5, 6, 7 };
+
+        var result = await Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.BinaryValue.SequenceEqual(value))
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        result.Should().Equal("ITEM#2");
+
+        AssertSql(
+            """
+            SELECT "pk"
+            FROM "QueryTypeMappingItems"
+            WHERE "binaryValue" = ?
+            """);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Binary_contains_byte_is_rejected()
+    {
+        var act = () => Db
+            .Items
+            .AsNoTracking()
+            .Where(item => item.BinaryValue.Contains((byte)5))
+            .Select(item => item.Pk)
+            .ToListAsync(CancellationToken);
+
+        await act
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage(
+                "*could not be translated*Contains translation supports in-memory collection membership only*");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public async Task Numeric_enum_parameter_comparison_returns_expected_item()
     {
         var status = MappingStatus.Active;
@@ -337,7 +396,7 @@ public class QueryTypeMappingTests : QueryTypeMappingTestFixture
             .Should()
             .OnlyContain(statement => statement
                 == """
-                   SELECT "pk", "$type", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
+                   SELECT "pk", "$type", "binaryValue", "nullableShortValue", "nullableStringStatus", "numericStatus", "shortValue", "stringStatus", "profile"
                    FROM "QueryTypeMappingItems"
                    WHERE "stringStatus" IN [?, ?, ?]
                    """);
@@ -467,6 +526,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["stringStatus"] = new AttributeValue { S = nameof(MappingStatus.Active) },
             ["nullableStringStatus"] =
                 new AttributeValue { S = nameof(MappingStatus.Active) },
+            ["binaryValue"] = new AttributeValue { B = new MemoryStream([1, 2, 3, 4]) },
             ["profile"] =
                 new AttributeValue
                 {
@@ -485,6 +545,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["numericStatus"] = new AttributeValue { N = "0" },
             ["stringStatus"] = new AttributeValue { S = nameof(MappingStatus.Inactive) },
             ["nullableStringStatus"] = new AttributeValue { NULL = true },
+            ["binaryValue"] = new AttributeValue { B = new MemoryStream([5, 6, 7]) },
             ["profile"] =
                 new AttributeValue
                 {
@@ -504,6 +565,7 @@ public class QueryTypeMappingTestFixture : DynamoTestFixtureBase
             ["stringStatus"] = new AttributeValue { S = nameof(MappingStatus.Pending) },
             ["nullableStringStatus"] =
                 new AttributeValue { S = nameof(MappingStatus.Pending) },
+            ["binaryValue"] = new AttributeValue { B = new MemoryStream([8, 9]) },
             ["profile"] = new AttributeValue
             {
                 M = new Dictionary<string, AttributeValue>
@@ -530,6 +592,7 @@ public sealed class QueryTypeMappingDbContext(DbContextOptions options) : DbCont
                 .Property(item => item.NullableShortValue)
                 .HasAttributeName("nullableShortValue");
             builder.Property(item => item.NumericStatus).HasAttributeName("numericStatus");
+            builder.Property(item => item.BinaryValue).HasAttributeName("binaryValue");
             builder
                 .Property(item => item.StringStatus)
                 .HasAttributeName("stringStatus")
@@ -558,6 +621,8 @@ public sealed record QueryTypeMappingItem
     public MappingStatus StringStatus { get; set; }
 
     public MappingStatus? NullableStringStatus { get; set; }
+
+    public byte[] BinaryValue { get; set; } = [];
 
     public QueryTypeMappingProfile Profile { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
Adds focused integration coverage for DynamoDB binary (`byte[]`) query semantics after enabling binary length and equality translation. This confirms the provider aligns with DynamoDB: `byte[]` is one Binary scalar, not a byte collection.

## Changes
- Adds seeded binary attributes to `QueryTypeMappingItems`.
- Covers `byte[].Length` translation to `size(attr)`.
- Covers `byte[].SequenceEqual(parameter)` translation to binary equality with a parameter.
- Confirms `byte[].Contains(byte)` remains rejected because membership semantics require DynamoDB list/set attributes, not Binary scalars.

## Validation
- `task test CONFIG="Debug EF10" FILTER="FullyQualifiedName~QueryTypeMappingTests"`
- `task test:ef11`

## Notes for Reviewers
The main binary translation change was already pushed to `main` in commit `e34e625`; this PR adds the requested focused validation/fix coverage on top.