### PR TITLE
fix(deps): update testcontainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.XunitV3" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.XunitV3" Version="4.14.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.2.0" />


### PR DESCRIPTION
## Summary

Updates Testcontainers DynamoDB and xUnit packages to 4.14.0. This releases the CI restore block by resolving SSH.NET 2026.0.0, the patched version for GHSA-q939-rpr3-3284.

## Changes

- Update Testcontainers.DynamoDb to 4.14.0.
- Update Testcontainers.XunitV3 to 4.14.0.

## Validation

- `task test:ef10`
- `task test:ef11`
- Confirmed integration and specification restore graphs resolve `SSH.NET` 2026.0.0.