### PR TITLE
feat(diagnostics): emit ConsumedCapacity event into the Capacity logger category

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -51,12 +51,13 @@ development and test contexts, not production deployments.
 
 ## What Gets Logged
 
-The provider uses two EF Core logger categories:
+The provider uses three EF Core logger categories:
 
-| Category           | Full Name                                        | Purpose                            |
-| ------------------ | ------------------------------------------------ | ---------------------------------- |
-| `Database.Command` | `Microsoft.EntityFrameworkCore.Database.Command` | Query and write execution          |
-| `Query`            | `Microsoft.EntityFrameworkCore.Query`            | Index selection during compilation |
+| Category           | Full Name                                         | Purpose                                     |
+| ------------------ | ------------------------------------------------- | ------------------------------------------- |
+| `Database.Command` | `Microsoft.EntityFrameworkCore.Database.Command`  | Query and write execution                   |
+| `Query`            | `Microsoft.EntityFrameworkCore.Query`             | Index selection during compilation          |
+| `Capacity`         | `Microsoft.EntityFrameworkCore.DynamoDB.Capacity` | RCU/WCU consumption and throttling (future) |
 
 **Command events** fire at runtime, once per query execution or once per write statement.
 
@@ -92,6 +93,8 @@ emitted as log events.
 
 Event IDs are stable across releases. You can use them to filter log output programmatically or
 in structured logging sinks.
+
+The `Capacity` category has no events yet; consumed-capacity logging arrives in a future release.
 
 ## Command Events
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -53,11 +53,11 @@ development and test contexts, not production deployments.
 
 The provider uses three EF Core logger categories:
 
-| Category           | Full Name                                         | Purpose                                     |
-| ------------------ | ------------------------------------------------- | ------------------------------------------- |
-| `Database.Command` | `Microsoft.EntityFrameworkCore.Database.Command`  | Query and write execution                   |
-| `Query`            | `Microsoft.EntityFrameworkCore.Query`             | Index selection during compilation          |
-| `Capacity`         | `Microsoft.EntityFrameworkCore.DynamoDB.Capacity` | RCU/WCU consumption and throttling (future) |
+| Category           | Full Name                                         | Purpose                            |
+| ------------------ | ------------------------------------------------- | ---------------------------------- |
+| `Database.Command` | `Microsoft.EntityFrameworkCore.Database.Command`  | Query and write execution          |
+| `Query`            | `Microsoft.EntityFrameworkCore.Query`             | Index selection during compilation |
+| `Capacity`         | `Microsoft.EntityFrameworkCore.DynamoDB.Capacity` | RCU/WCU consumption                |
 
 **Command events** fire at runtime, once per query execution or once per write statement.
 
@@ -90,11 +90,13 @@ emitted as log events.
 | `SecondaryIndexCandidateRejected`          | 30108    | `Query`            | Information | `DYNAMO_IDX005` |
 | `ExplicitIndexSelectionDisabled`           | 30109    | `Query`            | Information | `DYNAMO_IDX006` |
 | `ScanLikeQueryDetected`                    | 30111    | `Query`            | Warning     | —               |
+| `ConsumedCapacity`                         | 30117    | `Capacity`         | Information | —               |
 
 Event IDs are stable across releases. You can use them to filter log output programmatically or
 in structured logging sinks.
 
-The `Capacity` category has no events yet; consumed-capacity logging arrives in a future release.
+The `ConsumedCapacity` event fires only when `ReturnConsumedCapacity` is configured on the options
+builder, so DynamoDB includes capacity in the response.
 
 ## Command Events
 
