### PR TITLE
ci(github): add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'LayeredCraft/dynamodb-efcore-provider'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a hardened GitHub Actions workflow for Dependabot automation based on the Minimal Lambda pattern. Dependabot PRs for semver minor/patch updates are approved and queued for squash auto-merge after required checks pass.

## Changes

- Added `.github/workflows/dependabot-auto-merge.yml`.
- Uses `pull_request_target` so the workflow can perform approval/auto-merge mutations with `GITHUB_TOKEN`, while avoiding checkout or execution of PR-controlled code.
- Restricts execution to `dependabot[bot]` PRs in `LayeredCraft/dynamodb-efcore-provider`.
- Pins `dependabot/fetch-metadata` to commit `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (`v3`).
- Approves and enables squash auto-merge only for `version-update:semver-minor` and `version-update:semver-patch` updates.

## Validation

- Compared behavior against Minimal Lambda's existing Dependabot automation.
- Reviewed by 8 subagent passes covering workflow correctness, branch protection, security/supply chain, maintainability, Dependabot grouping, validation, and final post-fix security.
- Parsed the workflow YAML locally with Ruby.
- Checked whitespace with `git diff --check`.
- Confirmed GitHub can load the workflow from this branch with `gh workflow view --ref ci/dependabot-auto-merge --yaml`.
- Confirmed existing PR title workflow skips Dependabot PRs through the shared template.
- Confirmed branch protection requires `build / build`, so auto-merge will wait for the required build check.
- Did not run product test suites; change is GitHub workflow-only.

## Notes for Reviewers

Repository **Allow auto-merge** has been enabled (`allow_auto_merge: true`).

One organization-level setting still blocks end-to-end auto-approval: **Allow GitHub Actions to create and approve pull requests**. Attempting to enable it at the repo level fails with:

```text
gh: The organization does not allow GitHub Actions to create or approve pull requests (Conflict)
```

Org admin action required before `gh pr review --approve` can work:

- Enable org setting allowing Actions to create/approve PRs, then enable it for this repo.
