### PR TITLE
fix: use resolved version in release-drafter tag templates

### DIFF
--- a/.github/release-drafter-ef10.yml
+++ b/.github/release-drafter-ef10.yml
@@ -1,4 +1,4 @@
-tag-template: 'v10.$MINOR.$PATCH'
+tag-template: 'v$RESOLVED_VERSION'
 filter-by-range: '>=10.0.0 <11.0.0'
 version-template: '10.$MINOR.$PATCH'
 name-template: 'v$RESOLVED_VERSION (EF Core 10)'

--- a/.github/release-drafter-ef11.yml
+++ b/.github/release-drafter-ef11.yml
@@ -1,4 +1,4 @@
-tag-template: 'v11.$MINOR.$PATCH'
+tag-template: 'v$RESOLVED_VERSION'
 filter-by-range: '>=11.0.0 <12.0.0'
 version-template: '11.$MINOR.$PATCH'
 name-template: 'v$RESOLVED_VERSION (EF Core 11)'


### PR DESCRIPTION
## Summary
- `tag-template` in `release-drafter-ef10.yml`/`-ef11.yml` referenced `$MINOR`/`$PATCH` directly, but those tokens are only resolved while computing `$RESOLVED_VERSION` from `version-template` — they're not separately available inside `tag-template`.
- This produced drafted/published releases with a literal, unsubstituted tag like `v10.$MINOR.$PATCH` instead of `v10.0.0`.
- Fix: `tag-template` now uses `v$RESOLVED_VERSION`, matching the pattern already used correctly in `name-template`.

## Test plan
- [ ] Manually trigger `Release Drafter` workflow (`workflow_dispatch`) after merge and confirm both EF10/EF11 drafts show correct tags (`v10.x.x`, `v11.x.x`) with no literal `$MINOR`/`$PATCH`.