@@ -351,6 +353,26 @@ info: Microsoft.EntityFrameworkCore.Query[30109]
       Index selection was suppressed for table 'Orders' by '.WithoutIndex()'. The query will execute against the base table.
 ```
 
+## Capacity Events
+
+### `ConsumedCapacity` — 30117
+
+Fires after DynamoDB reports consumed capacity for a query page or a write request. It lands in the
+`Microsoft.EntityFrameworkCore.DynamoDB.Capacity` category, so you can route capacity tracking
+independently of command logs:
+
+```csharp
+optionsBuilder.LogTo(
+    Console.WriteLine,
+    LogLevel.Information,
+    DbLoggerCategory.Capacity.Name);
+```
+
+The message reports the total estimated capacity units and how many consumed-capacity entries were
+returned. The `ConsumedCapacity` property on the event data carries the raw per-table/index
+entries. This event fires **only when** `ReturnConsumedCapacity` is configured on the options
+builder; otherwise DynamoDB omits capacity and no event is emitted.
+
 ## Interpreting Pagination Logs
 
 Each DynamoDB page produces a before/after pair of `ExecutingExecuteStatement` and
@@ -496,6 +518,7 @@ EF Core also publishes these events through `DiagnosticListener` using provider-
 | `DynamoPartiQlWriteRequestFailedEventData`   | `PartiQlWriteRequestFailed`                        |
 | `DynamoBatchStatementErrorsEventData`        | `BatchPartiQlWriteReturnedStatementErrors`         |
 | `DynamoQueryDiagnosticEventData`             | Index-selection events and `ScanLikeQueryDetected` |
+| `DynamoConsumedCapacityEventData`            | `ConsumedCapacity`                                 |
 
 Use `commandId` to join request start/completion/failure events in traces. Use AWS `requestId` for
 AWS Support cases and to correlate with SDK/service logs.

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DbLoggerCategory.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DbLoggerCategory.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Microsoft.EntityFrameworkCore.DynamoDB;
+
+/// <summary>
+/// DynamoDB-specific logger categories. Most DynamoDB events use standard EF Core categories
+/// from the <c>Microsoft.EntityFrameworkCore.Diagnostics.DbLoggerCategory</c> class; this class
+/// provides additional categories for provider-specific concerns rooted at
+/// <c>Microsoft.EntityFrameworkCore.DynamoDB</c>.
+/// </summary>
+public static class DbLoggerCategory
+{
+    /// <summary>
+    /// Category for DynamoDB capacity-unit consumption and throttling events.
+    /// Category name: <c>Microsoft.EntityFrameworkCore.DynamoDB.Capacity</c>.
+    /// </summary>
+    public sealed class Capacity : LoggerCategory<Capacity> { }
+}

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventData.cs
@@ -235,3 +235,22 @@ public class DynamoQueryDiagnosticEventData(
     /// <summary>Gets diagnostic message.</summary>
     public virtual string Message { get; } = message;
 }
+
+/// <summary>DiagnosticSource payload for DynamoDB consumed-capacity events.</summary>
+public class DynamoConsumedCapacityEventData(
+    EventDefinitionBase eventDefinition,
+    Func<EventDefinitionBase, EventData, string> messageGenerator,
+    Guid commandId,
+    IReadOnlyList<ConsumedCapacity> consumedCapacities) : EventData(
+    eventDefinition,
+    messageGenerator)
+{
+    /// <summary>Gets provider command id for correlating back to the consuming command event.</summary>
+    public virtual Guid CommandId { get; } = commandId;
+
+    /// <summary>Gets the consumed-capacity entries returned by DynamoDB for the operation.</summary>
+    public virtual IReadOnlyList<ConsumedCapacity> ConsumedCapacities { get; } = consumedCapacities;
+
+    /// <summary>Gets the total estimated capacity units consumed across all entries.</summary>
+    public virtual double CapacityUnits => ConsumedCapacities.Sum(c => c.CapacityUnits ?? 0);
+}

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/DynamoEventId.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
 
 namespace EntityFrameworkCore.DynamoDb.Diagnostics;
 
@@ -30,11 +31,15 @@ public static class DynamoEventId
         ExplicitIndexSelected = CoreEventId.ProviderBaseId + 107,
         SecondaryIndexCandidateRejected = CoreEventId.ProviderBaseId + 108,
         ExplicitIndexSelectionDisabled = CoreEventId.ProviderBaseId + 109,
-        ScanLikeQueryDetected = CoreEventId.ProviderBaseId + 111
+        ScanLikeQueryDetected = CoreEventId.ProviderBaseId + 111,
+
+        // Capacity events
+        ConsumedCapacity = CoreEventId.ProviderBaseId + 117
     }
 
     private static readonly string CommandPrefix = DbLoggerCategory.Database.Command.Name + ".";
     private static readonly string QueryPrefix = DbLoggerCategory.Query.Name + ".";
+    private static readonly string CapacityPrefix = DynamoDbLoggerCategory.Capacity.Name + ".";
 
     /// <summary>
     /// A PartiQL query is going to be executed.
@@ -151,4 +156,14 @@ public static class DynamoEventId
     public static readonly EventId ScanLikeQueryDetected = new(
         (int)Id.ScanLikeQueryDetected,
         QueryPrefix + Id.ScanLikeQueryDetected);
+
+    /// <summary>
+    /// DynamoDB reported consumed capacity (RCU/WCU) for a query or write operation.
+    /// </summary>
+    /// <remarks>
+    /// This event is in the <c>DbLoggerCategory.Capacity</c> category and uses <see cref="DynamoConsumedCapacityEventData" /> payloads.
+    /// It fires only when <c>ReturnConsumedCapacity</c> is configured so DynamoDB returns capacity in the response.
+    /// </remarks>
+    public static readonly EventId ConsumedCapacity =
+        new((int)Id.ConsumedCapacity, CapacityPrefix + Id.ConsumedCapacity);
 }

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggerExtensions.cs
@@ -3,6 +3,7 @@ using EntityFrameworkCore.DynamoDb.Query.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
 
 namespace EntityFrameworkCore.DynamoDb.Diagnostics.Internal;
 
@@ -64,6 +65,49 @@ public static class DynamoLoggerExtensions
 
     private static readonly Func<LogLevel, Action<ILogger, string, Exception?>> LogMessage = level
         => LoggerMessage.Define<string>(level, default, "{message}");
+
+    private static readonly Func<LogLevel, Action<ILogger, double, int, Exception?>>
+        LogConsumedCapacity = level => LoggerMessage.Define<double, int>(
+            level,
+            DynamoEventId.ConsumedCapacity,
+            "Consumed {capacityUnits} estimated capacity units across {entryCount} table(s)");
+
+    /// <summary>Logs DynamoDB consumed capacity (RCU/WCU) reported for an operation.</summary>
+    /// <param name="diagnostics">The capacity diagnostics logger.</param>
+    /// <param name="commandId">Provider command id correlating to the consuming command event.</param>
+    /// <param name="consumedCapacities">Consumed-capacity entries returned by DynamoDB, if any.</param>
+    public static void ConsumedCapacity(
+        this IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity> diagnostics,
+        Guid commandId,
+        IReadOnlyList<ConsumedCapacity>? consumedCapacities)
+    {
+        if (consumedCapacities is null || consumedCapacities.Count == 0)
+            return;
+
+        var definition = Definition(
+            diagnostics,
+            d => d.LogConsumedCapacity,
+            (d, v) => d.LogConsumedCapacity = v,
+            DynamoEventId.ConsumedCapacity,
+            LogLevel.Information,
+            LogConsumedCapacity);
+
+        if (diagnostics.ShouldLog(definition))
+            definition.Log(
+                diagnostics,
+                consumedCapacities.Sum(c => c.CapacityUnits ?? 0),
+                consumedCapacities.Count);
+        if (diagnostics.NeedsEventData(definition, out var ds, out var sl))
+            diagnostics.DispatchEventData(
+                definition,
+                new DynamoConsumedCapacityEventData(
+                    definition,
+                    ConsumedCapacityMessage,
+                    commandId,
+                    consumedCapacities),
+                ds,
+                sl);
+    }
 
     /// <summary>Logs that a PartiQL query is about to be executed.</summary>
     public static void ExecutingPartiQlQuery(
@@ -755,4 +799,12 @@ public static class DynamoLoggerExtensions
     private static string QueryDiagnosticMessage(EventDefinitionBase definition, EventData payload)
         => ((EventDefinition<string>)definition).GenerateMessage(
             ((DynamoQueryDiagnosticEventData)payload).Message);
+
+    private static string ConsumedCapacityMessage(EventDefinitionBase definition, EventData payload)
+    {
+        var p = (DynamoConsumedCapacityEventData)payload;
+        return ((EventDefinition<double, int>)definition).GenerateMessage(
+            p.CapacityUnits,
+            p.ConsumedCapacities.Count);
+    }
 }

--- a/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Diagnostics/Internal/DynamoLoggingDefinition.cs
@@ -52,4 +52,7 @@ public class DynamoLoggingDefinition : LoggingDefinitions
 
     /// <summary>Cached event definition for scan-like query diagnostic logs.</summary>
     public EventDefinition<string>? LogScanLikeQueryDetected;
+
+    /// <summary>Cached event definition for consumed-capacity logs.</summary>
+    public EventDefinition<double, int>? LogConsumedCapacity;
 }

--- a/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
+++ b/src/EntityFrameworkCore.DynamoDb/Storage/DynamoClientWrapper.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
 
 namespace EntityFrameworkCore.DynamoDb.Storage;
 
@@ -20,6 +21,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
     private readonly ReturnConsumedCapacity? _returnConsumedCapacity;
     private readonly bool _consistentRead;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _commandLogger;
+    private readonly IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity> _capacityLogger;
     private readonly IExecutionStrategy _executionStrategy;
     private bool _ownsClient;
     private bool _disposed;
@@ -28,7 +30,8 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
     public DynamoClientWrapper(
         IDbContextOptions dbContextOptions,
         IExecutionStrategy executionStrategy,
-        IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
+        IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
+        IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity> capacityLogger)
     {
         var options =
             dbContextOptions.NotNull().FindExtension<DynamoDbOptionsExtension>().NotNull();
@@ -42,6 +45,7 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
         _consistentRead = options.ConsistentRead;
         _executionStrategy = executionStrategy.NotNull();
         _commandLogger = commandLogger.NotNull();
+        _capacityLogger = capacityLogger.NotNull();
     }
 
     /// <summary>Gets the resolved DynamoDB client, preferring an explicitly configured client instance.</summary>
@@ -145,6 +149,10 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
                     response.ResponseMetadata?.RequestId,
                     response.ConsumedCapacity is null ? null : [response.ConsumedCapacity]);
 
+                _capacityLogger.ConsumedCapacity(
+                    commandId,
+                    response.ConsumedCapacity is null ? null : [response.ConsumedCapacity]);
+
                 return true;
             },
             null,
@@ -201,6 +209,8 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
                     commandId,
                     response.ResponseMetadata?.RequestId,
                     response.ConsumedCapacity);
+
+                _capacityLogger.ConsumedCapacity(commandId, response.ConsumedCapacity);
 
                 return true;
             },
@@ -259,6 +269,8 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
                     commandId,
                     response.ResponseMetadata?.RequestId,
                     response.ConsumedCapacity);
+
+                _capacityLogger.ConsumedCapacity(commandId, response.ConsumedCapacity);
 
                 var responses = (IReadOnlyList<BatchStatementResponse>)(response.Responses ?? []);
                 var errorCount = responses.Count(r => r.Error is not null);
@@ -456,6 +468,10 @@ public class DynamoClientWrapper : IDynamoClientWrapper, IDisposable
                     _request.Limit,
                     seedNextTokenPresent,
                     response.ConsumedCapacity);
+
+                dynamoEnumerable._dynamoClientWrapper._capacityLogger.ConsumedCapacity(
+                    commandId,
+                    response.ConsumedCapacity is null ? null : [response.ConsumedCapacity]);
 
                 // Notify before items are yielded so callers can capture per-page metadata.
                 dynamoEnumerable._onPageFetched?.Invoke(response);

--- a/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.IntegrationTests/Storage/DynamoClientWrapperTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using NSubstitute;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
 
 namespace EntityFrameworkCore.DynamoDb.IntegrationTests.Storage;
 
@@ -16,6 +17,7 @@ public class DynamoClientWrapperTests
         var executionStrategy = new TestExecutionStrategy();
         var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
         var client = Substitute.For<IAmazonDynamoDB>();
         var nextTokens = new List<string?>();
@@ -67,12 +69,12 @@ public class DynamoClientWrapperTests
             dbContextOptions,
             executionStrategy,
             diagnosticsLogger,
+            capacityLogger,
             client);
 
         var requestPrototype = new ExecuteStatementRequest
         {
-            Statement = "SELECT * FROM Test",
-            Parameters = []
+            Statement = "SELECT * FROM Test", Parameters = []
         };
 
         var enumerable = wrapper.ExecutePartiQl(requestPrototype);
@@ -97,6 +99,7 @@ public class DynamoClientWrapperTests
         var executionStrategy = new TestExecutionStrategy();
         var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
         var capturedParameters = new List<List<AttributeValue>?>();
 
         var client = Substitute.For<IAmazonDynamoDB>();
@@ -110,13 +113,13 @@ public class DynamoClientWrapperTests
             dbContextOptions,
             executionStrategy,
             diagnosticsLogger,
+            capacityLogger,
             client);
 
         var parameters = new List<AttributeValue> { new() { S = "original" } };
         var requestPrototype = new ExecuteStatementRequest
         {
-            Statement = "SELECT * FROM Test WHERE pk = ?",
-            Parameters = parameters
+            Statement = "SELECT * FROM Test WHERE pk = ?", Parameters = parameters
         };
 
         var enumerable = wrapper.ExecutePartiQl(requestPrototype);
@@ -137,11 +140,13 @@ public class DynamoClientWrapperTests
         var executionStrategy = new TestExecutionStrategy();
         var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
         var client = Substitute.For<IAmazonDynamoDB>();
         var wrapper = new TestDynamoClientWrapper(
             dbContextOptions,
             executionStrategy,
             diagnosticsLogger,
+            capacityLogger,
             client);
         var request = new ExecuteStatementRequest { Statement = new string('x', 8193) };
 
@@ -163,9 +168,13 @@ public class DynamoClientWrapperTests
             .UseDynamo(options => options.DynamoDbClient(configuredClient))
             .Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
-        var wrapper =
-            new DynamoClientWrapper(dbContextOptions, executionStrategy, diagnosticsLogger);
+        var wrapper = new DynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            capacityLogger);
 
         wrapper.Client.Should().BeSameAs(configuredClient);
     }
@@ -178,14 +187,17 @@ public class DynamoClientWrapperTests
                 => options.DynamoDbClientConfig(
                     new AmazonDynamoDBConfig
                     {
-                        ServiceURL = "http://localhost:7001",
-                        AuthenticationRegion = "us-east-1"
+                        ServiceURL = "http://localhost:7001", AuthenticationRegion = "us-east-1"
                     }))
             .Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
-        var wrapper =
-            new DynamoClientWrapper(dbContextOptions, executionStrategy, diagnosticsLogger);
+        var wrapper = new DynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            capacityLogger);
 
         wrapper.Client.Config.ServiceURL.Should().StartWith("http://localhost:7001");
         wrapper.Client.Config.AuthenticationRegion.Should().Be("us-east-1");
@@ -200,8 +212,7 @@ public class DynamoClientWrapperTests
                 options.DynamoDbClientConfig(
                     new AmazonDynamoDBConfig
                     {
-                        ServiceURL = "http://localhost:7001",
-                        AuthenticationRegion = "us-west-1"
+                        ServiceURL = "http://localhost:7001", AuthenticationRegion = "us-west-1"
                     });
                 options.ConfigureDynamoDbClientConfig(config =>
                 {
@@ -211,9 +222,13 @@ public class DynamoClientWrapperTests
             })
             .Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
-        var wrapper =
-            new DynamoClientWrapper(dbContextOptions, executionStrategy, diagnosticsLogger);
+        var wrapper = new DynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            capacityLogger);
 
         wrapper.Client.Config.ServiceURL.Should().StartWith("http://localhost:7001");
         wrapper.Client.Config.AuthenticationRegion.Should().Be("us-west-1");
@@ -234,9 +249,13 @@ public class DynamoClientWrapperTests
             })
             .Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
-        var wrapper =
-            new DynamoClientWrapper(dbContextOptions, executionStrategy, diagnosticsLogger);
+        var wrapper = new DynamoClientWrapper(
+            dbContextOptions,
+            executionStrategy,
+            diagnosticsLogger,
+            capacityLogger);
 
         wrapper.Client.Config.ServiceURL.Should().StartWith("http://localhost:7001");
         wrapper.Client.Config.AuthenticationRegion.Should().Be("us-west-2");
@@ -249,6 +268,7 @@ public class DynamoClientWrapperTests
         var executionStrategy = new TestExecutionStrategy();
         var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
         var client = Substitute.For<IAmazonDynamoDB>();
         client
@@ -259,6 +279,7 @@ public class DynamoClientWrapperTests
             dbContextOptions,
             executionStrategy,
             diagnosticsLogger,
+            capacityLogger,
             client);
 
         await wrapper.ExecuteWriteAsync("INSERT INTO \"Test\" VALUE {'pk': 'a', 'sk': 'b'}", []);
@@ -276,6 +297,7 @@ public class DynamoClientWrapperTests
         var executionStrategy = new TestExecutionStrategy();
         var dbContextOptions = new DbContextOptionsBuilder<DbContext>().UseDynamo().Options;
         var diagnosticsLogger = CreateCommandLogger(dbContextOptions);
+        var capacityLogger = CreateCapacityLogger(dbContextOptions);
 
         var client = Substitute.For<IAmazonDynamoDB>();
         client
@@ -286,6 +308,7 @@ public class DynamoClientWrapperTests
             dbContextOptions,
             executionStrategy,
             diagnosticsLogger,
+            capacityLogger,
             client);
 
         var parameters = new List<AttributeValue> { new() { S = "val" } };
@@ -304,6 +327,13 @@ public class DynamoClientWrapperTests
     {
         using var context = new DbContext(dbContextOptions);
         return context.GetService<IDiagnosticsLogger<DbLoggerCategory.Database.Command>>();
+    }
+
+    private static IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity> CreateCapacityLogger(
+        DbContextOptions<DbContext> dbContextOptions)
+    {
+        using var context = new DbContext(dbContextOptions);
+        return context.GetService<IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity>>();
     }
 
     private static async Task<List<Dictionary<string, AttributeValue>>> EnumerateAsync(
@@ -338,10 +368,12 @@ public class DynamoClientWrapperTests
         IDbContextOptions dbContextOptions,
         IExecutionStrategy executionStrategy,
         IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
+        IDiagnosticsLogger<DynamoDbLoggerCategory.Capacity> capacityLogger,
         IAmazonDynamoDB client) : DynamoClientWrapper(
         dbContextOptions,
         executionStrategy,
-        commandLogger)
+        commandLogger,
+        capacityLogger)
     {
         public override IAmazonDynamoDB Client { get; } = client;
     }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/CapacityLoggingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/CapacityLoggingTests.cs
@@ -1,0 +1,174 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Storage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Diagnostics;
+
+/// <summary>Tests that consumed-capacity (RCU/WCU) events are emitted into the Capacity category.</summary>
+public class CapacityLoggingTests
+{
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Read_EmitConsumedCapacityEvent()
+    {
+        var capture = new CapturingLoggerFactory();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(
+                    new ExecuteStatementResponse
+                    {
+                        ConsumedCapacity = new ConsumedCapacity
+                        {
+                            TableName = "Test", CapacityUnits = 2.5
+                        }
+                    }));
+
+        await using var context = RequestContext.Create(client, capture);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        await foreach (var _ in wrapper.ExecutePartiQl(
+            new ExecuteStatementRequest { Statement = "SELECT * FROM Test" })) { }
+
+        var entry =
+            capture
+                .Entries
+                .Should()
+                .ContainSingle(e => e.EventId.Id == DynamoEventId.ConsumedCapacity.Id)
+                .Subject;
+        entry.LogLevel.Should().Be(LogLevel.Information);
+        entry.State["capacityUnits"].Should().Be(2.5);
+        entry.State["entryCount"].Should().Be(1);
+        entry.Message.Should().Contain("2.5");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task Write_EmitConsumedCapacityEvent()
+    {
+        var capture = new CapturingLoggerFactory();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(
+                    new ExecuteStatementResponse
+                    {
+                        ConsumedCapacity = new ConsumedCapacity
+                        {
+                            TableName = "Test", CapacityUnits = 4.0
+                        }
+                    }));
+
+        await using var context = RequestContext.Create(client, capture);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        await wrapper.ExecuteWriteAsync("INSERT INTO \"Test\" VALUE {'pk': 'a'}", []);
+
+        var entry =
+            capture
+                .Entries
+                .Should()
+                .ContainSingle(e => e.EventId.Id == DynamoEventId.ConsumedCapacity.Id)
+                .Subject;
+        entry.LogLevel.Should().Be(LogLevel.Information);
+        entry.State["capacityUnits"].Should().Be(4.0);
+        entry.State["entryCount"].Should().Be(1);
+        entry.Message.Should().Contain("4");
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task NoConsumedCapacity_EmitsNothing()
+    {
+        var capture = new CapturingLoggerFactory();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ExecuteStatementResponse()));
+
+        await using var context = RequestContext.Create(client, capture);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        await foreach (var _ in wrapper.ExecutePartiQl(
+            new ExecuteStatementRequest { Statement = "SELECT * FROM Test" })) { }
+
+        capture.Entries.Should().NotContain(e => e.EventId.Id == DynamoEventId.ConsumedCapacity.Id);
+    }
+
+    private sealed class RequestContext(DbContextOptions<RequestContext> options) : DbContext(
+        options)
+    {
+        public static RequestContext Create(IAmazonDynamoDB client, ILoggerFactory loggerFactory)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<RequestContext>();
+            optionsBuilder
+                .UseDynamo(options => options.DynamoDbClient(client))
+                .UseLoggerFactory(loggerFactory)
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+            return new RequestContext(optionsBuilder.Options);
+        }
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private readonly List<LogEntry> _entries = [];
+
+        public IReadOnlyList<LogEntry> Entries => _entries;
+
+        public ILogger CreateLogger(string categoryName)
+            => categoryName.StartsWith(
+                DynamoDbLoggerCategory.Capacity.Name,
+                StringComparison.Ordinal)
+                ? new CapturingLogger(this)
+                : NullLogger.Instance;
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+
+        private void Add(LogEntry entry) => _entries.Add(entry);
+
+        private sealed class CapturingLogger(CapturingLoggerFactory factory) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var structuredState = state is IReadOnlyList<KeyValuePair<string, object?>> values
+                    ? values
+                        .Where(pair => pair.Key != "{OriginalFormat}")
+                        .ToDictionary(pair => pair.Key, pair => pair.Value)
+                    : [];
+
+                factory.Add(
+                    new LogEntry(
+                        logLevel,
+                        eventId,
+                        exception,
+                        formatter(state, exception),
+                        structuredState));
+            }
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel LogLevel,
+        EventId EventId,
+        Exception? Exception,
+        string Message,
+        IReadOnlyDictionary<string, object?> State);
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/CapacityLoggingTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/CapacityLoggingTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using EntityFrameworkCore.DynamoDb.Diagnostics;
 using EntityFrameworkCore.DynamoDb.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -101,6 +103,53 @@ public class CapacityLoggingTests
         capture.Entries.Should().NotContain(e => e.EventId.Id == DynamoEventId.ConsumedCapacity.Id);
     }
 
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public async Task ConsumedCapacity_CommandId_MatchesConsumingCommand()
+    {
+        using var observer = new DynamoDiagnosticObserver();
+        var client = Substitute.For<IAmazonDynamoDB>();
+        client
+            .ExecuteStatementAsync(Arg.Any<ExecuteStatementRequest>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(
+                    new ExecuteStatementResponse
+                    {
+                        ConsumedCapacity = new ConsumedCapacity
+                        {
+                            TableName = "Test", CapacityUnits = 1.5
+                        }
+                    }));
+
+        await using var context = RequestContext.Create(client);
+        var wrapper = context.GetService<IDynamoClientWrapper>();
+
+        await foreach (var _ in wrapper.ExecutePartiQl(
+            new ExecuteStatementRequest { Statement = "SELECT * FROM Test" })) { }
+
+        // The DiagnosticListener is process-global, so other tests running in
+        // parallel may contribute events. Assert the correlation property rather
+        // than an exact count: every capacity event (this operation's is the one
+        // with 1.5 units) must share its CommandId with a command event.
+        var capacityCommandIds =
+            observer
+                .Snapshot()
+                .Where(e => e.Key == DynamoEventId.ConsumedCapacity.Name
+                    && e.Value is DynamoConsumedCapacityEventData { CapacityUnits: 1.5 })
+                .Select(e => ((DynamoConsumedCapacityEventData)e.Value!).CommandId)
+                .ToList();
+
+        capacityCommandIds.Should().NotBeEmpty();
+
+        var executedCommandIds =
+            observer
+                .Snapshot()
+                .Where(e => e.Key == DynamoEventId.ExecutedExecuteStatement.Name)
+                .Select(e => ((DynamoExecuteStatementExecutedEventData)e.Value!).CommandId)
+                .ToHashSet();
+
+        executedCommandIds.Should().Contain(capacityCommandIds);
+    }
+
     private sealed class RequestContext(DbContextOptions<RequestContext> options) : DbContext(
         options)
     {
@@ -113,6 +162,60 @@ public class CapacityLoggingTests
                 .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
             return new RequestContext(optionsBuilder.Options);
+        }
+
+        public static RequestContext Create(IAmazonDynamoDB client)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<RequestContext>();
+            optionsBuilder
+                .UseDynamo(options => options.DynamoDbClient(client))
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+            return new RequestContext(optionsBuilder.Options);
+        }
+    }
+
+    private sealed class DynamoDiagnosticObserver
+        : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>, IDisposable
+    {
+        private readonly IDisposable _subscription;
+        private readonly object _gate = new();
+        private IDisposable? _listenerSubscription;
+        private readonly List<KeyValuePair<string, object?>> _events = [];
+
+        public DynamoDiagnosticObserver()
+            => _subscription = DiagnosticListener.AllListeners.Subscribe(this);
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name == DbLoggerCategory.Name)
+                _listenerSubscription = value.Subscribe(this);
+        }
+
+        public void OnNext(KeyValuePair<string, object?> value)
+        {
+            lock (_gate)
+            {
+                _events.Add(value);
+            }
+        }
+
+        public IReadOnlyList<KeyValuePair<string, object?>> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _events.ToList();
+            }
+        }
+
+        public void OnError(Exception error) { }
+
+        public void OnCompleted() { }
+
+        public void Dispose()
+        {
+            _listenerSubscription?.Dispose();
+            _subscription.Dispose();
         }
     }
 

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoEventIdTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoEventIdTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Diagnostics;
+
+/// <summary>Tests the <see cref="DynamoEventId" /> event surface for stability invariants.</summary>
+public class DynamoEventIdTests
+{
+    private static readonly EventId[] EventIds =
+        typeof(DynamoEventId)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(static f => f.FieldType == typeof(EventId))
+            .Select(static f => (EventId)f.GetValue(null)!)
+            .ToArray();
+
+    private static readonly string CommandPrefix = DbLoggerCategory.Database.Command.Name + ".";
+    private static readonly string QueryPrefix = DbLoggerCategory.Query.Name + ".";
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Ids_AreUnique()
+        => EventIds
+            .GroupBy(static e => e.Id)
+            .Where(static g => g.Count() > 1)
+            .Select(static g => g.Key)
+            .Should()
+            .BeEmpty();
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Ids_BelongToProviderIdSpace()
+    {
+        var min = CoreEventId.ProviderBaseId + 100;
+        var max = CoreEventId.ProviderBaseId + 199;
+
+        EventIds.Should().OnlyContain(e => e.Id >= min && e.Id <= max);
+    }
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Names_CarryACategoryPrefix()
+        => EventIds
+            .Should()
+            .OnlyContain(static e
+                => !string.IsNullOrEmpty(e.Name)
+                && (e.Name.StartsWith(CommandPrefix, StringComparison.Ordinal)
+                    || e.Name.StartsWith(QueryPrefix, StringComparison.Ordinal)));
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void SourceCarriesStabilityContract()
+    {
+        var sourcePath = FindDynamoEventIdSource();
+
+        sourcePath
+            .Should()
+            .NotBeNull("the DynamoEventId source file must be discoverable from the repo root");
+
+        File
+            .ReadAllText(sourcePath!)
+            .Should()
+            .Contain("Warning: These values must not change between releases.");
+    }
+
+    private static string? FindDynamoEventIdSource()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            dir is not null;
+            dir = dir.Parent)
+        {
+            var candidate = Path.Combine(
+                dir.FullName,
+                "src",
+                "EntityFrameworkCore.DynamoDb",
+                "Diagnostics",
+                "DynamoEventId.cs");
+
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoEventIdTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoEventIdTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
+using DynamoDbLoggerCategory = Microsoft.EntityFrameworkCore.DynamoDB.DbLoggerCategory;
 
 namespace EntityFrameworkCore.DynamoDb.Tests.Diagnostics;
 
@@ -17,6 +18,12 @@ public class DynamoEventIdTests
 
     private static readonly string CommandPrefix = DbLoggerCategory.Database.Command.Name + ".";
     private static readonly string QueryPrefix = DbLoggerCategory.Query.Name + ".";
+    private static readonly string CapacityPrefix = DynamoDbLoggerCategory.Capacity.Name + ".";
+
+    private static readonly string[] KnownCategoryPrefixes =
+    [
+        CommandPrefix, QueryPrefix, CapacityPrefix
+    ];
 
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public void Ids_AreUnique()
@@ -41,42 +48,5 @@ public class DynamoEventIdTests
         => EventIds
             .Should()
             .OnlyContain(static e
-                => !string.IsNullOrEmpty(e.Name)
-                && (e.Name.StartsWith(CommandPrefix, StringComparison.Ordinal)
-                    || e.Name.StartsWith(QueryPrefix, StringComparison.Ordinal)));
-
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void SourceCarriesStabilityContract()
-    {
-        var sourcePath = FindDynamoEventIdSource();
-
-        sourcePath
-            .Should()
-            .NotBeNull("the DynamoEventId source file must be discoverable from the repo root");
-
-        File
-            .ReadAllText(sourcePath!)
-            .Should()
-            .Contain("Warning: These values must not change between releases.");
-    }
-
-    private static string? FindDynamoEventIdSource()
-    {
-        for (var dir = new DirectoryInfo(AppContext.BaseDirectory);
-            dir is not null;
-            dir = dir.Parent)
-        {
-            var candidate = Path.Combine(
-                dir.FullName,
-                "src",
-                "EntityFrameworkCore.DynamoDb",
-                "Diagnostics",
-                "DynamoEventId.cs");
-
-            if (File.Exists(candidate))
-                return candidate;
-        }
-
-        return null;
-    }
+                => !string.IsNullOrEmpty(e.Name) && KnownCategoryPrefixes.Any(e.Name.StartsWith));
 }

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoLoggerCategoryTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoLoggerCategoryTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.DynamoDB;
+
+namespace EntityFrameworkCore.DynamoDb.Tests.Diagnostics;
+
+/// <summary>Tests DynamoDB-specific provider logger category names.</summary>
+public class DynamoLoggerCategoryTests
+{
+    private const string CapacityName = "Microsoft.EntityFrameworkCore.DynamoDB.Capacity";
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Capacity_Name_IsExpected()
+        => DbLoggerCategory.Capacity.Name.Should().Be(CapacityName);
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Capacity_ToString_IsExpected()
+        => new DbLoggerCategory.Capacity().ToString().Should().Be(CapacityName);
+
+    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
+    public void Capacity_ImplicitStringConversion_IsExpected()
+    {
+        DbLoggerCategory.Capacity category = new();
+
+        string name = category;
+
+        name.Should().Be(CapacityName);
+    }
+}

--- a/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoLoggerCategoryTests.cs
+++ b/tests/EntityFrameworkCore.DynamoDb.Tests/Diagnostics/DynamoLoggerCategoryTests.cs
@@ -10,18 +10,4 @@ public class DynamoLoggerCategoryTests
     [Fact(Timeout = TestConfiguration.DefaultTimeout)]
     public void Capacity_Name_IsExpected()
         => DbLoggerCategory.Capacity.Name.Should().Be(CapacityName);
-
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void Capacity_ToString_IsExpected()
-        => new DbLoggerCategory.Capacity().ToString().Should().Be(CapacityName);
-
-    [Fact(Timeout = TestConfiguration.DefaultTimeout)]
-    public void Capacity_ImplicitStringConversion_IsExpected()
-    {
-        DbLoggerCategory.Capacity category = new();
-
-        string name = category;
-
-        name.Should().Be(CapacityName);
-    }
 }


### PR DESCRIPTION
## Summary

Implements the RCU/WCU consumption logging that the `Capacity` logger category was declared for, making the previously placeholder category functional. A `ConsumedCapacity` event (ID `30117`) is emitted into the `Microsoft.EntityFrameworkCore.DynamoDB.Capacity` category from all four request paths in `DynamoClientWrapper` (read page, write, transaction, batch), and only when DynamoDB returns capacity (`ReturnConsumedCapacity` configured).

This supersedes the placeholder category shipped earlier on this branch ("no emitter wired yet — consumed-capacity logging lands with OBS-002").

## Changes

- **`DynamoEventId.ConsumedCapacity`** (`30117`) under the new `Capacity` category.
- **`DynamoConsumedCapacityEventData`** payload carrying `CommandId` (for correlation to the consuming command event) and the raw per-table consumed-capacity entries.
- **`IDiagnosticsLogger<DbLoggerCategory.Capacity>.ConsumedCapacity` emitter**; capacity logger injected into `DynamoClientWrapper` (resolves via EF's open-generic `IDiagnosticsLogger<>` registration — no DI wiring).
- Emits a structured log: `Consumed {capacityUnits} estimated capacity units across {entryCount} table(s)`; no-op when no capacity is returned.
- **Category pump**: `DbLoggerCategory.Capacity` (`src/.../Diagnostics/DbLoggerCategory.cs`, namespace `Microsoft.EntityFrameworkCore.DynamoDB`) — category name `Microsoft.EntityFrameworkCore.DynamoDB.Capacity`. Note: a consumer importing both `Microsoft.EntityFrameworkCore.DynamoDB` and EF's `Microsoft.EntityFrameworkCore` and referring to bare `DbLoggerCategory` would hit CS0104; the provider code qualifies it via a `DynamoDbLoggerCategory` alias.
- **Tests**:
  - `CapacityLoggingTests` (behavioral): read/write emit a `ConsumedCapacity` event with correct units/entry-count/level; no-capacity responses emit nothing; `CommandId` correlates to the consuming command via `DiagnosticListener` (robust to the process-global listener's parallel-test pollution).
  - De-linted the event-surface suite: dropped the source-text stability lint, folded the category-prefix test to include the `Capacity` category, collapsed the redundant logger-category assertions.
  - `DynamoEventIdTests` reflects over the `EventId` fields asserting IDs are unique, within `ProviderBaseId + 100..199` (30100–30199), and names carry a known category prefix.
- **Docs** (`docs/diagnostics.md`): `Capacity` category, `ConsumedCapacity` event reference, payload table.

## Verification

- Builds clean (Debug EF10 + EF11).
- Unit suites: EF10 763/763, EF11 763/763 (deterministic across repeated runs).
- Full integration suites: EF10 457/457, EF11 457/457.
- Docs build clean (`task docs:build`).